### PR TITLE
feat: initialize plastic UI component library scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "plastic",
+  "version": "0.0.1",
+  "description": "Reusable UI component library built with TypeScript and React",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,45 @@
+import type { ButtonProps } from "./Button.types";
+
+// Internal style maps — not exported
+const variantStyles: Record<NonNullable<ButtonProps["variant"]>, string> = {
+  primary: "bg-blue-600 text-white hover:bg-blue-700",
+  secondary: "bg-gray-200 text-gray-900 hover:bg-gray-300",
+  ghost: "bg-transparent text-gray-700 hover:bg-gray-100",
+};
+
+const sizeStyles: Record<NonNullable<ButtonProps["size"]>, string> = {
+  sm: "px-3 py-1 text-sm",
+  md: "px-4 py-2 text-base",
+  lg: "px-6 py-3 text-lg",
+};
+
+export function Button({
+  variant = "primary",
+  size = "md",
+  loading = false,
+  disabled,
+  className = "",
+  children,
+  ...rest
+}: ButtonProps) {
+  const isDisabled = disabled || loading;
+
+  return (
+    <button
+      {...rest}
+      disabled={isDisabled}
+      className={[
+        "inline-flex items-center justify-center rounded font-medium transition-colors",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
+        variantStyles[variant],
+        sizeStyles[size],
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {loading ? <span aria-hidden="true">...</span> : children}
+    </button>
+  );
+}

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -1,0 +1,11 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost";
+export type ButtonSize = "sm" | "md" | "lg";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  loading?: boolean;
+  children: ReactNode;
+}

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,0 +1,3 @@
+// Public surface for Button — only export what consumers need
+export { Button } from "./Button";
+export type { ButtonProps, ButtonVariant, ButtonSize } from "./Button.types";

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,0 +1,20 @@
+import { CardRoot } from "./CardRoot";
+import { CardHeader } from "./CardHeader";
+import { CardBody } from "./CardBody";
+import { CardFooter } from "./CardFooter";
+
+/**
+ * Compound component — sub-components are attached as properties.
+ *
+ * Usage:
+ *   <Card.Root>
+ *     <Card.Header>Title</Card.Header>
+ *     <Card.Body>Content</Card.Body>
+ *     <Card.Footer>Actions</Card.Footer>
+ *   </Card.Root>
+ */
+export const Card = Object.assign(CardRoot, {
+  Header: CardHeader,
+  Body: CardBody,
+  Footer: CardFooter,
+});

--- a/src/components/Card/Card.types.ts
+++ b/src/components/Card/Card.types.ts
@@ -1,0 +1,17 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+export interface CardRootProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface CardHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface CardBodyProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface CardFooterProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}

--- a/src/components/Card/CardBody.tsx
+++ b/src/components/Card/CardBody.tsx
@@ -1,0 +1,12 @@
+import type { CardBodyProps } from "./Card.types";
+
+export function CardBody({ className = "", children, ...rest }: CardBodyProps) {
+  return (
+    <div
+      {...rest}
+      className={["px-4 py-4", className].filter(Boolean).join(" ")}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/Card/CardFooter.tsx
+++ b/src/components/Card/CardFooter.tsx
@@ -1,0 +1,12 @@
+import type { CardFooterProps } from "./Card.types";
+
+export function CardFooter({ className = "", children, ...rest }: CardFooterProps) {
+  return (
+    <div
+      {...rest}
+      className={["border-t border-gray-200 px-4 py-3", className].filter(Boolean).join(" ")}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/Card/CardHeader.tsx
+++ b/src/components/Card/CardHeader.tsx
@@ -1,0 +1,14 @@
+import type { CardHeaderProps } from "./Card.types";
+
+export function CardHeader({ className = "", children, ...rest }: CardHeaderProps) {
+  return (
+    <div
+      {...rest}
+      className={["border-b border-gray-200 px-4 py-3 font-semibold", className]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/Card/CardRoot.tsx
+++ b/src/components/Card/CardRoot.tsx
@@ -1,0 +1,14 @@
+import type { CardRootProps } from "./Card.types";
+
+export function CardRoot({ className = "", children, ...rest }: CardRootProps) {
+  return (
+    <div
+      {...rest}
+      className={["rounded-lg border border-gray-200 bg-white shadow-sm", className]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,0 +1,2 @@
+export { Card } from "./Card";
+export type { CardRootProps, CardHeaderProps, CardBodyProps, CardFooterProps } from "./Card.types";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from "./Button";
+export * from "./Card";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./Button";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * plastic — Public API
+ *
+ * Only symbols exported from this file are part of the public interface.
+ * Internal utilities, style maps, and implementation details live under
+ * src/ but are intentionally NOT re-exported here.
+ */
+
+export * from "./components";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  external: ["react", "react-dom"],
+});


### PR DESCRIPTION
- package.json: ESM+CJS dual output, exports field, peer deps (react >=18)
- tsconfig.json: strict TypeScript with react-jsx transform
- tsup.config.ts: builds ESM/CJS/dts, tree-shakeable, externals react
- src/index.ts: single public API entry point
- src/components/Button: first component demonstrating the pattern
  (implementation details not exported; only component + types surface)

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY