### PR TITLE
feat: plastic UI 컴포넌트 라이브러리 초기 구성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,223 @@
 # plastic
-Make it like plastics!
+
+TypeScript + React 기반 UI 컴포넌트 라이브러리.
+
+---
+
+## Installation
+
+```bash
+npm install plastic
+```
+
+> **참고** — plastic 컴포넌트는 Tailwind CSS 클래스를 사용합니다.  
+> 프로젝트의 `tailwind.config.js` `content` 배열에 아래 경로를 추가하세요.
+>
+> ```js
+> content: [
+>   "./src/**/*.{ts,tsx}",
+>   "./node_modules/plastic/dist/**/*.js", // plastic 컴포넌트 클래스 스캔
+> ]
+> ```
+
+---
+
+## Quick Start
+
+```ts
+import { Button, Card, CodeView } from "plastic";
+import type { ButtonProps, CardRootProps, CodeViewProps } from "plastic";
+```
+
+모든 컴포넌트와 타입은 `"plastic"` 단일 진입점에서 import합니다.
+
+---
+
+## Components
+
+### Button
+
+클릭 가능한 기본 버튼 컴포넌트. `HTMLButtonElement`의 모든 속성(`onClick`, `type`, `aria-*` 등)을 그대로 사용할 수 있습니다.
+
+![Button preview](docs/previews/button-preview.svg)
+
+#### Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `variant` | `"primary" \| "secondary" \| "ghost"` | `"primary"` | 버튼 스타일 |
+| `size` | `"sm" \| "md" \| "lg"` | `"md"` | 버튼 크기 |
+| `loading` | `boolean` | `false` | 로딩 상태 (자동으로 `disabled` 처리) |
+| `disabled` | `boolean` | `false` | 비활성화 |
+| `children` | `ReactNode` | 필수 | 버튼 내용 |
+
+#### Usage
+
+```tsx
+import { Button } from "plastic";
+
+// Variants
+<Button variant="primary">Primary</Button>
+<Button variant="secondary">Secondary</Button>
+<Button variant="ghost">Ghost</Button>
+
+// Sizes
+<Button size="sm">Small</Button>
+<Button size="md">Medium</Button>
+<Button size="lg">Large</Button>
+
+// States
+<Button disabled>Disabled</Button>
+<Button loading>Loading...</Button>
+
+// HTML 속성 그대로 사용
+<Button type="submit" onClick={() => console.log("clicked")}>
+  Submit
+</Button>
+```
+
+---
+
+### Card
+
+Compound 컴포넌트 패턴의 카드. `Card.Root`, `Card.Header`, `Card.Body`, `Card.Footer`를 조합해서 사용합니다. 서브 컴포넌트는 필요한 것만 선택적으로 사용할 수 있습니다.
+
+![Card preview](docs/previews/card-preview.svg)
+
+#### Sub-components
+
+| Component | Description |
+|---|---|
+| `Card.Root` | 카드 외곽 컨테이너 (필수) |
+| `Card.Header` | 상단 제목 영역 (선택) |
+| `Card.Body` | 본문 영역 (선택) |
+| `Card.Footer` | 하단 액션 영역 (선택) |
+
+모든 서브 컴포넌트는 `HTMLDivElement` 속성(`className`, `style`, `aria-*` 등)을 지원합니다.
+
+#### Usage
+
+```tsx
+import { Card, Button } from "plastic";
+
+// 전체 구성
+<Card.Root>
+  <Card.Header>Card Title</Card.Header>
+  <Card.Body>
+    <p>Card content goes here.</p>
+  </Card.Body>
+  <Card.Footer>
+    <Button size="sm">Confirm</Button>
+    <Button size="sm" variant="ghost">Cancel</Button>
+  </Card.Footer>
+</Card.Root>
+
+// 필요한 서브 컴포넌트만 사용
+<Card.Root>
+  <Card.Body>Body only card</Card.Body>
+</Card.Root>
+
+// className으로 커스터마이징
+<Card.Root className="max-w-sm shadow-lg">
+  <Card.Header className="text-blue-700">Custom Header</Card.Header>
+  <Card.Body>Content</Card.Body>
+</Card.Root>
+```
+
+---
+
+### CodeView
+
+라인 번호, 홀짝 배경, syntax highlighting을 갖춘 코드 표시 컴포넌트. `prism-react-renderer` 기반으로 동작합니다.
+
+![CodeView preview](docs/previews/codeview-preview.svg)
+
+#### Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `code` | `string` | 필수 | 표시할 코드 문자열 |
+| `language` | `Language` | `"typescript"` | 문법 강조 언어 ([지원 언어 목록](https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/generate-prism-languages/index.ts)) |
+| `theme` | `"light" \| "dark"` | `"light"` | 색상 테마 (light: VS Light, dark: VS Dark) |
+| `showLineNumbers` | `boolean` | `true` | 라인 번호 표시 여부 |
+| `showAlternatingRows` | `boolean` | `true` | 홀짝 라인 배경색 구분 여부 |
+| `className` | `string` | — | 외부 컨테이너에 추가할 클래스 |
+
+#### Usage
+
+```tsx
+import { CodeView } from "plastic";
+
+// 기본 (light 테마, 라인 번호, 홀짝 배경 모두 활성)
+<CodeView
+  code={`const x: number = 42;`}
+  language="typescript"
+/>
+
+// 다크 테마
+<CodeView
+  code={myCode}
+  language="python"
+  theme="dark"
+/>
+
+// 라인 번호 없이, 단색 배경
+<CodeView
+  code={myCode}
+  language="json"
+  showLineNumbers={false}
+  showAlternatingRows={false}
+/>
+```
+
+---
+
+## Demo
+
+각 컴포넌트의 실제 렌더링 결과를 로컬에서 확인하려면 데모 앱을 실행하세요.
+
+```bash
+cd demo
+npm install
+npm run dev
+```
+
+브라우저에서 `http://localhost:5173`을 열면 좌측 사이드바에서 각 컴포넌트 페이지를 탐색할 수 있습니다.
+
+---
+
+## Project Structure
+
+```
+src/
+├── index.ts                    ← 단일 public API 진입점
+└── components/
+    ├── Button/
+    │   ├── Button.tsx          ← 구현 (미노출)
+    │   ├── Button.types.ts     ← 타입 정의
+    │   └── index.ts            ← Button의 공개 surface
+    ├── Card/
+    │   ├── Card.tsx            ← Compound assembly (미노출)
+    │   ├── CardRoot.tsx        ← 서브 컴포넌트 (미노출)
+    │   ├── CardHeader.tsx      ← 서브 컴포넌트 (미노출)
+    │   ├── CardBody.tsx        ← 서브 컴포넌트 (미노출)
+    │   ├── CardFooter.tsx      ← 서브 컴포넌트 (미노출)
+    │   ├── Card.types.ts       ← 타입 정의
+    │   └── index.ts            ← Card의 공개 surface
+    └── CodeView/
+        ├── CodeView.tsx        ← 구현 (미노출)
+        ├── CodeView.types.ts   ← 타입 정의
+        └── index.ts            ← CodeView의 공개 surface
+```
+
+`src/index.ts`에서 명시적으로 export된 심볼만 외부에 노출됩니다. 내부 구현 파일(`CardRoot.tsx`, 스타일 맵, 컨텍스트 등)은 직접 import할 수 없습니다.
+
+---
+
+## Build
+
+```bash
+npm run build      # dist/ 에 ESM + CJS + .d.ts 생성
+npm run dev        # watch 모드
+npm run typecheck  # 타입 검사만
+```

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>plastic — component demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "plastic-demo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "prism-react-renderer": "^2.3.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/demo/postcss.config.js
+++ b/demo/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { ButtonPage } from "./pages/ButtonPage";
+import { CardPage } from "./pages/CardPage";
+import { CodeViewPage } from "./pages/CodeViewPage";
+
+type Page = "button" | "card" | "codeview";
+
+const NAV: { id: Page; label: string; description: string }[] = [
+  { id: "button", label: "Button", description: "단순 컴포넌트" },
+  { id: "card", label: "Card", description: "Compound 컴포넌트" },
+  { id: "codeview", label: "CodeView", description: "Syntax highlighting" },
+];
+
+export function App() {
+  const [current, setCurrent] = useState<Page>("button");
+
+  return (
+    <div className="flex min-h-screen">
+      {/* Sidebar */}
+      <aside className="w-60 shrink-0 border-r border-gray-200 bg-white flex flex-col">
+        <div className="px-5 py-4 border-b border-gray-200">
+          <p className="text-lg font-bold tracking-tight text-gray-900">plastic</p>
+          <p className="text-xs text-gray-400 mt-0.5">component demo</p>
+        </div>
+        <nav className="flex-1 py-3">
+          {NAV.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => setCurrent(item.id)}
+              className={[
+                "w-full text-left px-5 py-2.5 transition-colors",
+                current === item.id
+                  ? "bg-blue-50 border-l-2 border-blue-600"
+                  : "border-l-2 border-transparent hover:bg-gray-50",
+              ].join(" ")}
+            >
+              <p
+                className={[
+                  "text-sm font-medium",
+                  current === item.id ? "text-blue-700" : "text-gray-700",
+                ].join(" ")}
+              >
+                {item.label}
+              </p>
+              <p className="text-xs text-gray-400 mt-0.5">{item.description}</p>
+            </button>
+          ))}
+        </nav>
+      </aside>
+
+      {/* Main content */}
+      <main className="flex-1 p-10 overflow-y-auto">
+        {current === "button" && <ButtonPage />}
+        {current === "card" && <CardPage />}
+        {current === "codeview" && <CodeViewPage />}
+      </main>
+    </div>
+  );
+}

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  margin: 0;
+  background-color: #f9fafb;
+}

--- a/demo/src/main.tsx
+++ b/demo/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import { App } from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/demo/src/pages/ButtonPage.tsx
+++ b/demo/src/pages/ButtonPage.tsx
@@ -1,0 +1,109 @@
+import { Button, CodeView } from "plastic";
+
+const USAGE_CODE = `import { Button } from "plastic";
+
+// Variants
+<Button variant="primary">Primary</Button>
+<Button variant="secondary">Secondary</Button>
+<Button variant="ghost">Ghost</Button>
+
+// Sizes
+<Button size="sm">Small</Button>
+<Button size="md">Medium</Button>
+<Button size="lg">Large</Button>
+
+// States
+<Button disabled>Disabled</Button>
+<Button loading>Loading...</Button>`;
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+        {title}
+      </p>
+      <div className="flex flex-wrap items-center gap-3 px-6 py-5 bg-white rounded-lg border border-gray-200">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export function ButtonPage() {
+  return (
+    <div className="max-w-2xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Button</h1>
+        <p className="text-gray-500 mt-1">
+          클릭 가능한 기본 버튼 컴포넌트입니다.{" "}
+          <code className="text-sm bg-gray-100 px-1.5 py-0.5 rounded">
+            HTMLButtonElement
+          </code>{" "}
+          의 모든 속성을 그대로 사용할 수 있습니다.
+        </p>
+      </div>
+
+      <Section title="Variants">
+        <Button variant="primary">Primary</Button>
+        <Button variant="secondary">Secondary</Button>
+        <Button variant="ghost">Ghost</Button>
+      </Section>
+
+      <Section title="Sizes">
+        <Button size="sm">Small</Button>
+        <Button size="md">Medium</Button>
+        <Button size="lg">Large</Button>
+      </Section>
+
+      <Section title="States">
+        <Button disabled>Disabled</Button>
+        <Button loading>Loading</Button>
+        <Button variant="secondary" disabled>
+          Secondary Disabled
+        </Button>
+      </Section>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          Props
+        </p>
+        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                {["Prop", "Type", "Default", "Description"].map((h) => (
+                  <th key={h} className="text-left px-4 py-2.5 text-xs font-semibold text-gray-500">
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {[
+                ["variant", '"primary" | "secondary" | "ghost"', '"primary"', "버튼 스타일"],
+                ["size", '"sm" | "md" | "lg"', '"md"', "버튼 크기"],
+                ["loading", "boolean", "false", "로딩 상태 (disabled 포함)"],
+                ["disabled", "boolean", "false", "비활성화"],
+                ["children", "ReactNode", "—", "버튼 내용 (필수)"],
+              ].map(([prop, type, def, desc]) => (
+                <tr key={prop}>
+                  <td className="px-4 py-2.5 font-mono text-xs text-blue-700">{prop}</td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-gray-500">{type}</td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-gray-400">{def}</td>
+                  <td className="px-4 py-2.5 text-gray-600">{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          Usage
+        </p>
+        <CodeView code={USAGE_CODE} language="tsx" showAlternatingRows={false} />
+      </section>
+    </div>
+  );
+}

--- a/demo/src/pages/CardPage.tsx
+++ b/demo/src/pages/CardPage.tsx
@@ -1,0 +1,101 @@
+import { Card, Button, CodeView } from "plastic";
+
+const USAGE_CODE = `import { Card } from "plastic";
+
+// 전체 구성
+<Card.Root>
+  <Card.Header>Card Title</Card.Header>
+  <Card.Body>
+    Card content goes here.
+  </Card.Body>
+  <Card.Footer>
+    <Button size="sm">Confirm</Button>
+    <Button size="sm" variant="ghost">Cancel</Button>
+  </Card.Footer>
+</Card.Root>
+
+// 필요한 서브 컴포넌트만 사용 가능
+<Card.Root>
+  <Card.Body>Body only card</Card.Body>
+</Card.Root>`;
+
+export function CardPage() {
+  return (
+    <div className="max-w-2xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Card</h1>
+        <p className="text-gray-500 mt-1">
+          Compound 컴포넌트 패턴의 카드입니다.{" "}
+          <code className="text-sm bg-gray-100 px-1.5 py-0.5 rounded">Card.Root</code>,{" "}
+          <code className="text-sm bg-gray-100 px-1.5 py-0.5 rounded">Card.Header</code>,{" "}
+          <code className="text-sm bg-gray-100 px-1.5 py-0.5 rounded">Card.Body</code>,{" "}
+          <code className="text-sm bg-gray-100 px-1.5 py-0.5 rounded">Card.Footer</code>를{" "}
+          조합해서 사용합니다.
+        </p>
+      </div>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          Full Card
+        </p>
+        <div className="p-6 bg-white rounded-lg border border-gray-200">
+          <Card.Root className="max-w-sm">
+            <Card.Header>Card Title</Card.Header>
+            <Card.Body>
+              <p className="text-sm text-gray-600">
+                This is the card body. You can put any content here — text,
+                images, forms, and more.
+              </p>
+            </Card.Body>
+            <Card.Footer>
+              <div className="flex gap-2">
+                <Button size="sm">Confirm</Button>
+                <Button size="sm" variant="ghost">
+                  Cancel
+                </Button>
+              </div>
+            </Card.Footer>
+          </Card.Root>
+        </div>
+      </section>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          Body Only
+        </p>
+        <div className="p-6 bg-white rounded-lg border border-gray-200">
+          <Card.Root className="max-w-sm">
+            <Card.Body>
+              <p className="text-sm text-gray-600">
+                서브 컴포넌트는 필요한 것만 골라 사용할 수 있습니다.
+              </p>
+            </Card.Body>
+          </Card.Root>
+        </div>
+      </section>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          Header + Body
+        </p>
+        <div className="p-6 bg-white rounded-lg border border-gray-200">
+          <Card.Root className="max-w-sm">
+            <Card.Header>Settings</Card.Header>
+            <Card.Body>
+              <p className="text-sm text-gray-600">
+                푸터 없이 헤더 + 바디 구성도 가능합니다.
+              </p>
+            </Card.Body>
+          </Card.Root>
+        </div>
+      </section>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          Usage
+        </p>
+        <CodeView code={USAGE_CODE} language="tsx" showAlternatingRows={false} />
+      </section>
+    </div>
+  );
+}

--- a/demo/src/pages/CodeViewPage.tsx
+++ b/demo/src/pages/CodeViewPage.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react";
+import { CodeView, Button } from "plastic";
+import type { CodeViewTheme } from "plastic";
+
+const TS_SAMPLE = `interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+async function fetchUser(id: number): Promise<User> {
+  const res = await fetch(\`/api/users/\${id}\`);
+  if (!res.ok) throw new Error("Not found");
+  return res.json() as Promise<User>;
+}
+
+const user = await fetchUser(42);
+console.log(\`Hello, \${user.name}!\`);`;
+
+const PYTHON_SAMPLE = `from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class User:
+    id: int
+    name: str
+    email: str
+
+def fetch_user(user_id: int) -> Optional[User]:
+    # fetch from database
+    return User(id=user_id, name="Alice", email="alice@example.com")
+
+user = fetch_user(42)
+if user:
+    print(f"Hello, {user.name}!")`;
+
+const JSON_SAMPLE = `{
+  "name": "plastic",
+  "version": "0.0.1",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  }
+}`;
+
+const USAGE_CODE = `import { CodeView } from "plastic";
+
+<CodeView
+  code={myCode}
+  language="typescript"
+  theme="dark"
+  showLineNumbers={true}
+  showAlternatingRows={true}
+/>`;
+
+export function CodeViewPage() {
+  const [theme, setTheme] = useState<CodeViewTheme>("light");
+
+  return (
+    <div className="max-w-2xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">CodeView</h1>
+        <p className="text-gray-500 mt-1">
+          라인 번호, 홀짝 배경, syntax highlighting을 갖춘 코드 표시 컴포넌트입니다.
+          <code className="text-sm bg-gray-100 px-1.5 py-0.5 rounded ml-1">
+            prism-react-renderer
+          </code>{" "}
+          기반으로 동작합니다.
+        </p>
+      </div>
+
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <p className="text-xs font-semibold uppercase tracking-widest text-gray-400">
+            TypeScript
+          </p>
+          <div className="flex gap-1.5">
+            <Button
+              size="sm"
+              variant={theme === "light" ? "primary" : "secondary"}
+              onClick={() => setTheme("light")}
+            >
+              Light
+            </Button>
+            <Button
+              size="sm"
+              variant={theme === "dark" ? "primary" : "secondary"}
+              onClick={() => setTheme("dark")}
+            >
+              Dark
+            </Button>
+          </div>
+        </div>
+        <CodeView code={TS_SAMPLE} language="typescript" theme={theme} />
+      </section>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          Python
+        </p>
+        <CodeView code={PYTHON_SAMPLE} language="python" theme={theme} />
+      </section>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          JSON
+        </p>
+        <CodeView code={JSON_SAMPLE} language="json" theme={theme} />
+      </section>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          No Line Numbers
+        </p>
+        <CodeView
+          code={TS_SAMPLE}
+          language="typescript"
+          theme={theme}
+          showLineNumbers={false}
+          showAlternatingRows={false}
+        />
+      </section>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          Props
+        </p>
+        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                {["Prop", "Type", "Default", "Description"].map((h) => (
+                  <th key={h} className="text-left px-4 py-2.5 text-xs font-semibold text-gray-500">
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {[
+                ["code", "string", "—", "표시할 코드 (필수)"],
+                ["language", "Language", '"typescript"', "문법 강조 언어"],
+                ["theme", '"light" | "dark"', '"light"', "색상 테마"],
+                ["showLineNumbers", "boolean", "true", "라인 번호 표시"],
+                ["showAlternatingRows", "boolean", "true", "홀짝 배경 구분"],
+              ].map(([prop, type, def, desc]) => (
+                <tr key={prop}>
+                  <td className="px-4 py-2.5 font-mono text-xs text-blue-700">{prop}</td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-gray-500">{type}</td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-gray-400">{def}</td>
+                  <td className="px-4 py-2.5 text-gray-600">{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          Usage
+        </p>
+        <CodeView code={USAGE_CODE} language="tsx" showAlternatingRows={false} />
+      </section>
+    </div>
+  );
+}

--- a/demo/tailwind.config.js
+++ b/demo/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./src/**/*.{ts,tsx}",
+    "../src/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "paths": {
+      "plastic": ["../src/index.ts"]
+    }
+  },
+  "include": ["src"]
+}

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      plastic: resolve(__dirname, "../src/index.ts"),
+    },
+  },
+});

--- a/docs/previews/button-preview.svg
+++ b/docs/previews/button-preview.svg
@@ -1,0 +1,36 @@
+<svg width="600" height="176" viewBox="0 0 600 176" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="600" height="176" rx="8" fill="#f9fafb"/>
+  <rect x="0.5" y="0.5" width="599" height="175" rx="7.5" stroke="#e5e7eb"/>
+
+  <!-- Variants label -->
+  <text x="20" y="26" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="10" font-weight="600" letter-spacing="0.08em" fill="#9ca3af">VARIANTS</text>
+
+  <!-- Primary button -->
+  <rect x="20" y="36" width="110" height="36" rx="5" fill="#2563eb"/>
+  <text x="75" y="60" text-anchor="middle" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="14" font-weight="500" fill="#ffffff">Primary</text>
+
+  <!-- Secondary button -->
+  <rect x="142" y="36" width="115" height="36" rx="5" fill="#e5e7eb"/>
+  <text x="199" y="60" text-anchor="middle" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="14" font-weight="500" fill="#111827">Secondary</text>
+
+  <!-- Ghost button -->
+  <text x="284" y="60" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="14" font-weight="500" fill="#374151">Ghost</text>
+
+  <!-- Divider -->
+  <line x1="20" y1="92" x2="580" y2="92" stroke="#e5e7eb" stroke-width="1"/>
+
+  <!-- Sizes label -->
+  <text x="20" y="114" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="10" font-weight="600" letter-spacing="0.08em" fill="#9ca3af">SIZES</text>
+
+  <!-- sm button -->
+  <rect x="20" y="122" width="70" height="28" rx="4" fill="#2563eb"/>
+  <text x="55" y="141" text-anchor="middle" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="12" font-weight="500" fill="#ffffff">Small</text>
+
+  <!-- md button -->
+  <rect x="102" y="118" width="94" height="36" rx="4" fill="#2563eb"/>
+  <text x="149" y="141" text-anchor="middle" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="14" font-weight="500" fill="#ffffff">Medium</text>
+
+  <!-- lg button -->
+  <rect x="208" y="114" width="112" height="44" rx="4" fill="#2563eb"/>
+  <text x="264" y="141" text-anchor="middle" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="16" font-weight="500" fill="#ffffff">Large</text>
+</svg>

--- a/docs/previews/card-preview.svg
+++ b/docs/previews/card-preview.svg
@@ -1,0 +1,33 @@
+<svg width="600" height="200" viewBox="0 0 600 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="600" height="200" rx="8" fill="#f9fafb"/>
+  <rect x="0.5" y="0.5" width="599" height="199" rx="7.5" stroke="#e5e7eb"/>
+
+  <!-- Card container -->
+  <rect x="20" y="20" width="300" height="160" rx="8" fill="#ffffff" stroke="#e5e7eb"/>
+
+  <!-- Card.Header -->
+  <text x="36" y="52" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="14" font-weight="600" fill="#111827">Card Title</text>
+  <line x1="20" y1="66" x2="320" y2="66" stroke="#e5e7eb" stroke-width="1"/>
+
+  <!-- Card.Body -->
+  <text x="36" y="92" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="13" fill="#6b7280">This is the card body. You can put</text>
+  <text x="36" y="110" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="13" fill="#6b7280">any content here.</text>
+
+  <!-- Card.Footer separator -->
+  <line x1="20" y1="138" x2="320" y2="138" stroke="#e5e7eb" stroke-width="1"/>
+
+  <!-- Card.Footer buttons -->
+  <rect x="36" y="148" width="72" height="24" rx="4" fill="#2563eb"/>
+  <text x="72" y="165" text-anchor="middle" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="12" font-weight="500" fill="#ffffff">Confirm</text>
+  <text x="122" y="165" font-family="ui-sans-serif,system-ui,-apple-system,sans-serif" font-size="12" font-weight="500" fill="#374151">Cancel</text>
+
+  <!-- Labels -->
+  <text x="340" y="52" font-family="ui-monospace,monospace" font-size="11" fill="#9ca3af">Card.Header</text>
+  <line x1="330" y1="50" x2="340" y2="50" stroke="#d1d5db" stroke-width="1"/>
+
+  <text x="340" y="100" font-family="ui-monospace,monospace" font-size="11" fill="#9ca3af">Card.Body</text>
+  <line x1="330" y1="98" x2="340" y2="98" stroke="#d1d5db" stroke-width="1"/>
+
+  <text x="340" y="160" font-family="ui-monospace,monospace" font-size="11" fill="#9ca3af">Card.Footer</text>
+  <line x1="330" y1="158" x2="340" y2="158" stroke="#d1d5db" stroke-width="1"/>
+</svg>

--- a/docs/previews/codeview-preview.svg
+++ b/docs/previews/codeview-preview.svg
@@ -1,0 +1,82 @@
+<svg width="600" height="220" viewBox="0 0 600 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Light theme panel -->
+  <rect width="600" height="220" rx="8" fill="#ffffff" stroke="#e5e7eb"/>
+
+  <!-- Line numbers column bg -->
+  <rect x="0" y="0" width="44" height="220" rx="8" fill="#f8f8f8"/>
+  <rect x="44" y="0" width="1" height="220" fill="#e5e7eb"/>
+
+  <!-- Alternating row (odd) -->
+  <rect x="0" y="28" width="600" height="28" fill="rgba(0,0,0,0.025)"/>
+  <rect x="0" y="84" width="600" height="28" fill="rgba(0,0,0,0.025)"/>
+  <rect x="0" y="140" width="600" height="28" fill="rgba(0,0,0,0.025)"/>
+  <rect x="0" y="196" width="600" height="24" fill="rgba(0,0,0,0.025)"/>
+
+  <!-- Line numbers -->
+  <text x="34" y="20" text-anchor="end" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12" fill="#9ca3af">1</text>
+  <text x="34" y="48" text-anchor="end" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12" fill="#9ca3af">2</text>
+  <text x="34" y="76" text-anchor="end" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12" fill="#9ca3af">3</text>
+  <text x="34" y="104" text-anchor="end" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12" fill="#9ca3af">4</text>
+  <text x="34" y="132" text-anchor="end" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12" fill="#9ca3af">5</text>
+  <text x="34" y="160" text-anchor="end" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12" fill="#9ca3af">6</text>
+  <text x="34" y="188" text-anchor="end" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12" fill="#9ca3af">7</text>
+  <text x="34" y="210" text-anchor="end" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12" fill="#9ca3af">8</text>
+
+  <!-- Code line 1: interface User { -->
+  <text x="56" y="20" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12">
+    <tspan fill="#0000ff">interface</tspan>
+    <tspan fill="#267f99"> User</tspan>
+    <tspan fill="#000000"> {</tspan>
+  </text>
+
+  <!-- Code line 2 (alternating):   id: number; -->
+  <text x="56" y="48" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12">
+    <tspan fill="#000000">  id</tspan>
+    <tspan fill="#000000">: </tspan>
+    <tspan fill="#267f99">number</tspan>
+    <tspan fill="#000000">;</tspan>
+  </text>
+
+  <!-- Code line 3:   name: string; -->
+  <text x="56" y="76" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12">
+    <tspan fill="#000000">  name</tspan>
+    <tspan fill="#000000">: </tspan>
+    <tspan fill="#267f99">string</tspan>
+    <tspan fill="#000000">;</tspan>
+  </text>
+
+  <!-- Code line 4 (alternating): } -->
+  <text x="56" y="104" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12" fill="#000000">}</text>
+
+  <!-- Code line 5: blank -->
+
+  <!-- Code line 6 (alternating): async function fetchUser -->
+  <text x="56" y="132" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12">
+    <tspan fill="#0000ff">async function </tspan>
+    <tspan fill="#795e26">fetchUser</tspan>
+    <tspan fill="#000000">(id: </tspan>
+    <tspan fill="#267f99">number</tspan>
+    <tspan fill="#000000">)</tspan>
+  </text>
+
+  <!-- Code line 7: const res = await fetch -->
+  <text x="56" y="160" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12">
+    <tspan fill="#0000ff">  const </tspan>
+    <tspan fill="#001080">res </tspan>
+    <tspan fill="#000000">= </tspan>
+    <tspan fill="#0000ff">await </tspan>
+    <tspan fill="#795e26">fetch</tspan>
+    <tspan fill="#000000">(</tspan>
+    <tspan fill="#a31515">`/api/users/`</tspan>
+    <tspan fill="#000000">)</tspan>
+  </text>
+
+  <!-- Code line 8 (alternating): return res.json() -->
+  <text x="56" y="188" font-family="ui-monospace,'Cascadia Code',monospace" font-size="12">
+    <tspan fill="#0000ff">  return </tspan>
+    <tspan fill="#001080">res</tspan>
+    <tspan fill="#000000">.</tspan>
+    <tspan fill="#795e26">json</tspan>
+    <tspan fill="#000000">();</tspan>
+  </text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },
+  "dependencies": {
+    "prism-react-renderer": "^2.3.0"
+  },
   "devDependencies": {
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",

--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -1,0 +1,86 @@
+import { Highlight, themes } from "prism-react-renderer";
+import type { CodeViewProps } from "./CodeView.types";
+
+// Internal — not exported
+const internalThemes = {
+  light: themes.vsLight,
+  dark: themes.vsDark,
+} as const;
+
+const lineNumberColor = {
+  light: "rgba(0,0,0,0.25)",
+  dark: "rgba(255,255,255,0.25)",
+} as const;
+
+const alternatingRowColor = {
+  light: "rgba(0,0,0,0.04)",
+  dark: "rgba(255,255,255,0.04)",
+} as const;
+
+export function CodeView({
+  code,
+  language = "typescript",
+  showLineNumbers = true,
+  showAlternatingRows = true,
+  theme = "light",
+  className = "",
+}: CodeViewProps) {
+  return (
+    <Highlight
+      theme={internalThemes[theme]}
+      code={code.trimEnd()}
+      language={language}
+    >
+      {({ className: hlClassName, style, tokens, getLineProps, getTokenProps }) => (
+        <pre
+          className={["overflow-x-auto rounded-lg text-sm", hlClassName, className]
+            .filter(Boolean)
+            .join(" ")}
+          style={style}
+        >
+          <code>
+            {tokens.map((line, lineIndex) => {
+              const { className: lineClassName, style: lineStyle, ...lineRest } = getLineProps({ line });
+              const isOdd = lineIndex % 2 !== 0;
+
+              return (
+                <div
+                  key={lineIndex}
+                  className={["flex", lineClassName].filter(Boolean).join(" ")}
+                  style={{
+                    ...lineStyle,
+                    ...(showAlternatingRows && isOdd
+                      ? { backgroundColor: alternatingRowColor[theme] }
+                      : {}),
+                  }}
+                  {...lineRest}
+                >
+                  {showLineNumbers && (
+                    <span
+                      aria-hidden="true"
+                      style={{
+                        minWidth: "2.5rem",
+                        paddingRight: "1rem",
+                        textAlign: "right",
+                        userSelect: "none",
+                        color: lineNumberColor[theme],
+                        flexShrink: 0,
+                      }}
+                    >
+                      {lineIndex + 1}
+                    </span>
+                  )}
+                  <span style={{ flex: 1 }}>
+                    {line.map((token, tokenIndex) => (
+                      <span key={tokenIndex} {...getTokenProps({ token })} />
+                    ))}
+                  </span>
+                </div>
+              );
+            })}
+          </code>
+        </pre>
+      )}
+    </Highlight>
+  );
+}

--- a/src/components/CodeView/CodeView.types.ts
+++ b/src/components/CodeView/CodeView.types.ts
@@ -1,0 +1,19 @@
+import type { Language } from "prism-react-renderer";
+
+export type { Language as CodeViewLanguage };
+
+export type CodeViewTheme = "light" | "dark";
+
+export interface CodeViewProps {
+  /** 표시할 코드 문자열 */
+  code: string;
+  /** 문법 강조 언어 (기본값: "typescript") */
+  language?: Language;
+  /** 라인 번호 표시 여부 (기본값: true) */
+  showLineNumbers?: boolean;
+  /** 홀짝 라인 배경색 구분 여부 (기본값: true) */
+  showAlternatingRows?: boolean;
+  /** 라이트 / 다크 테마 (기본값: "light") */
+  theme?: CodeViewTheme;
+  className?: string;
+}

--- a/src/components/CodeView/index.ts
+++ b/src/components/CodeView/index.ts
@@ -1,0 +1,2 @@
+export { CodeView } from "./CodeView";
+export type { CodeViewProps, CodeViewTheme, CodeViewLanguage } from "./CodeView.types";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./Button";
 export * from "./Card";
+export * from "./CodeView";


### PR DESCRIPTION
## Summary

- TypeScript + React 기반 UI 컴포넌트 라이브러리 초기 구조 구성
- 단일 진입점(`src/index.ts`) + Compound 컴포넌트 혼합 패턴 적용
- 빌드 도구(tsup), 타입 설정(tsconfig), 로컬 데모 앱(Vite) 포함

## Components

| 컴포넌트 | 패턴 | 설명 |
|---|---|---|
| `Button` | 단순 | variant / size / loading / disabled 지원 |
| `Card` | Compound | `Card.Root`, `Card.Header`, `Card.Body`, `Card.Footer` |
| `CodeView` | 단순 | 라인 번호, 홀짝 배경, syntax highlighting (prism-react-renderer) |

## Architecture

- `src/index.ts`에서 명시적으로 export된 심볼만 외부 노출
- 내부 구현(스타일 맵, 서브 컴포넌트, Context 등)은 미노출
- ESM + CJS 동시 빌드, `package.json` `exports` 필드로 진입점 제어

## Demo

```bash
cd demo && npm install && npm run dev
```

## Test plan

- [ ] `npm run build` — `dist/` 에 ESM, CJS, `.d.ts` 정상 생성 확인
- [ ] `npm run typecheck` — 타입 에러 없음 확인
- [ ] 데모 앱 실행 후 Button variants/sizes/states 렌더링 확인
- [ ] 데모 앱에서 Card 서브 컴포넌트 조합 렌더링 확인
- [ ] 데모 앱에서 CodeView light/dark 테마 토글 확인

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY