### PR TITLE
feat: plastic UI 컴포넌트 라이브러리 초기 구성

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ import { Card, Button } from "plastic";
 | `theme` | `"light" \| "dark"` | `"light"` | 색상 테마 (light: VS Light, dark: VS Dark) |
 | `showLineNumbers` | `boolean` | `true` | 라인 번호 표시 여부 |
 | `showAlternatingRows` | `boolean` | `true` | 홀짝 라인 배경색 구분 여부 |
+| `showInvisibles` | `boolean` | `false` | 탭·공백·불가시 유니코드 문자 시각화 여부 |
+| `tabSize` | `number` | `2` | 탭 너비 (`tab-size` CSS 및 불가시 문자 렌더링에 적용) |
 | `className` | `string` | — | 외부 컨테이너에 추가할 클래스 |
 
 #### Usage
@@ -167,6 +169,17 @@ import { CodeView } from "plastic";
   language="json"
   showLineNumbers={false}
   showAlternatingRows={false}
+/>
+
+// 불가시 문자 시각화
+// - 탭 → →  (tabSize 너비의 inline-block)
+// - 공백 → ·
+// - 특수 불가시 유니코드 → ZWS, NBS, BOM 등 3자 니모닉 칩 (hover 시 U+XXXX 툴팁)
+<CodeView
+  code={myCode}
+  language="typescript"
+  showInvisibles
+  tabSize={2}
 />
 ```
 

--- a/demo/src/pages/CodeViewPage.tsx
+++ b/demo/src/pages/CodeViewPage.tsx
@@ -46,6 +46,14 @@ const JSON_SAMPLE = `{
   }
 }`;
 
+// Contains tabs, spaces, and a zero-width space (U+200B) after the colon
+const INVISIBLES_SAMPLE = `function greet(name: string) {
+\tconst message = "Hello, " + name;
+\t// tab-indented line  with trailing spaces
+\tconst url = "https://example.com\u200B/path";
+\treturn message;
+}`;
+
 const USAGE_CODE = `import { CodeView } from "plastic";
 
 <CodeView
@@ -121,6 +129,24 @@ export function CodeViewPage() {
           theme={theme}
           showLineNumbers={false}
           showAlternatingRows={false}
+        />
+      </section>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          Show Invisibles
+        </p>
+        <p className="text-sm text-gray-500 mb-3">
+          탭 → <code className="bg-gray-100 px-1 rounded">→</code> &nbsp;
+          공백 → <code className="bg-gray-100 px-1 rounded">·</code> &nbsp;
+          특수 불가시 문자 → <code className="bg-gray-100 px-1 rounded">ZWS</code> 형태의 니모닉 칩
+        </p>
+        <CodeView
+          code={INVISIBLES_SAMPLE}
+          language="typescript"
+          theme={theme}
+          showInvisibles
+          tabSize={2}
         />
       </section>
 

--- a/src/components/CodeView/CodeView.invisibles.tsx
+++ b/src/components/CodeView/CodeView.invisibles.tsx
@@ -2,9 +2,10 @@
  * Internal — not exported from the package.
  *
  * Renders invisible characters as visual markers:
- *   - Tab        → arrow (→) with tab-width inline-block
- *   - Space      → middle dot (·)
- *   - Known invisible Unicode → 3-char uppercase mnemonic chip
+ *   - Tab (U+0009)          → arrow (→) with tab-width inline-block
+ *   - Space (U+0020)        → middle dot (·)
+ *   - ASCII control chars   → 3-char uppercase mnemonic chip
+ *   - Unicode invisible     → 3-char uppercase mnemonic chip
  */
 import type { ReactNode } from "react";
 import type { CodeViewTheme } from "./CodeView.types";
@@ -19,8 +20,49 @@ const CHIP_COLORS: Record<CodeViewTheme, { background: string; color: string }> 
   dark: { background: "rgba(255,255,255,0.12)", color: "rgba(255,255,255,0.5)" },
 };
 
-/** Unicode invisible characters → 3-char mnemonic */
+/**
+ * Invisible / non-printing characters → 3-char uppercase mnemonic.
+ *
+ * U+0009 (HT) and U+0020 (SP) are handled separately before this map
+ * and must NOT be added here.
+ */
 const MNEMONICS: Readonly<Record<string, string>> = {
+  // ── ASCII control characters U+0000–U+001F ──────────────────────────────
+  "\u0000": "NUL", // Null
+  "\u0001": "SOH", // Start of Heading
+  "\u0002": "STX", // Start of Text
+  "\u0003": "ETX", // End of Text
+  "\u0004": "EOT", // End of Transmission
+  "\u0005": "ENQ", // Enquiry
+  "\u0006": "ACK", // Acknowledge
+  "\u0007": "BEL", // Bell
+  "\u0008": "BSP", // Backspace
+  // U+0009 HT — handled as → (tab arrow), not here
+  "\u000A": "LFD", // Line Feed
+  "\u000B": "VTB", // Vertical Tab
+  "\u000C": "FFD", // Form Feed
+  "\u000D": "CRT", // Carriage Return
+  "\u000E": "SFO", // Shift Out
+  "\u000F": "SFI", // Shift In
+  "\u0010": "DLE", // Data Link Escape
+  "\u0011": "DC1", // Device Control 1 (XON)
+  "\u0012": "DC2", // Device Control 2
+  "\u0013": "DC3", // Device Control 3 (XOFF)
+  "\u0014": "DC4", // Device Control 4
+  "\u0015": "NAK", // Negative Acknowledge
+  "\u0016": "SYN", // Synchronous Idle
+  "\u0017": "ETB", // End of Transmission Block
+  "\u0018": "CAN", // Cancel
+  "\u0019": "EOM", // End of Medium
+  "\u001A": "SUB", // Substitute
+  "\u001B": "ESC", // Escape
+  "\u001C": "FSP", // File Separator
+  "\u001D": "GSP", // Group Separator
+  "\u001E": "RSP", // Record Separator
+  "\u001F": "USP", // Unit Separator
+  // ── ASCII delete ────────────────────────────────────────────────────────
+  "\u007F": "DEL", // Delete
+  // ── Unicode invisible / formatting characters ───────────────────────────
   "\u00A0": "NBS", // Non-breaking space
   "\u00AD": "SHY", // Soft hyphen
   "\u034F": "CGJ", // Combining grapheme joiner

--- a/src/components/CodeView/CodeView.invisibles.tsx
+++ b/src/components/CodeView/CodeView.invisibles.tsx
@@ -1,0 +1,138 @@
+/**
+ * Internal — not exported from the package.
+ *
+ * Renders invisible characters as visual markers:
+ *   - Tab        → arrow (→) with tab-width inline-block
+ *   - Space      → middle dot (·)
+ *   - Known invisible Unicode → 3-char uppercase mnemonic chip
+ */
+import type { ReactNode } from "react";
+import type { CodeViewTheme } from "./CodeView.types";
+
+const INVISIBLE_COLOR: Record<CodeViewTheme, string> = {
+  light: "rgba(0,0,0,0.22)",
+  dark: "rgba(255,255,255,0.28)",
+};
+
+const CHIP_COLORS: Record<CodeViewTheme, { background: string; color: string }> = {
+  light: { background: "rgba(0,0,0,0.08)", color: "rgba(0,0,0,0.45)" },
+  dark: { background: "rgba(255,255,255,0.12)", color: "rgba(255,255,255,0.5)" },
+};
+
+/** Unicode invisible characters → 3-char mnemonic */
+const MNEMONICS: Readonly<Record<string, string>> = {
+  "\u00A0": "NBS", // Non-breaking space
+  "\u00AD": "SHY", // Soft hyphen
+  "\u034F": "CGJ", // Combining grapheme joiner
+  "\u180E": "MVS", // Mongolian vowel separator
+  "\u200B": "ZWS", // Zero-width space
+  "\u200C": "ZWN", // Zero-width non-joiner
+  "\u200D": "ZWJ", // Zero-width joiner
+  "\u200E": "LRM", // Left-to-right mark
+  "\u200F": "RLM", // Right-to-left mark
+  "\u202A": "LRE", // Left-to-right embedding
+  "\u202B": "RLE", // Right-to-left embedding
+  "\u202C": "PDF", // Pop directional formatting
+  "\u202D": "LRO", // Left-to-right override
+  "\u202E": "RLO", // Right-to-left override
+  "\u2060": "WJR", // Word joiner
+  "\u2061": "FAP", // Function application (invisible)
+  "\u2062": "ITP", // Invisible times
+  "\u2063": "ISP", // Invisible separator
+  "\u2064": "IPL", // Invisible plus
+  "\uFEFF": "BOM", // Zero-width no-break space / BOM
+};
+
+const CHIP_BASE_STYLE = {
+  display: "inline-flex" as const,
+  alignItems: "center" as const,
+  fontSize: "0.6em",
+  fontWeight: 700 as const,
+  lineHeight: 1 as const,
+  padding: "1px 3px",
+  borderRadius: "3px",
+  verticalAlign: "middle" as const,
+  marginInline: "1px",
+  letterSpacing: "0.03em",
+};
+
+/**
+ * Splits a token's string content into an array of ReactNodes,
+ * replacing each invisible character with its visual representation.
+ */
+export function renderWithInvisibles(
+  content: string,
+  theme: CodeViewTheme,
+  tabSize: number
+): ReactNode[] {
+  const result: ReactNode[] = [];
+  let buffer = "";
+  let key = 0;
+
+  const flush = () => {
+    if (buffer) {
+      result.push(buffer);
+      buffer = "";
+    }
+  };
+
+  for (const char of content) {
+    if (char === "\t") {
+      flush();
+      result.push(
+        <span
+          key={key++}
+          role="presentation"
+          aria-label="tab"
+          style={{
+            display: "inline-block",
+            width: `${tabSize}ch`,
+            color: INVISIBLE_COLOR[theme],
+            overflow: "hidden",
+            userSelect: "none",
+          }}
+        >
+          →
+        </span>
+      );
+    } else if (char === " ") {
+      flush();
+      result.push(
+        <span
+          key={key++}
+          role="presentation"
+          aria-label="space"
+          style={{
+            color: INVISIBLE_COLOR[theme],
+            userSelect: "none",
+          }}
+        >
+          ·
+        </span>
+      );
+    } else if (char in MNEMONICS) {
+      flush();
+      const mnemonic = MNEMONICS[char]!;
+      const hex = char.codePointAt(0)!.toString(16).toUpperCase().padStart(4, "0");
+      result.push(
+        <span
+          key={key++}
+          title={`U+${hex} ${mnemonic}`}
+          aria-label={mnemonic}
+          style={{
+            ...CHIP_BASE_STYLE,
+            background: CHIP_COLORS[theme].background,
+            color: CHIP_COLORS[theme].color,
+          }}
+        >
+          {mnemonic}
+        </span>
+      );
+    } else {
+      buffer += char;
+    }
+  }
+
+  flush();
+  return result;
+}

--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -1,5 +1,6 @@
 import { Highlight, themes } from "prism-react-renderer";
 import type { CodeViewProps } from "./CodeView.types";
+import { renderWithInvisibles } from "./CodeView.invisibles";
 
 // Internal — not exported
 const internalThemes = {
@@ -22,6 +23,8 @@ export function CodeView({
   language = "typescript",
   showLineNumbers = true,
   showAlternatingRows = true,
+  showInvisibles = false,
+  tabSize = 2,
   theme = "light",
   className = "",
 }: CodeViewProps) {
@@ -36,7 +39,7 @@ export function CodeView({
           className={["overflow-x-auto rounded-lg text-sm", hlClassName, className]
             .filter(Boolean)
             .join(" ")}
-          style={style}
+          style={{ ...style, tabSize }}
         >
           <code>
             {tokens.map((line, lineIndex) => {
@@ -71,9 +74,16 @@ export function CodeView({
                     </span>
                   )}
                   <span style={{ flex: 1 }}>
-                    {line.map((token, tokenIndex) => (
-                      <span key={tokenIndex} {...getTokenProps({ token })} />
-                    ))}
+                    {line.map((token, tokenIndex) => {
+                      const { children: tokenContent, ...tokenSpanProps } = getTokenProps({ token });
+                      return (
+                        <span key={tokenIndex} {...tokenSpanProps}>
+                          {showInvisibles
+                            ? renderWithInvisibles(token.content, theme, tabSize)
+                            : tokenContent}
+                        </span>
+                      );
+                    })}
                   </span>
                 </div>
               );

--- a/src/components/CodeView/CodeView.types.ts
+++ b/src/components/CodeView/CodeView.types.ts
@@ -13,6 +13,10 @@ export interface CodeViewProps {
   showLineNumbers?: boolean;
   /** 홀짝 라인 배경색 구분 여부 (기본값: true) */
   showAlternatingRows?: boolean;
+  /** 탭·공백·불가시 유니코드 문자 시각화 여부 (기본값: false) */
+  showInvisibles?: boolean;
+  /** 탭 너비 — tab-size CSS 및 showInvisibles 탭 렌더링에 적용 (기본값: 2) */
+  tabSize?: number;
   /** 라이트 / 다크 테마 (기본값: "light") */
   theme?: CodeViewTheme;
   className?: string;


### PR DESCRIPTION
## Summary

- TypeScript + React 기반 UI 컴포넌트 라이브러리 초기 구조 구성
- 단일 진입점(`src/index.ts`) + Compound 컴포넌트 혼합 패턴 적용
- 빌드 도구(tsup), 타입 설정(tsconfig), 로컬 데모 앱(Vite) 포함

## Components

| 컴포넌트 | 패턴 | 설명 |
|---|---|---|
| `Button` | 단순 | variant / size / loading / disabled 지원 |
| `Card` | Compound | `Card.Root`, `Card.Header`, `Card.Body`, `Card.Footer` |
| `CodeView` | 단순 | 라인 번호, 홀짝 배경, syntax highlighting, 불가시 문자 시각화 |

## CodeView — 불가시 문자 시각화 (`showInvisibles`)

- 탭 → `→` (tabSize ch 너비 inline-block)
- 공백 → `·`
- ASCII 제어 문자 32종 (U+0000–U+001F, U+007F) → 3자 니모닉 칩 (`ESC`, `NUL`, `BEL` 등)
- Unicode 불가시 문자 20종 → 3자 니모닉 칩 (`ZWS`, `NBS`, `BOM` 등)
- hover 시 `U+XXXX` 코드포인트 툴팁

## Architecture

- `src/index.ts`에서 명시적으로 export된 심볼만 외부 노출
- 내부 구현(스타일 맵, 서브 컴포넌트, 불가시 문자 렌더러 등)은 미노출
- ESM + CJS 동시 빌드, `package.json` `exports` 필드로 진입점 제어

## Demo

```bash
cd demo && npm install && npm run dev
```

## Test plan

- [ ] `npm run build` — `dist/` 에 ESM, CJS, `.d.ts` 정상 생성 확인
- [ ] `npm run typecheck` — 타입 에러 없음 확인
- [ ] 데모 앱 Button variants / sizes / states 렌더링 확인
- [ ] 데모 앱 Card 서브 컴포넌트 조합 렌더링 확인
- [ ] 데모 앱 CodeView light/dark 테마 토글 확인
- [ ] 데모 앱 CodeView `showInvisibles` — 탭(`→`), 공백(`·`), `ZWS` 칩 확인
- [ ] `ESC`(U+001B) 등 ASCII 제어 문자 니모닉 칩 및 툴팁 확인

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY