### PR TITLE
feat: plastic UI 컴포넌트 라이브러리 초기 구성

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,16 +171,35 @@ import { CodeView } from "plastic";
   showAlternatingRows={false}
 />
 
-// 불가시 문자 시각화
-// - 탭 → →  (tabSize 너비의 inline-block)
-// - 공백 → ·
-// - 특수 불가시 유니코드 → ZWS, NBS, BOM 등 3자 니모닉 칩 (hover 시 U+XXXX 툴팁)
+// 불가시 문자 시각화 (showInvisibles)
+// 아래 코드는 탭 들여쓰기, 연속 공백, ESC 시퀀스, ZWS를 모두 포함합니다.
+const sample = `function greet(name: string) {\n\tconst msg = "Hello, " + name;\n\tconst esc = "\x1b[31mred\x1b[0m";\n\tconst url = "https://example.com\u200B/path";\n\treturn msg;\n}`;
+
 <CodeView
-  code={myCode}
+  code={sample}
   language="typescript"
   showInvisibles
   tabSize={2}
 />
+
+// showInvisibles 렌더링 규칙:
+//
+//  문자           표시          설명
+//  ─────────────────────────────────────────────────────────
+//  \t (U+0009)   →             탭 — tabSize ch 너비 inline-block
+//  ' ' (U+0020)  ·             공백 — 미들 닷
+//  \x1b (U+001B) [ESC]         ASCII 제어 문자 — 3자 니모닉 칩
+//  \x00 (U+0000) [NUL]           "
+//  \x07 (U+0007) [BEL]           "
+//  \x08 (U+0008) [BSP]           "
+//  \x0d (U+000D) [CRT]           "
+//  ... 총 32종 (U+0000–U+001F, U+007F)
+//  \u200B        [ZWS]         Unicode 불가시 문자 — 3자 니모닉 칩
+//  \uFEFF        [BOM]           "
+//  \u00A0        [NBS]           "
+//  ... 총 20종
+//
+//  모든 칩은 hover 시 "U+001B ESC" 형식의 툴팁을 표시합니다.
 ```
 
 ---


### PR DESCRIPTION
## Summary

- TypeScript + React 기반 UI 컴포넌트 라이브러리 초기 구조 구성
- 단일 진입점(`src/index.ts`) + Compound 컴포넌트 혼합 패턴 적용
- 빌드 도구(tsup), 타입 설정(tsconfig), 로컬 데모 앱(Vite) 포함

## Components

| 컴포넌트 | 패턴 | 설명 |
|---|---|---|
| `Button` | 단순 | variant / size / loading / disabled 지원 |
| `Card` | Compound | `Card.Root`, `Card.Header`, `Card.Body`, `Card.Footer` |
| `CodeView` | 단순 | 라인 번호, 홀짝 배경, syntax highlighting, 불가시 문자 시각화 |

## CodeView — 불가시 문자 시각화 (`showInvisibles`)

| 문자 | 표시 | 설명 |
|---|---|---|
| `\t` (U+0009) | `→` | 탭 — tabSize ch 너비 inline-block |
| ` ` (U+0020) | `·` | 공백 |
| U+0000–U+001F, U+007F | `ESC` `NUL` `BEL` … | ASCII 제어 문자 32종 — 3자 니모닉 칩 |
| U+00A0, U+200B … | `NBS` `ZWS` `BOM` … | Unicode 불가시 문자 20종 — 3자 니모닉 칩 |

모든 칩은 hover 시 `U+001B ESC` 형식의 툴팁을 표시합니다.

## Demo

```bash
cd demo && npm install && npm run dev
```

## Test plan

- [ ] `npm run build` — `dist/` 에 ESM, CJS, `.d.ts` 정상 생성 확인
- [ ] `npm run typecheck` — 타입 에러 없음 확인
- [ ] 데모 앱 Button variants / sizes / states 렌더링 확인
- [ ] 데모 앱 Card 서브 컴포넌트 조합 렌더링 확인
- [ ] 데모 앱 CodeView light/dark 테마 토글 확인
- [ ] 데모 앱 CodeView `showInvisibles` — 탭(`→`), 공백(`·`), `ZWS` 칩 확인
- [ ] `ESC`(U+001B) 등 ASCII 제어 문자 니모닉 칩 및 툴팁 확인

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY