### PR TITLE
fix(ci): remove npm cache config (no lock file in demo/)

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -25,8 +25,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: demo/package-lock.json
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
## Summary

- `demo/package-lock.json`이 존재하지 않아 `actions/setup-node`의 `cache-dependency-path` 설정이 실패하는 문제 수정
- `cache` / `cache-dependency-path` 옵션 제거

## Test plan

- [ ] PR merge 후 Actions 탭에서 워크플로 재실행 확인
- [ ] 모든 step 성공 후 `https://pihitpihit.github.io/plastic/` 접속 확인

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY