### PR TITLE
fix(ci): install root deps before demo build

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -26,7 +26,10 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Install dependencies
+      - name: Install root dependencies
+        run: npm install
+
+      - name: Install demo dependencies
         run: npm install
         working-directory: demo
 

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "noEmit": true,
     "paths": {
       "plastic": ["../src/index.ts"]
     }


### PR DESCRIPTION
## Summary

- CI에서 `demo/` 빌드 전 root `npm install`을 추가
- `tsc -b`가 `../src/**` 파일을 컴파일할 때 root `node_modules/@types/react`를 필요로 하는데, 이전에는 root 의존성을 설치하지 않아 `Cannot find module 'react'` 에러 발생

## Test plan

- [ ] PR merge 후 Actions 탭에서 워크플로 성공 확인
- [ ] `https://pihitpihit.github.io/plastic/` 접속 확인

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY