### PR TITLE
feat(CodeView): gutter/stripe 분리, 라인번호 폰트, 복사 버튼, 라인 하이라이트, 편집 강화

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ import { Card, Button } from "plastic";
 | `showAlternatingRows` | `boolean` | `true` | 홀짝 라인 배경색 구분 여부 |
 | `showInvisibles` | `boolean` | `false` | 탭·공백·불가시 유니코드 문자 시각화 여부 |
 | `tabSize` | `number` | `2` | 탭 너비 (`tab-size` CSS 및 불가시 문자 렌더링에 적용) |
-| `editable` | `boolean` | `false` | 인라인 편집 활성화. 포커스 시 줄 배경이 파란 계열로 전환 |
+| `editable` | `boolean` | `false` | 인라인 편집 활성화. 포커스 시 줄 배경이 파란 계열로 전환. Tab/Shift+Tab 들여쓰기, Enter 자동 들여쓰기 지원 |
 | `onValueChange` | `(value: string) => void` | — | 편집 시 호출되는 콜백 |
+| `highlightLines` | `number[]` | — | 강조할 라인 번호 배열 (1-indexed, 황색 배경 적용) |
 | `className` | `string` | — | 외부 컨테이너에 추가할 클래스 |
 
 #### Usage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 TypeScript + React 기반 UI 컴포넌트 라이브러리.
 
+**[데모 보기 →](https://pihitpihit.github.io/plastic/)**
+
 ---
 
 ## Installation

--- a/demo/src/pages/CodeViewPage.tsx
+++ b/demo/src/pages/CodeViewPage.tsx
@@ -152,11 +152,27 @@ export function CodeViewPage() {
 
       <section>
         <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
+          Highlight Lines
+        </p>
+        <p className="text-sm text-gray-500 mb-3">
+          <code className="bg-gray-100 px-1 rounded">highlightLines</code> prop에 강조할 라인 번호(1-indexed) 배열을 전달합니다.
+        </p>
+        <CodeView
+          code={TS_SAMPLE}
+          language="typescript"
+          theme={theme}
+          highlightLines={[1, 2, 3, 11]}
+        />
+      </section>
+
+      <section>
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">
           Editable
         </p>
         <p className="text-sm text-gray-500 mb-3">
           <code className="bg-gray-100 px-1 rounded">editable</code> 활성 시 인라인 편집 가능.
           포커스 진입 시 줄 배경색이 파란 계열로 전환되어 편집 상태를 시각적으로 구분합니다.
+          Tab으로 다중 라인 들여쓰기, Shift+Tab으로 내어쓰기, Enter로 자동 들여쓰기를 지원합니다.
         </p>
         <EditableDemo theme={theme} />
       </section>
@@ -183,6 +199,7 @@ export function CodeViewPage() {
                 ["theme", '"light" | "dark"', '"light"', "색상 테마"],
                 ["showLineNumbers", "boolean", "true", "라인 번호 표시"],
                 ["showAlternatingRows", "boolean", "true", "홀짝 배경 구분"],
+                ["highlightLines", "number[]", "—", "강조할 라인 번호 배열 (1-indexed)"],
                 ["editable", "boolean", "false", "인라인 편집 활성화"],
                 ["onValueChange", "(value: string) => void", "—", "편집 시 호출되는 콜백"],
               ].map(([prop, type, def, desc]) => (

--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -20,16 +20,35 @@ const alternatingRowColor = {
   dark: "rgba(255,255,255,0.04)",
 } as const;
 
-// editable + focused 모드 줄 배경 (파란 계열로 편집 중임을 시각화)
+// editable + focused 모드 줄 배경
 const alternatingRowEditColor = {
   light: "rgba(59,130,246,0.08)",
   dark: "rgba(96,165,250,0.10)",
+} as const;
+
+// highlightLines 강조 배경
+const highlightRowColor = {
+  light: "rgba(253,224,71,0.35)",
+  dark: "rgba(253,224,71,0.15)",
 } as const;
 
 const caretColor = {
   light: "rgba(0,0,0,0.85)",
   dark: "rgba(255,255,255,0.85)",
 } as const;
+
+const copyButtonColor = {
+  light: { bg: "rgba(0,0,0,0.06)", text: "rgba(0,0,0,0.45)" },
+  dark:  { bg: "rgba(255,255,255,0.08)", text: "rgba(255,255,255,0.45)" },
+} as const;
+
+/** 라인 수에 따라 gutter(라인번호 컬럼) 너비를 동적 계산 */
+function getGutterWidth(lineCount: number): string {
+  if (lineCount < 10)   return "1.5rem";
+  if (lineCount < 100)  return "2rem";
+  if (lineCount < 1000) return "2.75rem";
+  return "3.5rem";
+}
 
 export function CodeView({
   code,
@@ -41,12 +60,15 @@ export function CodeView({
   theme = "light",
   editable = false,
   onValueChange,
+  highlightLines,
   className = "",
 }: CodeViewProps) {
-  const [editValue, setEditValue] = useState(code);
-  const [isFocused, setIsFocused] = useState(false);
-  const prevCodeRef = useRef(code);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [editValue, setEditValue]     = useState(code);
+  const [isFocused, setIsFocused]     = useState(false);
+  const [copyState, setCopyState]     = useState<"idle" | "copied">("idle");
+  const prevCodeRef   = useRef(code);
+  const textareaRef   = useRef<HTMLTextAreaElement>(null);
+  const containerRef  = useRef<HTMLDivElement>(null);
 
   // code prop 변경 시 내부 상태 동기화 (외부에서 코드를 교체하는 경우)
   useEffect(() => {
@@ -58,11 +80,15 @@ export function CodeView({
 
   const displayCode = editable ? editValue : code;
 
-  const rowColor =
-    showAlternatingRows
-      ? (editable && isFocused ? alternatingRowEditColor[theme] : alternatingRowColor[theme])
-      : undefined;
+  // ── 복사 ────────────────────────────────────────────────────────────────
+  function handleCopy() {
+    navigator.clipboard.writeText(displayCode).then(() => {
+      setCopyState("copied");
+      setTimeout(() => setCopyState("idle"), 2000);
+    });
+  }
 
+  // ── 편집 이벤트 ──────────────────────────────────────────────────────────
   function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
     const next = e.target.value;
     setEditValue(next);
@@ -70,22 +96,83 @@ export function CodeView({
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    const el    = e.currentTarget;
+    const start = el.selectionStart;
+    const end   = el.selectionEnd;
+    const indent = " ".repeat(tabSize);
+
     if (e.key === "Tab") {
       e.preventDefault();
-      const el = e.currentTarget;
-      const start = el.selectionStart;
-      const end = el.selectionEnd;
-      const indent = " ".repeat(tabSize);
-      const next = editValue.slice(0, start) + indent + editValue.slice(end);
+      const lines     = editValue.split("\n");
+      const startLine = editValue.slice(0, start).split("\n").length - 1;
+      const endLine   = editValue.slice(0, end).split("\n").length - 1;
+
+      if (startLine !== endLine) {
+        // 다중 라인 선택 — 각 줄 들여쓰기/내어쓰기
+        let startDelta = 0;
+        let totalDelta = 0;
+        const newLines = lines.map((line, i) => {
+          if (i < startLine || i > endLine) return line;
+          if (e.shiftKey) {
+            const modified = line.startsWith(indent)
+              ? line.slice(tabSize)
+              : line.replace(/^( +)/, (m) => m.slice(Math.min(m.length, tabSize)));
+            const delta = modified.length - line.length;
+            if (i === startLine) startDelta = delta;
+            totalDelta += delta;
+            return modified;
+          } else {
+            if (i === startLine) startDelta = tabSize;
+            totalDelta += tabSize;
+            return indent + line;
+          }
+        });
+        const next = newLines.join("\n");
+        setEditValue(next);
+        onValueChange?.(next);
+        const newStart = Math.max(0, start + startDelta);
+        const newEnd   = Math.max(newStart, end + totalDelta);
+        requestAnimationFrame(() => {
+          if (textareaRef.current) {
+            textareaRef.current.selectionStart = newStart;
+            textareaRef.current.selectionEnd   = newEnd;
+          }
+        });
+      } else {
+        // 단일 커서 — 커서 위치에 indent 삽입
+        const next = editValue.slice(0, start) + indent + editValue.slice(end);
+        setEditValue(next);
+        onValueChange?.(next);
+        requestAnimationFrame(() => {
+          if (textareaRef.current) {
+            textareaRef.current.selectionStart = start + tabSize;
+            textareaRef.current.selectionEnd   = start + tabSize;
+          }
+        });
+      }
+    } else if (e.key === "Enter") {
+      // 자동 들여쓰기 — 현재 라인의 leading whitespace 유지
+      e.preventDefault();
+      const currentLine     = editValue.slice(0, start).split("\n").pop() ?? "";
+      const leadingWs       = currentLine.match(/^(\s*)/)?.[1] ?? "";
+      const next            = editValue.slice(0, start) + "\n" + leadingWs + editValue.slice(end);
       setEditValue(next);
       onValueChange?.(next);
-      // 커서 위치 복원 (setState가 비동기이므로 rAF 사용)
+      const newCursorPos = start + 1 + leadingWs.length;
       requestAnimationFrame(() => {
         if (textareaRef.current) {
-          textareaRef.current.selectionStart = start + tabSize;
-          textareaRef.current.selectionEnd = start + tabSize;
+          textareaRef.current.selectionStart = newCursorPos;
+          textareaRef.current.selectionEnd   = newCursorPos;
         }
       });
+    }
+  }
+
+  // textarea 내부 스크롤을 외부 컨테이너에 동기화
+  function handleTextareaScroll(e: React.UIEvent<HTMLTextAreaElement>) {
+    if (containerRef.current) {
+      containerRef.current.scrollTop  = e.currentTarget.scrollTop;
+      containerRef.current.scrollLeft = e.currentTarget.scrollLeft;
     }
   }
 
@@ -95,103 +182,143 @@ export function CodeView({
       code={displayCode.trimEnd()}
       language={language}
     >
-      {({ className: hlClassName, style, tokens, getLineProps, getTokenProps }) => (
-        // 외부 div가 scroll 컨테이너 & position 기준점 역할
-        <div
-          className={["overflow-x-auto rounded-lg text-sm", hlClassName, className]
-            .filter(Boolean)
-            .join(" ")}
-          style={{ ...style, tabSize, position: "relative" }}
-        >
-          <pre style={{ overflow: "visible", margin: 0 }}>
-            <code>
-              {tokens.map((line, lineIndex) => {
-                const { className: lineClassName, style: lineStyle, ...lineRest } = getLineProps({ line });
-                const isOdd = lineIndex % 2 !== 0;
+      {({ className: hlClassName, style, tokens, getLineProps, getTokenProps }) => {
+        const gutterWidth  = showLineNumbers ? getGutterWidth(tokens.length) : "0";
+        const gutterPad    = "1rem";
+        const textareaLeft = showLineNumbers ? `calc(${gutterWidth} + ${gutterPad})` : "0";
 
-                return (
-                  <div
-                    key={lineIndex}
-                    className={["flex", lineClassName].filter(Boolean).join(" ")}
-                    style={{ ...lineStyle }}
-                    {...lineRest}
-                  >
-                    {showLineNumbers && (
+        return (
+          // 외부 div가 scroll 컨테이너 & position 기준점 역할
+          <div
+            ref={containerRef}
+            className={["overflow-x-auto rounded-lg text-sm", hlClassName, className]
+              .filter(Boolean)
+              .join(" ")}
+            style={{ ...style, tabSize, position: "relative" }}
+          >
+            {/* 복사 버튼 */}
+            <button
+              onClick={handleCopy}
+              aria-label="코드 복사"
+              style={{
+                position:   "absolute",
+                top:        "0.35rem",
+                right:      "0.35rem",
+                zIndex:     10,
+                padding:    "0.15rem 0.45rem",
+                borderRadius: "0.25rem",
+                border:     "none",
+                cursor:     "pointer",
+                fontFamily: "ui-sans-serif, system-ui, sans-serif",
+                fontSize:   "0.7rem",
+                lineHeight: 1.4,
+                background: copyButtonColor[theme].bg,
+                color:      copyButtonColor[theme].text,
+                userSelect: "none",
+                transition: "opacity 0.1s",
+              }}
+            >
+              {copyState === "copied" ? "✓ 복사됨" : "복사"}
+            </button>
+
+            <pre style={{ overflow: "visible", margin: 0 }}>
+              <code>
+                {tokens.map((line, lineIndex) => {
+                  const { className: lineClassName, style: lineStyle, ...lineRest } = getLineProps({ line });
+                  const isOdd        = lineIndex % 2 !== 0;
+                  const isHighlighted = highlightLines?.includes(lineIndex + 1) ?? false;
+
+                  const rowBg = isHighlighted
+                    ? highlightRowColor[theme]
+                    : showAlternatingRows && isOdd
+                      ? (editable && isFocused ? alternatingRowEditColor[theme] : alternatingRowColor[theme])
+                      : undefined;
+
+                  return (
+                    <div
+                      key={lineIndex}
+                      className={["flex", lineClassName].filter(Boolean).join(" ")}
+                      style={{ ...lineStyle }}
+                      {...lineRest}
+                    >
+                      {showLineNumbers && (
+                        <span
+                          aria-hidden="true"
+                          style={{
+                            minWidth:    gutterWidth,
+                            paddingRight: gutterPad,
+                            textAlign:   "right",
+                            userSelect:  "none",
+                            color:       lineNumberColor[theme],
+                            flexShrink:  0,
+                            fontSize:    "0.85em",
+                          }}
+                        >
+                          {lineIndex + 1}
+                        </span>
+                      )}
                       <span
-                        aria-hidden="true"
                         style={{
-                          minWidth: "2.5rem",
-                          paddingRight: "1rem",
-                          textAlign: "right",
-                          userSelect: "none",
-                          color: lineNumberColor[theme],
-                          flexShrink: 0,
-                          fontSize: "0.85em",
+                          flex: 1,
+                          ...(rowBg ? { backgroundColor: rowBg } : {}),
                         }}
                       >
-                        {lineIndex + 1}
+                        {line.map((token, tokenIndex) => {
+                          const { children: tokenContent, ...tokenSpanProps } = getTokenProps({ token });
+                          return (
+                            <span key={tokenIndex} {...tokenSpanProps}>
+                              {showInvisibles
+                                ? renderWithInvisibles(token.content, theme, tabSize)
+                                : tokenContent}
+                            </span>
+                          );
+                        })}
                       </span>
-                    )}
-                    <span
-                      style={{
-                        flex: 1,
-                        ...(isOdd ? { backgroundColor: rowColor } : {}),
-                      }}
-                    >
-                      {line.map((token, tokenIndex) => {
-                        const { children: tokenContent, ...tokenSpanProps } = getTokenProps({ token });
-                        return (
-                          <span key={tokenIndex} {...tokenSpanProps}>
-                            {showInvisibles
-                              ? renderWithInvisibles(token.content, theme, tabSize)
-                              : tokenContent}
-                          </span>
-                        );
-                      })}
-                    </span>
-                  </div>
-                );
-              })}
-            </code>
-          </pre>
+                    </div>
+                  );
+                })}
+              </code>
+            </pre>
 
-          {editable && (
-            <textarea
-              ref={textareaRef}
-              value={editValue}
-              onChange={handleChange}
-              onKeyDown={handleKeyDown}
-              onFocus={() => setIsFocused(true)}
-              onBlur={() => setIsFocused(false)}
-              aria-label="code editor"
-              spellCheck={false}
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
-              style={{
-                position: "absolute",
-                inset: 0,
-                padding: 0,
-                paddingLeft: showLineNumbers ? "calc(2.5rem + 1rem)" : 0,
-                background: "transparent",
-                color: "transparent",
-                caretColor: caretColor[theme],
-                resize: "none",
-                border: "none",
-                outline: "none",
-                fontFamily: "ui-monospace, 'Cascadia Code', Menlo, monospace",
-                fontSize: "inherit",
-                lineHeight: "inherit",
-                overflow: "hidden",
-                whiteSpace: "pre",
-                wordBreak: "normal",
-                overflowWrap: "normal",
-                tabSize,
-              }}
-            />
-          )}
-        </div>
-      )}
+            {editable && (
+              <textarea
+                ref={textareaRef}
+                value={editValue}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => setIsFocused(false)}
+                onScroll={handleTextareaScroll}
+                aria-label="code editor"
+                spellCheck={false}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                style={{
+                  position:      "absolute",
+                  inset:         0,
+                  padding:       0,
+                  paddingLeft:   textareaLeft,
+                  background:    "transparent",
+                  color:         "transparent",
+                  caretColor:    caretColor[theme],
+                  resize:        "none",
+                  border:        "none",
+                  outline:       "none",
+                  fontFamily:    "ui-monospace, 'Cascadia Code', Menlo, monospace",
+                  fontSize:      "inherit",
+                  lineHeight:    "inherit",
+                  overflow:      "hidden",
+                  whiteSpace:    "pre",
+                  wordBreak:     "normal",
+                  overflowWrap:  "normal",
+                  tabSize,
+                }}
+              />
+            )}
+          </div>
+        );
+      }}
     </Highlight>
   );
 }

--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -113,10 +113,7 @@ export function CodeView({
                   <div
                     key={lineIndex}
                     className={["flex", lineClassName].filter(Boolean).join(" ")}
-                    style={{
-                      ...lineStyle,
-                      ...(isOdd ? { backgroundColor: rowColor } : {}),
-                    }}
+                    style={{ ...lineStyle }}
                     {...lineRest}
                   >
                     {showLineNumbers && (
@@ -129,12 +126,18 @@ export function CodeView({
                           userSelect: "none",
                           color: lineNumberColor[theme],
                           flexShrink: 0,
+                          fontSize: "0.85em",
                         }}
                       >
                         {lineIndex + 1}
                       </span>
                     )}
-                    <span style={{ flex: 1 }}>
+                    <span
+                      style={{
+                        flex: 1,
+                        ...(isOdd ? { backgroundColor: rowColor } : {}),
+                      }}
+                    >
                       {line.map((token, tokenIndex) => {
                         const { children: tokenContent, ...tokenSpanProps } = getTokenProps({ token });
                         return (

--- a/src/components/CodeView/CodeView.types.ts
+++ b/src/components/CodeView/CodeView.types.ts
@@ -23,5 +23,7 @@ export interface CodeViewProps {
   editable?: boolean;
   /** editable=true 시 코드 변경 콜백 */
   onValueChange?: (value: string) => void;
+  /** 강조할 라인 번호 배열 (1-indexed) */
+  highlightLines?: number[];
   className?: string;
 }


### PR DESCRIPTION
## Summary

- **README**: 상단에 GitHub Pages 데모 링크 추가
- **Gutter 분리**: alternating stripe를 content 영역에만 적용 — gutter(라인번호)는 stripe 없이 단색 유지
- **라인번호 폰트**: `0.85em`으로 축소 (content 대비 구분감)
- **복사 버튼**: 우상단 클립보드 복사 버튼 — 2초간 "✓ 복사됨" 피드백
- **`highlightLines` prop**: 지정 라인에 황색 배경 강조 (1-indexed)
- **다중 라인 Tab**: 여러 줄 선택 후 Tab/Shift+Tab으로 일괄 들여쓰기/내어쓰기
- **Enter 자동 들여쓰기**: 현재 줄의 leading whitespace를 다음 줄에 자동 삽입
- **Bug fix**: 라인번호 너비 동적 계산 (100줄 이상에서 gutter/textarea 정렬 깨짐 해소)
- **Bug fix**: textarea `onScroll` → 외부 컨테이너 스크롤 동기화

## Test plan

- [ ] PR merge 후 `https://pihitpihit.github.io/plastic/` 접속
- [ ] 복사 버튼 클릭 → "✓ 복사됨" 2초 표시 확인
- [ ] `highlightLines` 섹션에서 황색 강조 라인 확인
- [ ] Editable 섹션에서 여러 줄 선택 후 Tab/Shift+Tab 확인
- [ ] Enter 입력 시 들여쓰기 유지 확인

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY