### PR TITLE
feat: 패키징 개선, wordWrap·gutterWidth·gutterGap props, Layout Contract 문서화

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ import { Card, Button } from "plastic";
 | `editable` | `boolean` | `false` | 인라인 편집 활성화. 포커스 시 줄 배경이 파란 계열로 전환. Tab/Shift+Tab 들여쓰기, Enter 자동 들여쓰기 지원 |
 | `onValueChange` | `(value: string) => void` | — | 편집 시 호출되는 콜백 |
 | `highlightLines` | `number[]` | — | 강조할 라인 번호 배열 (1-indexed, 황색 배경 적용) |
+| `wordWrap` | `boolean` | `false` | 긴 줄 자동 줄바꿈 여부 |
 | `className` | `string` | — | 외부 컨테이너에 추가할 클래스 |
 
 #### Usage

--- a/README.md
+++ b/README.md
@@ -8,8 +8,23 @@ TypeScript + React 기반 UI 컴포넌트 라이브러리.
 
 ## Installation
 
+### GitHub에서 직접 설치 (npm 7+)
+
 ```bash
-npm install plastic
+# 최신 main 브랜치
+npm install github:pihitpihit/plastic
+
+# 특정 태그/커밋 고정
+npm install github:pihitpihit/plastic#v0.1.0
+```
+
+npm이 설치 후 자동으로 `prepare` 스크립트를 실행해 `dist/`를 빌드합니다.  
+**npm 7 이상** 필요 (npm 7+는 GitHub dependency 설치 시 devDependencies 설치 및 `prepare` 자동 실행).
+
+### npm 배포판 설치 (추후)
+
+```bash
+npm install @pihitpihit/plastic
 ```
 
 > **참고** — plastic 컴포넌트는 Tailwind CSS 클래스를 사용합니다.  
@@ -18,7 +33,7 @@ npm install plastic
 > ```js
 > content: [
 >   "./src/**/*.{ts,tsx}",
->   "./node_modules/plastic/dist/**/*.js", // plastic 컴포넌트 클래스 스캔
+>   "./node_modules/@pihitpihit/plastic/dist/**/*.js",
 > ]
 > ```
 
@@ -27,11 +42,11 @@ npm install plastic
 ## Quick Start
 
 ```ts
-import { Button, Card, CodeView } from "plastic";
-import type { ButtonProps, CardRootProps, CodeViewProps } from "plastic";
+import { Button, Card, CodeView } from "@pihitpihit/plastic";
+import type { ButtonProps, CardRootProps, CodeViewProps } from "@pihitpihit/plastic";
 ```
 
-모든 컴포넌트와 타입은 `"plastic"` 단일 진입점에서 import합니다.
+모든 컴포넌트와 타입은 `"@pihitpihit/plastic"` 단일 진입점에서 import합니다.
 
 ---
 
@@ -149,6 +164,8 @@ import { Card, Button } from "plastic";
 | `onValueChange` | `(value: string) => void` | — | 편집 시 호출되는 콜백 |
 | `highlightLines` | `number[]` | — | 강조할 라인 번호 배열 (1-indexed, 황색 배경 적용) |
 | `wordWrap` | `boolean` | `false` | 긴 줄 자동 줄바꿈 여부 |
+| `gutterWidth` | `string` | auto | 라인번호 컬럼 너비 (예: `"3rem"`). 미설정 시 줄 수에 따라 자동 계산 |
+| `gutterGap` | `string` | `"1rem"` | 라인번호와 코드 내용 사이 간격 |
 | `className` | `string` | — | 외부 컨테이너에 추가할 클래스 |
 
 #### Usage
@@ -237,6 +254,42 @@ src/
 ```
 
 `src/index.ts`에서 명시적으로 export된 심볼만 외부에 노출됩니다. 내부 구현 파일(`CardRoot.tsx`, 스타일 맵, 컨텍스트 등)은 직접 import할 수 없습니다.
+
+---
+
+## CodeView Layout Contract
+
+CodeView를 다른 프로젝트에 통합할 때 안전하게 조작할 수 있는 부분과 주의해야 할 부분입니다.
+
+### 안전한 외부 조작
+
+| 방법 | 설명 |
+|------|------|
+| `className` | 외부 컨테이너(scroll wrapper)에 클래스 추가. `max-w-*`, `shadow-*`, `border-*` 등 레이아웃 외부 스타일에 사용 |
+| `gutterWidth` | 라인번호 컬럼 너비 명시적 지정. textarea paddingLeft에 자동 반영됨 |
+| `gutterGap` | 라인번호와 코드 내용 사이 간격 지정. textarea paddingLeft에 자동 반영됨 |
+| `tabSize`, `showLineNumbers`, `wordWrap` 등 | 모든 공개 prop은 안전하게 사용 가능 |
+
+### 주의사항 — geometry가 깨지는 경우
+
+| 금지 사항 | 이유 |
+|-----------|------|
+| `className`으로 `padding` 추가 | 내부 textarea는 `inset: 0`으로 컨테이너를 꽉 채우므로, outer padding이 생기면 textarea와 렌더링 영역이 misalign됨 |
+| `<pre>` / gutter `<span>` 직접 스타일 조작 | flex 레이아웃 계산이 gutterWidth·gutterGap 기준으로 이루어지므로, 직접 조작 시 textarea overlay와 위치가 어긋남 |
+| `editable` 모드에서 font-size 변경 | `fontSize: "inherit"`으로 맞춰져 있지만, 외부에서 font-size를 계단식으로 바꾸면 줄 높이가 달라져 caret 위치가 어긋날 수 있음 |
+
+### editable 모드 통합 시
+
+```tsx
+// ✅ 안전 — 외부 컨테이너에 크기 제한
+<CodeView editable className="max-w-2xl" ... />
+
+// ❌ 위험 — outer padding이 textarea overlay와 misalign 유발
+<CodeView editable className="p-4" ... />
+
+// ✅ 안전 — gutter 간격 조정은 prop으로
+<CodeView editable gutterWidth="2rem" gutterGap="0.75rem" ... />
+```
 
 ---
 

--- a/demo/src/pages/CodeViewPage.tsx
+++ b/demo/src/pages/CodeViewPage.tsx
@@ -301,6 +301,8 @@ function PlaygroundSection() {
   const [editable, setEditable]               = useState(false);
   const [wordWrap, setWordWrap]               = useState(false);
   const [hlInput, setHlInput]                 = useState("");
+  const [gutterWidth, setGutterWidth]         = useState("");
+  const [gutterGap, setGutterGap]             = useState("");
 
   const highlightLines = hlInput
     .split(",")
@@ -383,17 +385,39 @@ function PlaygroundSection() {
           ))}
         </div>
 
-        {/* highlightLines */}
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-gray-500 w-24">highlightLines</span>
-          <input
-            type="text"
-            value={hlInput}
-            onChange={(e) => setHlInput(e.target.value)}
-            placeholder="1, 3, 5"
-            className="text-xs font-mono border border-gray-200 rounded px-2 py-1 bg-white w-36 focus:outline-none"
-          />
-          <span className="text-xs text-gray-400">콤마로 구분 (1-indexed)</span>
+        {/* highlightLines / gutterWidth / gutterGap */}
+        <div className="flex flex-wrap gap-x-4 gap-y-2">
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-500 w-24">highlightLines</span>
+            <input
+              type="text"
+              value={hlInput}
+              onChange={(e) => setHlInput(e.target.value)}
+              placeholder="1, 3, 5"
+              className="text-xs font-mono border border-gray-200 rounded px-2 py-1 bg-white w-28 focus:outline-none"
+            />
+            <span className="text-xs text-gray-400">콤마 구분</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-500 w-24">gutterWidth</span>
+            <input
+              type="text"
+              value={gutterWidth}
+              onChange={(e) => setGutterWidth(e.target.value)}
+              placeholder="auto"
+              className="text-xs font-mono border border-gray-200 rounded px-2 py-1 bg-white w-24 focus:outline-none"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-500 w-24">gutterGap</span>
+            <input
+              type="text"
+              value={gutterGap}
+              onChange={(e) => setGutterGap(e.target.value)}
+              placeholder="1rem"
+              className="text-xs font-mono border border-gray-200 rounded px-2 py-1 bg-white w-24 focus:outline-none"
+            />
+          </div>
         </div>
       </div>
 
@@ -424,6 +448,8 @@ function PlaygroundSection() {
           editable={editable}
           onValueChange={editable ? setCode : undefined}
           highlightLines={highlightLines.length > 0 ? highlightLines : undefined}
+          gutterWidth={gutterWidth || undefined}
+          gutterGap={gutterGap || undefined}
         />
       </div>
     </div>

--- a/demo/src/pages/CodeViewPage.tsx
+++ b/demo/src/pages/CodeViewPage.tsx
@@ -299,6 +299,7 @@ function PlaygroundSection() {
   const [showInvisibles, setShowInvisibles]   = useState(false);
   const [tabSize, setTabSize]                 = useState(2);
   const [editable, setEditable]               = useState(false);
+  const [wordWrap, setWordWrap]               = useState(false);
   const [hlInput, setHlInput]                 = useState("");
 
   const highlightLines = hlInput
@@ -310,6 +311,7 @@ function PlaygroundSection() {
     { label: "showLineNumbers",    value: showLineNumbers,    set: setShowLineNumbers },
     { label: "showAlternatingRows",value: showAlternatingRows,set: setShowAlternatingRows },
     { label: "showInvisibles",     value: showInvisibles,     set: setShowInvisibles },
+    { label: "wordWrap",           value: wordWrap,           set: setWordWrap },
     { label: "editable",           value: editable,           set: setEditable },
   ] as const;
 
@@ -418,6 +420,7 @@ function PlaygroundSection() {
           showAlternatingRows={showAlternatingRows}
           showInvisibles={showInvisibles}
           tabSize={tabSize}
+          wordWrap={wordWrap}
           editable={editable}
           onValueChange={editable ? setCode : undefined}
           highlightLines={highlightLines.length > 0 ? highlightLines : undefined}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "plastic",
+  "name": "@pihitpihit/plastic",
   "version": "0.0.1",
   "description": "Reusable UI component library built with TypeScript and React",
   "type": "module",
@@ -18,6 +18,7 @@
   ],
   "sideEffects": false,
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit"

--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -62,6 +62,8 @@ export function CodeView({
   onValueChange,
   highlightLines,
   wordWrap = false,
+  gutterWidth: gutterWidthProp,
+  gutterGap: gutterGapProp,
   className = "",
 }: CodeViewProps) {
   const [editValue, setEditValue]     = useState(code);
@@ -184,8 +186,10 @@ export function CodeView({
       language={language}
     >
       {({ className: hlClassName, style, tokens, getLineProps, getTokenProps }) => {
-        const gutterWidth  = showLineNumbers ? getGutterWidth(tokens.length) : "0";
-        const gutterPad    = "1rem";
+        const gutterWidth  = showLineNumbers
+          ? (gutterWidthProp ?? getGutterWidth(tokens.length))
+          : "0";
+        const gutterPad    = gutterGapProp ?? "1rem";
         const textareaLeft = showLineNumbers ? `calc(${gutterWidth} + ${gutterPad})` : "0";
 
         return (

--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -61,6 +61,7 @@ export function CodeView({
   editable = false,
   onValueChange,
   highlightLines,
+  wordWrap = false,
   className = "",
 }: CodeViewProps) {
   const [editValue, setEditValue]     = useState(code);
@@ -191,7 +192,7 @@ export function CodeView({
           // 외부 div가 scroll 컨테이너 & position 기준점 역할
           <div
             ref={containerRef}
-            className={["overflow-x-auto rounded-lg text-sm", hlClassName, className]
+            className={[wordWrap ? "" : "overflow-x-auto", "rounded-lg text-sm", hlClassName, className]
               .filter(Boolean)
               .join(" ")}
             style={{ ...style, tabSize, position: "relative" }}
@@ -221,7 +222,7 @@ export function CodeView({
               {copyState === "copied" ? "✓ 복사됨" : "복사"}
             </button>
 
-            <pre style={{ overflow: "visible", margin: 0 }}>
+            <pre style={{ overflow: "visible", margin: 0, whiteSpace: wordWrap ? "pre-wrap" : "pre", wordBreak: wordWrap ? "break-all" : "normal" }}>
               <code>
                 {tokens.map((line, lineIndex) => {
                   const { className: lineClassName, style: lineStyle, ...lineRest } = getLineProps({ line });
@@ -309,9 +310,9 @@ export function CodeView({
                   fontSize:      "inherit",
                   lineHeight:    "inherit",
                   overflow:      "hidden",
-                  whiteSpace:    "pre",
-                  wordBreak:     "normal",
-                  overflowWrap:  "normal",
+                  whiteSpace:    wordWrap ? "pre-wrap" : "pre",
+                  wordBreak:     wordWrap ? "break-all" : "normal",
+                  overflowWrap:  wordWrap ? "break-word" : "normal",
                   tabSize,
                 }}
               />

--- a/src/components/CodeView/CodeView.types.ts
+++ b/src/components/CodeView/CodeView.types.ts
@@ -27,5 +27,9 @@ export interface CodeViewProps {
   highlightLines?: number[];
   /** 긴 줄 자동 줄바꿈 여부 (기본값: false) */
   wordWrap?: boolean;
+  /** 라인번호 컬럼 너비 명시 (예: "3rem"). 미설정 시 줄 수에 따라 자동 계산 */
+  gutterWidth?: string;
+  /** 라인번호와 코드 내용 사이 간격 (기본값: "1rem") */
+  gutterGap?: string;
   className?: string;
 }

--- a/src/components/CodeView/CodeView.types.ts
+++ b/src/components/CodeView/CodeView.types.ts
@@ -25,5 +25,7 @@ export interface CodeViewProps {
   onValueChange?: (value: string) => void;
   /** 강조할 라인 번호 배열 (1-indexed) */
   highlightLines?: number[];
+  /** 긴 줄 자동 줄바꿈 여부 (기본값: false) */
+  wordWrap?: boolean;
   className?: string;
 }


### PR DESCRIPTION
## Summary

### 패키징 개선
- 패키지명 `plastic` → `@pihitpihit/plastic` (scoped, npm 동명 충돌 방지)
- `"prepare": "npm run build"` 추가 — `npm install github:pihitpihit/plastic` 로 GitHub에서 바로 설치 가능 (npm 7+)
- README Installation 섹션 전면 업데이트 (GitHub 설치 문법, npm 배포 안내)

### CodeView 신규 props
- `wordWrap` — 긴 줄 자동 줄바꿈 (기본 `false`)
- `gutterWidth` — 라인번호 컬럼 너비 명시 (미설정 시 자동 계산)
- `gutterGap` — 라인번호-코드 간격 (기본 `"1rem"`)

### Demo Playground
- `wordWrap`, `gutterWidth`, `gutterGap` 컨트롤 추가

### 문서
- README에 **Layout Contract** 섹션 추가 — 안전한 외부 조작 vs geometry 깨지는 경우 명시

## Test plan

- [ ] PR merge 후 `https://pihitpihit.github.io/plastic/` 접속
- [ ] Playground에서 `wordWrap` 토글 → 긴 줄 wrapping 확인
- [ ] `gutterWidth="2rem"`, `gutterGap="0.5rem"` 입력 → gutter 크기 변경 확인
- [ ] `npm install github:pihitpihit/plastic` 로 설치 후 import 동작 확인 (npm 7+)

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY