### PR TITLE
fix: CodeView editable 모드 커서 위치 misalign 수정

### DIFF
--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -199,7 +199,7 @@ export function CodeView({
             className={[wordWrap ? "" : "overflow-x-auto", "rounded-lg text-sm", hlClassName, className]
               .filter(Boolean)
               .join(" ")}
-            style={{ ...style, tabSize, position: "relative" }}
+            style={{ ...style, tabSize, position: "relative", fontFamily: "ui-monospace, 'Cascadia Code', Menlo, monospace" }}
           >
             {/* 복사 버튼 */}
             <button
@@ -226,7 +226,7 @@ export function CodeView({
               {copyState === "copied" ? "✓ 복사됨" : "복사"}
             </button>
 
-            <pre style={{ overflow: "visible", margin: 0, whiteSpace: wordWrap ? "pre-wrap" : "pre", wordBreak: wordWrap ? "break-all" : "normal" }}>
+            <pre style={{ overflow: "visible", margin: 0, padding: 0, whiteSpace: wordWrap ? "pre-wrap" : "pre", wordBreak: wordWrap ? "break-all" : "normal" }}>
               <code>
                 {tokens.map((line, lineIndex) => {
                   const { className: lineClassName, style: lineStyle, ...lineRest } = getLineProps({ line });
@@ -252,6 +252,7 @@ export function CodeView({
                           style={{
                             minWidth:    gutterWidth,
                             paddingRight: gutterPad,
+                            boxSizing:   "content-box",
                             textAlign:   "right",
                             userSelect:  "none",
                             color:       lineNumberColor[theme],
@@ -310,7 +311,7 @@ export function CodeView({
                   resize:        "none",
                   border:        "none",
                   outline:       "none",
-                  fontFamily:    "ui-monospace, 'Cascadia Code', Menlo, monospace",
+                  fontFamily:    "inherit",
                   fontSize:      "inherit",
                   lineHeight:    "inherit",
                   overflow:      "hidden",


### PR DESCRIPTION
## Summary

### 원인 분석

**1. `box-sizing` 불일치 (주요 원인)**

gutter span이 `minWidth: gutterWidth` + `paddingRight: gutterPad`를 사용하는데, Tailwind preflight 등이 전역으로 `box-sizing: border-box`를 적용하면 `paddingRight`가 `minWidth` 안으로 흡수됨.

- `border-box` 환경: 코드 시작 위치 = `gutterWidth`
- textarea `paddingLeft` = `calc(gutterWidth + gutterPad)` = `gutterPad`(기본 1rem)만큼 오른쪽으로 어긋남

→ gutter span에 `boxSizing: "content-box"` 명시 → 환경에 관계없이 gutter 총 너비 = `gutterWidth + gutterPad` 보장

**2. 폰트 불일치**

prism 테마 style이 외부 div에 적용될 때 `fontFamily`가 달라질 수 있고, textarea는 별도 폰트를 명시 → 문자 너비 차이로 수평 drift 발생.

→ 외부 div에 monospace 폰트 명시, textarea는 `fontFamily: "inherit"`으로 통일, `<pre>`에 `padding: 0` 추가

## Changes

| 위치 | 변경 |
|------|------|
| 외부 `<div>` style | `fontFamily` 명시 추가 |
| `<pre>` style | `padding: 0` 추가 (브라우저 기본값 제거) |
| gutter `<span>` style | `boxSizing: "content-box"` 추가 |
| `<textarea>` style | `fontFamily: "inherit"` 으로 변경 |

## Test plan

- [ ] editable 모드 활성화 후 타이핑 — 커서가 텍스트 위치와 일치하는지 확인
- [ ] Tailwind 환경(데모 앱)에서 gutter 좌우 정렬 이상 없는지 확인
- [ ] `gutterWidth`/`gutterGap` prop 변경 시 커서 정렬 유지되는지 확인
- [ ] `showLineNumbers={false}` 시 커서 위치 정상인지 확인

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY