### PR TITLE
fix: CodeView 텍스트 선택 영역 우측 drift 수정

### DIFF
--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -199,7 +199,7 @@ export function CodeView({
             className={[wordWrap ? "" : "overflow-x-auto", "rounded-lg text-sm", hlClassName, className]
               .filter(Boolean)
               .join(" ")}
-            style={{ ...style, tabSize, position: "relative", fontFamily: "ui-monospace, 'Cascadia Code', Menlo, monospace" }}
+            style={{ ...style, tabSize, position: "relative", fontFamily: "ui-monospace, 'Cascadia Code', Menlo, monospace", fontVariantLigatures: "none", fontKerning: "none" }}
           >
             {/* 복사 버튼 */}
             <button


### PR DESCRIPTION
## Summary

투명 textarea 오버레이 패턴에서 텍스트를 선택할 때 오른쪽으로 갈수록 선택 블록과 텍스트 위치가 어긋나는 현상 수정.

### 원인

`<pre>`는 코드를 토큰별 `<span>`으로 분할 렌더링하고, 브라우저는 각 span을 독립적으로 측정한다. 이 과정에서 두 가지 오차가 발생한다:

1. **서브픽셀 누적** — 각 span 경계에서 발생하는 서브픽셀 반올림 오차가 오른쪽으로 갈수록 누적됨
2. **합자(ligature) 불일치** — Cascadia Code 등의 폰트가 지원하는 `=>`, `->`, `===` 같은 합자가 토큰 경계에 걸리면 `<pre>`와 `<textarea>`의 문자 너비가 달라짐

### 수정

외부 컨테이너 div에 두 CSS 속성 추가 (상속되어 `<pre>` 내부와 `<textarea>` 모두에 적용):

- `fontVariantLigatures: "none"` — 합자 비활성화
- `fontKerning: "none"` — 커닝 비활성화

## Test plan

- [ ] editable 모드에서 긴 코드 줄 선택 → 선택 블록이 텍스트와 일치하는지 확인
- [ ] `=>`, `->`, `===` 등 합자 문자 포함 코드 선택 시 drift 없는지 확인

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY