### PR TITLE
refactor: CodeView 편집 모드 contenteditable 전면 재설계 및 기타 개선

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 pihitpihit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/demo/src/pages/CodeViewPage.tsx
+++ b/demo/src/pages/CodeViewPage.tsx
@@ -278,6 +278,7 @@ function EditableDemo({ theme }: { theme: import("plastic").CodeViewTheme }) {
 const PLAYGROUND_LANGUAGES: CodeViewLanguage[] = [
   "typescript", "javascript", "tsx", "jsx",
   "python", "json", "css", "bash", "markup",
+  "markdown", "text",
 ];
 
 const PLAYGROUND_INITIAL = `interface User {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@pihitpihit/plastic",
   "version": "0.0.1",
   "description": "Reusable UI component library built with TypeScript and React",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/CodeView/CodeView.invisibles.tsx
+++ b/src/components/CodeView/CodeView.invisibles.tsx
@@ -85,16 +85,30 @@ const MNEMONICS: Readonly<Record<string, string>> = {
   "\uFEFF": "BOM", // Zero-width no-break space / BOM
 };
 
+// 칩 외곽 컨테이너: 레이아웃상 정확히 1ch를 차지 (textarea와 동일)
+const CHIP_OUTER_STYLE = {
+  display: "inline-block" as const,
+  width: "1ch",
+  height: "1em",
+  position: "relative" as const,
+  verticalAlign: "middle" as const,
+  overflow: "visible" as const,
+};
+
+// 칩 본체: absolute로 1ch 컨테이너 중앙에 위치, 시각적으로만 오버플로우
 const CHIP_BASE_STYLE = {
+  position: "absolute" as const,
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
   display: "inline-flex" as const,
   alignItems: "center" as const,
+  whiteSpace: "nowrap" as const,
   fontSize: "0.6em",
   fontWeight: 700 as const,
   lineHeight: 1 as const,
   padding: "1px 3px",
   borderRadius: "3px",
-  verticalAlign: "middle" as const,
-  marginInline: "1px",
   letterSpacing: "0.03em",
 };
 
@@ -157,17 +171,24 @@ export function renderWithInvisibles(
       const mnemonic = MNEMONICS[char]!;
       const hex = char.codePointAt(0)!.toString(16).toUpperCase().padStart(4, "0");
       result.push(
+        // 외곽 span: 레이아웃상 정확히 1ch (textarea 문자 너비와 일치)
         <span
           key={key++}
           title={`U+${hex} ${mnemonic}`}
           aria-label={mnemonic}
-          style={{
-            ...CHIP_BASE_STYLE,
-            background: CHIP_COLORS[theme].background,
-            color: CHIP_COLORS[theme].color,
-          }}
+          style={CHIP_OUTER_STYLE}
         >
-          {mnemonic}
+          {/* 칩 본체: absolute로 중앙에 위치, 시각적으로만 오버플로우 */}
+          <span
+            aria-hidden="true"
+            style={{
+              ...CHIP_BASE_STYLE,
+              background: CHIP_COLORS[theme].background,
+              color: CHIP_COLORS[theme].color,
+            }}
+          >
+            {mnemonic}
+          </span>
         </span>
       );
     } else {

--- a/src/components/CodeView/CodeView.invisibles.tsx
+++ b/src/components/CodeView/CodeView.invisibles.tsx
@@ -38,7 +38,7 @@ const MNEMONIC_CATEGORY: Readonly<Record<string, ChipCategory>> = {
   // device control
   DC1: "device", DC2: "device", DC3: "device", DC4: "device",
   // format / whitespace effectors
-  BEL: "format", BSP: "format", LFD: "format", VTB: "format",
+  BEL: "format", BSP: "format", VTB: "format",
   FFD: "format", CRT: "format", SFO: "format", SFI: "format", EOM: "format",
   // information separators + delete
   FSP: "separator", GSP: "separator", RSP: "separator", USP: "separator", DEL: "separator",
@@ -99,7 +99,7 @@ const MNEMONICS: Readonly<Record<string, string>> = {
   "\u0007": "BEL", // Bell
   "\u0008": "BSP", // Backspace
   // U+0009 HT — handled as → (tab arrow), not here
-  "\u000A": "LFD", // Line Feed
+  // U+000A LF — 줄바꿈으로 실제 처리되므로 칩 표현 제외
   "\u000B": "VTB", // Vertical Tab
   "\u000C": "FFD", // Form Feed
   "\u000D": "CRT", // Carriage Return

--- a/src/components/CodeView/CodeView.invisibles.tsx
+++ b/src/components/CodeView/CodeView.invisibles.tsx
@@ -176,11 +176,17 @@ const CHIP_BASE_STYLE = {
 /**
  * Splits a token's string content into an array of ReactNodes,
  * replacing each invisible character with its visual representation.
+ *
+ * @param atomic  true = contenteditable 편집 모드용.
+ *                모든 칩 span에 `contentEditable="false"` + `data-char` 속성을 추가하여
+ *                브라우저가 칩 전체를 하나의 커서 단위로 처리하게 하고,
+ *                커스텀 DOM 워커가 실제 문자를 추출할 수 있게 한다.
  */
 export function renderWithInvisibles(
   content: string,
   theme: CodeViewTheme,
-  tabSize: number
+  tabSize: number,
+  atomic = false,
 ): ReactNode[] {
   const result: ReactNode[] = [];
   let buffer = "";
@@ -193,6 +199,11 @@ export function renderWithInvisibles(
     }
   };
 
+  // atomic 모드에서 공통으로 쓰이는 contentEditable props
+  const atomicProps = atomic
+    ? ({ contentEditable: "false" as const, suppressContentEditableWarning: true })
+    : {};
+
   for (const char of content) {
     if (char === "\t") {
       flush();
@@ -201,6 +212,8 @@ export function renderWithInvisibles(
           key={key++}
           role="presentation"
           aria-label="tab"
+          data-char={"\t"}
+          {...atomicProps}
           style={{
             display: "inline-block",
             width: `${tabSize}ch`,
@@ -219,6 +232,8 @@ export function renderWithInvisibles(
           key={key++}
           role="presentation"
           aria-label="space"
+          data-char={" "}
+          {...atomicProps}
           style={{
             color: INVISIBLE_COLOR[theme],
             userSelect: "none",
@@ -234,14 +249,14 @@ export function renderWithInvisibles(
       const category = MNEMONIC_CATEGORY[mnemonic] ?? "null";
       const chipColors = CHIP_CATEGORY_COLORS[category][theme];
       result.push(
-        // 외곽 span: 레이아웃상 정확히 1ch (textarea 문자 너비와 일치)
         <span
           key={key++}
           title={`U+${hex} ${mnemonic}`}
           aria-label={mnemonic}
+          data-char={char}
+          {...atomicProps}
           style={CHIP_OUTER_STYLE}
         >
-          {/* 칩 본체: absolute로 중앙에 위치, 시각적으로만 오버플로우 */}
           <span
             aria-hidden="true"
             style={{

--- a/src/components/CodeView/CodeView.invisibles.tsx
+++ b/src/components/CodeView/CodeView.invisibles.tsx
@@ -15,9 +15,70 @@ const INVISIBLE_COLOR: Record<CodeViewTheme, string> = {
   dark: "rgba(255,255,255,0.28)",
 };
 
-const CHIP_COLORS: Record<CodeViewTheme, { background: string; color: string }> = {
-  light: { background: "rgba(0,0,0,0.08)", color: "rgba(0,0,0,0.45)" },
-  dark: { background: "rgba(255,255,255,0.12)", color: "rgba(255,255,255,0.5)" },
+// ── 니모닉 칩 카테고리 ────────────────────────────────────────────────────────
+
+type ChipCategory =
+  | "null"           // NUL
+  | "escape"         // ESC, SUB, CAN
+  | "communication"  // 전송 제어 (SOH~ETB, DLE)
+  | "device"         // DC1~DC4
+  | "format"         // 형식 제어 (BEL, BSP, LFD, CRT, 등)
+  | "separator"      // 구분자 (FSP~USP, DEL)
+  | "unicode";       // Unicode 불가시 문자
+
+/** 니모닉 문자열 → 카테고리 매핑 */
+const MNEMONIC_CATEGORY: Readonly<Record<string, ChipCategory>> = {
+  NUL: "null",
+  // escape / special
+  ESC: "escape", SUB: "escape", CAN: "escape",
+  // transmission control
+  SOH: "communication", STX: "communication", ETX: "communication",
+  EOT: "communication", ENQ: "communication", ACK: "communication",
+  DLE: "communication", NAK: "communication", SYN: "communication", ETB: "communication",
+  // device control
+  DC1: "device", DC2: "device", DC3: "device", DC4: "device",
+  // format / whitespace effectors
+  BEL: "format", BSP: "format", LFD: "format", VTB: "format",
+  FFD: "format", CRT: "format", SFO: "format", SFI: "format", EOM: "format",
+  // information separators + delete
+  FSP: "separator", GSP: "separator", RSP: "separator", USP: "separator", DEL: "separator",
+  // Unicode invisible / formatting
+  NBS: "unicode", SHY: "unicode", CGJ: "unicode", MVS: "unicode",
+  ZWS: "unicode", ZWN: "unicode", ZWJ: "unicode", LRM: "unicode", RLM: "unicode",
+  LRE: "unicode", RLE: "unicode", PDF: "unicode", LRO: "unicode", RLO: "unicode",
+  WJR: "unicode", FAP: "unicode", ITP: "unicode", ISP: "unicode", IPL: "unicode", BOM: "unicode",
+};
+
+/** 카테고리별 칩 색상 */
+const CHIP_CATEGORY_COLORS: Record<ChipCategory, Record<CodeViewTheme, { background: string; color: string }>> = {
+  null: {
+    light: { background: "rgba(100,100,100,0.12)", color: "rgba(70,70,70,0.85)"    },
+    dark:  { background: "rgba(150,150,150,0.20)", color: "rgba(190,190,190,0.85)" },
+  },
+  escape: {
+    light: { background: "rgba(220,60,20,0.13)",   color: "rgba(180,40,10,0.90)"   },
+    dark:  { background: "rgba(255,110,60,0.20)",  color: "rgba(255,150,100,0.90)" },
+  },
+  communication: {
+    light: { background: "rgba(30,100,220,0.13)",  color: "rgba(20,75,185,0.90)"   },
+    dark:  { background: "rgba(70,145,255,0.20)",  color: "rgba(110,175,255,0.90)" },
+  },
+  device: {
+    light: { background: "rgba(130,45,205,0.13)",  color: "rgba(100,25,170,0.90)"  },
+    dark:  { background: "rgba(175,105,255,0.20)", color: "rgba(205,145,255,0.90)" },
+  },
+  format: {
+    light: { background: "rgba(0,145,130,0.13)",   color: "rgba(0,105,95,0.90)"    },
+    dark:  { background: "rgba(35,185,165,0.20)",  color: "rgba(70,205,185,0.90)"  },
+  },
+  separator: {
+    light: { background: "rgba(175,125,0,0.13)",   color: "rgba(135,95,0,0.90)"    },
+    dark:  { background: "rgba(225,175,35,0.20)",  color: "rgba(250,205,75,0.90)"  },
+  },
+  unicode: {
+    light: { background: "rgba(185,35,115,0.13)",  color: "rgba(145,15,85,0.90)"   },
+    dark:  { background: "rgba(250,95,155,0.20)",  color: "rgba(255,135,185,0.90)" },
+  },
 };
 
 /**
@@ -107,7 +168,7 @@ const CHIP_BASE_STYLE = {
   fontSize: "0.6em",
   fontWeight: 700 as const,
   lineHeight: 1 as const,
-  padding: "1px 3px",
+  padding: "2px 3px",
   borderRadius: "3px",
   letterSpacing: "0.03em",
 };
@@ -170,6 +231,8 @@ export function renderWithInvisibles(
       flush();
       const mnemonic = MNEMONICS[char]!;
       const hex = char.codePointAt(0)!.toString(16).toUpperCase().padStart(4, "0");
+      const category = MNEMONIC_CATEGORY[mnemonic] ?? "null";
+      const chipColors = CHIP_CATEGORY_COLORS[category][theme];
       result.push(
         // 외곽 span: 레이아웃상 정확히 1ch (textarea 문자 너비와 일치)
         <span
@@ -183,8 +246,8 @@ export function renderWithInvisibles(
             aria-hidden="true"
             style={{
               ...CHIP_BASE_STYLE,
-              background: CHIP_COLORS[theme].background,
-              color: CHIP_COLORS[theme].color,
+              background: chipColors.background,
+              color: chipColors.color,
             }}
           >
             {mnemonic}

--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useLayoutEffect, useRef, Fragment } from "react";
 import { Highlight, themes } from "prism-react-renderer";
 import type { CodeViewProps } from "./CodeView.types";
 import { renderWithInvisibles } from "./CodeView.invisibles";
@@ -14,32 +14,14 @@ const lineNumberColor = {
   dark: "rgba(255,255,255,0.25)",
 } as const;
 
-// readonly 모드 줄 배경
 const alternatingRowColor = {
   light: "rgba(0,0,0,0.04)",
   dark: "rgba(255,255,255,0.04)",
 } as const;
 
-// editable + focused 모드 줄 배경
-const alternatingRowEditColor = {
-  light: "rgba(59,130,246,0.08)",
-  dark: "rgba(96,165,250,0.10)",
-} as const;
-
-// highlightLines 강조 배경
 const highlightRowColor = {
   light: "rgba(253,224,71,0.35)",
   dark: "rgba(253,224,71,0.15)",
-} as const;
-
-const caretColor = {
-  light: "rgba(0,0,0,0.85)",
-  dark: "rgba(255,255,255,0.85)",
-} as const;
-
-const selectionColor = {
-  light: "rgba(59,130,246,0.25)",
-  dark: "rgba(96,165,250,0.30)",
 } as const;
 
 const copyButtonColor = {
@@ -55,33 +37,49 @@ function getGutterWidth(lineCount: number): string {
   return "3.5rem";
 }
 
-// ── 커서/선택 계산 헬퍼 (순수 함수) ─────────────────────────────────────────
+// ── contenteditable 커서 헬퍼 ─────────────────────────────────────────────────
 
-/** 문자열 offset → {row, col} */
-function offsetToPos(text: string, offset: number): { row: number; col: number } {
-  const before = text.slice(0, Math.min(offset, text.length));
-  const lines = before.split("\n");
-  return { row: lines.length - 1, col: (lines[lines.length - 1] ?? "").length };
+/**
+ * (targetNode, targetOffset) → root 내 선형 문자 오프셋.
+ * root 아래의 텍스트 노드를 순서대로 순회하여 누적 길이를 반환한다.
+ */
+function domPosToOffset(
+  root: Element,
+  targetNode: Node,
+  targetOffset: number
+): number {
+  let count = 0;
+  const iter = document.createNodeIterator(root, NodeFilter.SHOW_TEXT);
+  let n: Node | null;
+  while ((n = iter.nextNode())) {
+    if (n === targetNode) return count + targetOffset;
+    count += (n as Text).length;
+  }
+  return count;
 }
 
 /**
- * col 인덱스 → 실제 픽셀 X (탭 너비 반영).
- * CSS tab-size와 동일한 로직: 현재 컬럼에서 다음 tabSize 배수 스톱으로 이동.
+ * 선형 문자 오프셋 → root 내 { node, offset }.
+ * 오프셋이 텍스트 범위를 벗어나면 마지막 노드의 끝을 반환한다.
  */
-function colToX(lineText: string, col: number, charWidth: number, tabSz: number): number {
-  let x = 0;
-  const limit = Math.min(col, lineText.length);
-  for (let i = 0; i < limit; i++) {
-    if (lineText[i] === "\t") {
-      const currentCol = Math.round(x / charWidth);
-      const nextStop   = Math.ceil((currentCol + 1) / tabSz) * tabSz;
-      x = nextStop * charWidth;
-    } else {
-      x += charWidth;
-    }
+function offsetToDomPos(
+  root: Element,
+  charOffset: number
+): { node: Node; offset: number } | null {
+  let remaining = charOffset;
+  const iter = document.createNodeIterator(root, NodeFilter.SHOW_TEXT);
+  let n: Node | null;
+  let lastNode: Node | null = null;
+  let lastLen = 0;
+  while ((n = iter.nextNode())) {
+    const len = (n as Text).length;
+    if (remaining <= len) return { node: n, offset: remaining };
+    remaining -= len;
+    lastNode = n;
+    lastLen = len;
   }
-  if (col > lineText.length) x += (col - lineText.length) * charWidth;
-  return x;
+  if (lastNode) return { node: lastNode, offset: lastLen };
+  return null;
 }
 
 // ── 컴포넌트 ──────────────────────────────────────────────────────────────────
@@ -104,20 +102,13 @@ export function CodeView({
   className = "",
 }: CodeViewProps) {
   const [editValue, setEditValue] = useState(code);
-  const [isFocused, setIsFocused] = useState(false);
   const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
 
-  // 커서/선택 추적
-  const [selInfo, setSelInfo] = useState({ start: 0, end: 0 });
-
-  // 문자 측정값 — charWidth: 1글자 픽셀 너비, lineHeight: 1줄 픽셀 높이,
-  //               gutterPixels: gutter 전체 픽셀 너비 (minWidth + paddingRight)
-  const [metrics, setMetrics] = useState({ charWidth: 0, lineHeight: 0, gutterPixels: 0 });
-
-  const prevCodeRef   = useRef(code);
-  const textareaRef   = useRef<HTMLTextAreaElement>(null);
-  const containerRef  = useRef<HTMLDivElement>(null);
-  const charMeasureRef = useRef<HTMLSpanElement>(null); // 문자폭 측정용 hidden span
+  const prevCodeRef    = useRef(code);
+  const preRef         = useRef<HTMLPreElement>(null);
+  const containerRef   = useRef<HTMLDivElement>(null);
+  // 렌더 후 커서를 복원할 때 사용하는 선형 오프셋 저장소
+  const savedCursorRef = useRef<{ start: number; end: number } | null>(null);
 
   // code prop 변경 시 내부 상태 동기화
   useEffect(() => {
@@ -127,147 +118,85 @@ export function CodeView({
     }
   }, [code]);
 
-  // ── 커서/선택 스타일 & 애니메이션 CSS 전역 1회 주입 ─────────────────────────
-  useLayoutEffect(() => {
-    if (!editable || typeof document === "undefined") return;
-    const id = "plastic-cv-style";
-    if (document.getElementById(id)) return;
-    const el = document.createElement("style");
-    el.id = id;
-    el.textContent = [
-      // 커서 깜박임
-      "@keyframes plastic-cv-blink{0%,100%{opacity:1}50%{opacity:0}}",
-      // textarea native 선택 영역 숨기기 (커스텀 overlay로 대체)
-      ".plastic-cv-ta::selection{background:transparent!important}",
-    ].join("");
-    document.head.appendChild(el);
-  }, [editable]);
-
-  // ── 문자 측정 (editable 전용) ────────────────────────────────────────────────
-  useLayoutEffect(() => {
-    if (!editable || !containerRef.current) return;
-
-    const doMeasure = () => {
-      const charEl   = charMeasureRef.current;
-      const lineEl   = containerRef.current?.querySelector<HTMLElement>("[data-cv-line]");
-      const gutterEl = containerRef.current?.querySelector<HTMLElement>("[data-cv-gutter]");
-      if (!charEl) return;
-
-      const cw = charEl.getBoundingClientRect().width;
-      const lh = lineEl   ? lineEl.getBoundingClientRect().height   : 0;
-      const gp = gutterEl ? gutterEl.getBoundingClientRect().width  : 0;
-
-      if (cw > 0) setMetrics({ charWidth: cw, lineHeight: lh, gutterPixels: gp });
-    };
-
-    doMeasure();
-
-    // 컨테이너 크기 변경 시 재측정 (폰트 크기 변경 대응)
-    const ro = new ResizeObserver(doMeasure);
-    ro.observe(containerRef.current);
-    return () => ro.disconnect();
-  }, [editable, showLineNumbers, gutterWidthProp, gutterGapProp, tabSize]);
-
-  // ── 선택 영역 동기화 ──────────────────────────────────────────────────────────
-  const syncSel = useCallback(() => {
-    const ta = textareaRef.current;
-    if (ta) setSelInfo({ start: ta.selectionStart, end: ta.selectionEnd });
-  }, []);
-
   const displayCode = editable ? editValue : code;
 
-  // ── 커서/선택 오버레이 렌더링 ─────────────────────────────────────────────────
-  function renderCursorOverlay() {
-    const { charWidth, lineHeight, gutterPixels } = metrics;
-    if (!editable || charWidth === 0 || lineHeight === 0) return null;
+  // ── 렌더 후 커서 복원 ─────────────────────────────────────────────────────
+  // React가 Prism 토큰을 업데이트하면 DOM이 바뀌고 selection이 무효화된다.
+  // useLayoutEffect(브라우저 페인트 전)에서 저장된 오프셋으로 selection을 복원한다.
+  useLayoutEffect(() => {
+    const saved = savedCursorRef.current;
+    if (!saved || !preRef.current) return;
+    savedCursorRef.current = null;
 
-    const codeLines  = editValue.split("\n");
-    const startPos   = offsetToPos(editValue, selInfo.start);
-    const endPos     = offsetToPos(editValue, selInfo.end);
-    const isCursor   = selInfo.start === selInfo.end;
+    const pre = preRef.current;
+    const sel = window.getSelection();
+    if (!sel) return;
 
-    if (isCursor) {
-      if (!isFocused) return null;
-      const x = gutterPixels + colToX(codeLines[startPos.row] ?? "", startPos.col, charWidth, tabSize);
-      const y = startPos.row * lineHeight;
-      return (
-        <div style={{ position: "absolute", inset: 0, pointerEvents: "none", overflow: "hidden" }}>
-          <div style={{
-            position:        "absolute",
-            left:            x,
-            top:             y,
-            width:           2,
-            height:          lineHeight,
-            backgroundColor: caretColor[theme],
-            animation:       "plastic-cv-blink 1.2s step-end infinite",
-          }} />
-        </div>
-      );
+    const startPos = offsetToDomPos(pre, saved.start);
+    const endPos   = saved.end !== saved.start
+      ? offsetToDomPos(pre, saved.end)
+      : startPos;
+
+    if (!startPos) return;
+    try {
+      const range = document.createRange();
+      range.setStart(startPos.node, startPos.offset);
+      if (endPos && saved.end !== saved.start) {
+        range.setEnd(endPos.node, endPos.offset);
+      } else {
+        range.collapse(true);
+      }
+      sel.removeAllRanges();
+      sel.addRange(range);
+    } catch {
+      // 빠른 편집 중 range가 잠시 무효화될 수 있음 — 무시
     }
-
-    // 선택 영역 — 라인별 rect 계산
-    const rects: Array<{ row: number; x1: number; x2: number }> = [];
-    for (let row = startPos.row; row <= endPos.row; row++) {
-      const lineText  = codeLines[row] ?? "";
-      // 줄 끝 너비: 마지막 문자 오른쪽 + 1ch (EOL 포함)
-      const lineEndX  = colToX(lineText, lineText.length, charWidth, tabSize) + charWidth;
-      const x1 = row === startPos.row
-        ? colToX(lineText, startPos.col, charWidth, tabSize)
-        : 0;
-      const x2 = row === endPos.row
-        ? colToX(lineText, endPos.col, charWidth, tabSize)
-        : lineEndX;
-      rects.push({ row, x1, x2 });
-    }
-
-    return (
-      <div style={{ position: "absolute", inset: 0, pointerEvents: "none", overflow: "hidden" }}>
-        {rects.map((rect, i) => (
-          <div
-            key={i}
-            style={{
-              position:        "absolute",
-              left:            gutterPixels + rect.x1,
-              top:             rect.row * lineHeight,
-              width:           Math.max(0, rect.x2 - rect.x1),
-              height:          lineHeight,
-              backgroundColor: selectionColor[theme],
-            }}
-          />
-        ))}
-      </div>
-    );
-  }
-
-  // ── 복사 ────────────────────────────────────────────────────────────────────
-  function handleCopy() {
-    navigator.clipboard.writeText(displayCode).then(() => {
-      setCopyState("copied");
-      setTimeout(() => setCopyState("idle"), 2000);
-    });
-  }
+  });
 
   // ── 편집 이벤트 ──────────────────────────────────────────────────────────────
-  function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
-    const next = e.target.value;
-    setEditValue(next);
-    onValueChange?.(next);
-    syncSel();
+
+  function handleInput() {
+    const pre = preRef.current;
+    if (!pre) return;
+
+    // 상태 업데이트 전에 커서 오프셋을 저장 (브라우저가 수정한 DOM 기준)
+    const sel = window.getSelection();
+    if (sel?.rangeCount) {
+      const range = sel.getRangeAt(0);
+      const start = domPosToOffset(pre, range.startContainer, range.startOffset);
+      const end   = sel.isCollapsed
+        ? start
+        : domPosToOffset(pre, range.endContainer, range.endOffset);
+      savedCursorRef.current = { start, end };
+    }
+
+    // innerText: <pre> 안의 텍스트를 줄바꿈 포함해 추출
+    const newValue = (pre.innerText ?? "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    setEditValue(newValue);
+    onValueChange?.(newValue);
   }
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    const el     = e.currentTarget;
-    const start  = el.selectionStart;
-    const end    = el.selectionEnd;
+  function handleKeyDown(e: React.KeyboardEvent<HTMLPreElement>) {
+    const pre = preRef.current!;
     const indent = " ".repeat(tabSize);
 
     if (e.key === "Tab") {
       e.preventDefault();
-      const lines     = editValue.split("\n");
-      const startLine = editValue.slice(0, start).split("\n").length - 1;
-      const endLine   = editValue.slice(0, end).split("\n").length - 1;
+      const sel = window.getSelection();
+      if (!sel?.rangeCount) return;
 
-      if (startLine !== endLine) {
+      if (sel.isCollapsed) {
+        // 단일 커서: 공백 삽입
+        document.execCommand("insertText", false, indent);
+      } else {
+        // 다중 라인 선택: 들여쓰기 / 내어쓰기
+        const range      = sel.getRangeAt(0);
+        const start      = domPosToOffset(pre, range.startContainer, range.startOffset);
+        const end        = domPosToOffset(pre, range.endContainer, range.endOffset);
+        const lines      = editValue.split("\n");
+        const startLine  = editValue.slice(0, start).split("\n").length - 1;
+        const endLine    = editValue.slice(0, end).split("\n").length - 1;
+
         let startDelta = 0;
         let totalDelta = 0;
         const newLines = lines.map((line, i) => {
@@ -287,128 +216,184 @@ export function CodeView({
           }
         });
         const next = newLines.join("\n");
+        savedCursorRef.current = {
+          start: Math.max(0, start + startDelta),
+          end:   Math.max(0, end + totalDelta),
+        };
         setEditValue(next);
         onValueChange?.(next);
-        const newStart = Math.max(0, start + startDelta);
-        const newEnd   = Math.max(newStart, end + totalDelta);
-        requestAnimationFrame(() => {
-          if (textareaRef.current) {
-            textareaRef.current.selectionStart = newStart;
-            textareaRef.current.selectionEnd   = newEnd;
-            syncSel();
-          }
-        });
-      } else {
-        const next = editValue.slice(0, start) + indent + editValue.slice(end);
-        setEditValue(next);
-        onValueChange?.(next);
-        requestAnimationFrame(() => {
-          if (textareaRef.current) {
-            textareaRef.current.selectionStart = start + tabSize;
-            textareaRef.current.selectionEnd   = start + tabSize;
-            syncSel();
-          }
-        });
       }
     } else if (e.key === "Enter") {
       e.preventDefault();
-      const currentLine  = editValue.slice(0, start).split("\n").pop() ?? "";
-      const leadingWs    = currentLine.match(/^(\s*)/)?.[1] ?? "";
-      const next         = editValue.slice(0, start) + "\n" + leadingWs + editValue.slice(end);
-      setEditValue(next);
-      onValueChange?.(next);
-      const newCursorPos = start + 1 + leadingWs.length;
-      requestAnimationFrame(() => {
-        if (textareaRef.current) {
-          textareaRef.current.selectionStart = newCursorPos;
-          textareaRef.current.selectionEnd   = newCursorPos;
-          syncSel();
-        }
-      });
+      const sel = window.getSelection();
+      if (!sel?.rangeCount) return;
+      const range  = sel.getRangeAt(0);
+      const cursor = domPosToOffset(pre, range.startContainer, range.startOffset);
+      const before = editValue.slice(0, cursor);
+      const lineIndent = (before.split("\n").pop() ?? "").match(/^(\s*)/)?.[1] ?? "";
+      document.execCommand("insertText", false, "\n" + lineIndent);
     }
   }
 
-  // textarea 스크롤을 외부 컨테이너에 동기화
-  function handleTextareaScroll(e: React.UIEvent<HTMLTextAreaElement>) {
-    if (containerRef.current) {
-      containerRef.current.scrollTop  = e.currentTarget.scrollTop;
-      containerRef.current.scrollLeft = e.currentTarget.scrollLeft;
-    }
+  function handlePaste(e: React.ClipboardEvent<HTMLPreElement>) {
+    e.preventDefault();
+    const text = e.clipboardData.getData("text/plain");
+    if (text) document.execCommand("insertText", false, text);
   }
 
+  // ── 복사 ────────────────────────────────────────────────────────────────────
+  function handleCopy() {
+    navigator.clipboard.writeText(displayCode).then(() => {
+      setCopyState("copied");
+      setTimeout(() => setCopyState("idle"), 2000);
+    });
+  }
+
+  // ── 렌더 ─────────────────────────────────────────────────────────────────────
   return (
     <Highlight
       theme={internalThemes[theme]}
-      code={displayCode.trimEnd()}
+      // 편집 모드: trimEnd 하지 않아 실제 줄 수 유지 / 읽기 모드: 후행 공백 제거
+      code={editable ? displayCode : displayCode.trimEnd()}
       language={language}
     >
       {({ className: hlClassName, style, tokens, getLineProps, getTokenProps }) => {
-        const gutterWidth  = showLineNumbers
+        const resolvedGutterWidth = showLineNumbers
           ? (gutterWidthProp ?? getGutterWidth(tokens.length))
           : "0";
-        const gutterPad    = gutterGapProp ?? "1rem";
-        const textareaLeft = showLineNumbers ? `calc(${gutterWidth} + ${gutterPad})` : "0";
+        const resolvedGutterGap = gutterGapProp ?? "1rem";
 
+        const baseContainerClass = [
+          wordWrap ? "" : "overflow-x-auto",
+          "rounded-lg text-sm",
+          hlClassName,
+          className,
+        ].filter(Boolean).join(" ");
+
+        const baseStyle = {
+          ...style,
+          position:             "relative" as const,
+          fontFamily:           "ui-monospace, 'Cascadia Code', Menlo, monospace",
+          fontVariantLigatures: "none" as const,
+          fontKerning:          "none" as const,
+        };
+
+        const copyBtn = showCopyButton ? (
+          <button
+            onClick={handleCopy}
+            aria-label="코드 복사"
+            style={{
+              position:     "absolute",
+              top:          "0.35rem",
+              right:        "0.35rem",
+              zIndex:       10,
+              padding:      "0.15rem 0.45rem",
+              borderRadius: "0.25rem",
+              border:       "none",
+              cursor:       "pointer",
+              fontFamily:   "ui-sans-serif, system-ui, sans-serif",
+              fontSize:     "0.7rem",
+              lineHeight:   1.4,
+              background:   copyButtonColor[theme].bg,
+              color:        copyButtonColor[theme].text,
+              userSelect:   "none",
+              transition:   "opacity 0.1s",
+            }}
+          >
+            {copyState === "copied" ? "✓ 복사됨" : "복사"}
+          </button>
+        ) : null;
+
+        // ── 편집 모드: <pre contenteditable> ─────────────────────────────────
+        if (editable) {
+          return (
+            <div
+              ref={containerRef}
+              className={baseContainerClass}
+              style={{ ...baseStyle, display: "flex", tabSize }}
+            >
+              {copyBtn}
+
+              {/* 라인 번호 컬럼 */}
+              {showLineNumbers && (
+                <div
+                  aria-hidden="true"
+                  style={{
+                    flexShrink:      0,
+                    width:           resolvedGutterWidth,
+                    paddingRight:    resolvedGutterGap,
+                    boxSizing:       "content-box" as const,
+                    textAlign:       "right" as const,
+                    color:           lineNumberColor[theme],
+                    fontSize:        "0.85em",
+                    lineHeight:      "inherit",
+                    userSelect:      "none" as const,
+                    pointerEvents:   "none" as const,
+                    // 수평 스크롤 시 번호 컬럼이 가려지지 않도록 sticky
+                    position:        "sticky" as const,
+                    left:            0,
+                    zIndex:          1,
+                    backgroundColor: style.backgroundColor as string,
+                  }}
+                >
+                  {tokens.map((_, i) => (
+                    <div key={i}>{i + 1}</div>
+                  ))}
+                </div>
+              )}
+
+              {/* 편집 가능한 코드 영역 */}
+              <pre
+                ref={preRef}
+                contentEditable
+                suppressContentEditableWarning
+                spellCheck={false}
+                onInput={handleInput}
+                onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
+                style={{
+                  flex:       1,
+                  margin:     0,
+                  padding:    0,
+                  outline:    "none",
+                  whiteSpace: wordWrap ? "pre-wrap" : "pre",
+                  wordBreak:  wordWrap ? "break-all" : "normal",
+                  background: "transparent",
+                  color:      "inherit",
+                  fontFamily: "inherit",
+                  fontSize:   "inherit",
+                  lineHeight: "inherit",
+                  tabSize,
+                  // Prism theme의 overflow 설정을 무력화
+                  overflow:   "visible",
+                }}
+              >
+                {tokens.map((line, li) => (
+                  <Fragment key={li}>
+                    {li > 0 && "\n"}
+                    {line.map((token, ti) => {
+                      const { className: tc, style: ts } = getTokenProps({ token });
+                      return (
+                        <span key={ti} className={tc} style={ts}>
+                          {token.content}
+                        </span>
+                      );
+                    })}
+                  </Fragment>
+                ))}
+              </pre>
+            </div>
+          );
+        }
+
+        // ── 읽기 모드: 현재 구조 유지 ────────────────────────────────────────
         return (
           <div
             ref={containerRef}
-            className={[wordWrap ? "" : "overflow-x-auto", "rounded-lg text-sm", hlClassName, className]
-              .filter(Boolean)
-              .join(" ")}
-            style={{
-              ...style,
-              tabSize,
-              position:            "relative",
-              fontFamily:          "ui-monospace, 'Cascadia Code', Menlo, monospace",
-              fontVariantLigatures: "none",
-              fontKerning:         "none",
-            }}
+            className={baseContainerClass}
+            style={{ ...baseStyle, tabSize }}
           >
-            {/* 문자폭 측정용 hidden span — editable 모드에서만 사용 */}
-            {editable && (
-              <span
-                ref={charMeasureRef}
-                aria-hidden="true"
-                style={{
-                  position:   "absolute",
-                  top:        0,
-                  left:       0,
-                  visibility: "hidden",
-                  pointerEvents: "none",
-                  whiteSpace: "pre",
-                  userSelect: "none",
-                }}
-              >
-                {"M"}
-              </span>
-            )}
-
-            {/* 복사 버튼 */}
-            {showCopyButton && (
-              <button
-                onClick={handleCopy}
-                aria-label="코드 복사"
-                style={{
-                  position:     "absolute",
-                  top:          "0.35rem",
-                  right:        "0.35rem",
-                  zIndex:       10,
-                  padding:      "0.15rem 0.45rem",
-                  borderRadius: "0.25rem",
-                  border:       "none",
-                  cursor:       "pointer",
-                  fontFamily:   "ui-sans-serif, system-ui, sans-serif",
-                  fontSize:     "0.7rem",
-                  lineHeight:   1.4,
-                  background:   copyButtonColor[theme].bg,
-                  color:        copyButtonColor[theme].text,
-                  userSelect:   "none",
-                  transition:   "opacity 0.1s",
-                }}
-              >
-                {copyState === "copied" ? "✓ 복사됨" : "복사"}
-              </button>
-            )}
+            {copyBtn}
 
             <pre style={{
               overflow:   "visible",
@@ -422,18 +407,15 @@ export function CodeView({
                   const { className: lineClassName, style: lineStyle, ...lineRest } = getLineProps({ line });
                   const isOdd         = lineIndex % 2 !== 0;
                   const isHighlighted = highlightLines?.includes(lineIndex + 1) ?? false;
-
                   const rowBg = isHighlighted
                     ? highlightRowColor[theme]
                     : showAlternatingRows && isOdd
-                      ? (editable && isFocused ? alternatingRowEditColor[theme] : alternatingRowColor[theme])
+                      ? alternatingRowColor[theme]
                       : undefined;
 
                   return (
                     <div
                       key={lineIndex}
-                      // 첫 번째 줄에만 측정용 data attribute 부착
-                      {...(lineIndex === 0 ? { "data-cv-line": "" } : {})}
                       className={["flex", lineClassName].filter(Boolean).join(" ")}
                       style={{ ...lineStyle }}
                       {...lineRest}
@@ -441,13 +423,12 @@ export function CodeView({
                       {showLineNumbers && (
                         <span
                           aria-hidden="true"
-                          {...(lineIndex === 0 ? { "data-cv-gutter": "" } : {})}
                           style={{
-                            minWidth:     gutterWidth,
-                            paddingRight: gutterPad,
-                            boxSizing:    "content-box",
-                            textAlign:    "right",
-                            userSelect:   "none",
+                            minWidth:     resolvedGutterWidth,
+                            paddingRight: resolvedGutterGap,
+                            boxSizing:    "content-box" as const,
+                            textAlign:    "right" as const,
+                            userSelect:   "none" as const,
                             color:        lineNumberColor[theme],
                             flexShrink:   0,
                             fontSize:     "0.85em",
@@ -456,12 +437,7 @@ export function CodeView({
                           {lineIndex + 1}
                         </span>
                       )}
-                      <span
-                        style={{
-                          flex: 1,
-                          ...(rowBg ? { backgroundColor: rowBg } : {}),
-                        }}
-                      >
+                      <span style={{ flex: 1, ...(rowBg ? { backgroundColor: rowBg } : {}) }}>
                         {line.map((token, tokenIndex) => {
                           const { children: tokenContent, ...tokenSpanProps } = getTokenProps({ token });
                           return (
@@ -478,50 +454,6 @@ export function CodeView({
                 })}
               </code>
             </pre>
-
-            {/* 커서/선택 오버레이 — 측정된 charWidth 기반 픽셀 정밀 배치 */}
-            {renderCursorOverlay()}
-
-            {editable && (
-              <textarea
-                ref={textareaRef}
-                className="plastic-cv-ta"
-                value={editValue}
-                onChange={handleChange}
-                onKeyDown={handleKeyDown}
-                onFocus={() => { setIsFocused(true); syncSel(); }}
-                onBlur={() => setIsFocused(false)}
-                onSelect={syncSel}
-                onKeyUp={syncSel}
-                onMouseUp={syncSel}
-                onScroll={handleTextareaScroll}
-                aria-label="code editor"
-                spellCheck={false}
-                autoComplete="off"
-                autoCorrect="off"
-                autoCapitalize="off"
-                style={{
-                  position:     "absolute",
-                  inset:        0,
-                  padding:      0,
-                  paddingLeft:  textareaLeft,
-                  background:   "transparent",
-                  color:        "transparent",
-                  caretColor:   "transparent",   // native 커서 제거 — 오버레이로 대체
-                  resize:       "none",
-                  border:       "none",
-                  outline:      "none",
-                  fontFamily:   "inherit",
-                  fontSize:     "inherit",
-                  lineHeight:   "inherit",
-                  overflow:     "hidden",
-                  whiteSpace:   wordWrap ? "pre-wrap" : "pre",
-                  wordBreak:    wordWrap ? "break-all" : "normal",
-                  overflowWrap: wordWrap ? "break-word" : "normal",
-                  tabSize,
-                }}
-              />
-            )}
           </div>
         );
       }}

--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -103,12 +103,28 @@ export function CodeView({
 }: CodeViewProps) {
   const [editValue, setEditValue] = useState(code);
   const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+  const [lineHeightPx, setLineHeightPx] = useState(0);
 
   const prevCodeRef    = useRef(code);
   const preRef         = useRef<HTMLPreElement>(null);
   const containerRef   = useRef<HTMLDivElement>(null);
   // 렌더 후 커서를 복원할 때 사용하는 선형 오프셋 저장소
-  const savedCursorRef = useRef<{ start: number; end: number } | null>(null);
+  const savedCursorRef  = useRef<{ start: number; end: number } | null>(null);
+  // IME 조합(한글 등) 중에는 React 재렌더를 막아 조합이 깨지지 않도록 함
+  const isComposingRef  = useRef(false);
+
+  // 편집 모드 라인 높이 측정 (alternatingRows / highlightLines 오버레이용)
+  useLayoutEffect(() => {
+    if (!editable || !preRef.current) return;
+    const measure = () => {
+      const lh = parseFloat(getComputedStyle(preRef.current!).lineHeight);
+      if (lh > 0) setLineHeightPx(lh);
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(preRef.current);
+    return () => ro.disconnect();
+  }, [editable]);
 
   // code prop 변경 시 내부 상태 동기화
   useEffect(() => {
@@ -158,6 +174,9 @@ export function CodeView({
   function handleInput() {
     const pre = preRef.current;
     if (!pre) return;
+    // IME 조합 중(isComposing)에는 중간 문자를 state에 반영하지 않는다.
+    // compositionend 이후 최종 문자가 확정되면 정상 처리된다.
+    if (isComposingRef.current) return;
 
     // 상태 업데이트 전에 커서 오프셋을 저장 (브라우저가 수정한 DOM 기준)
     const sel = window.getSelection();
@@ -342,12 +361,57 @@ export function CodeView({
                 </div>
               )}
 
+              {/* 라인 배경 오버레이 (alternatingRows / highlightLines) */}
+              {lineHeightPx > 0 && (showAlternatingRows || (highlightLines && highlightLines.length > 0)) && (
+                <div
+                  aria-hidden="true"
+                  style={{
+                    position:      "absolute",
+                    // gutter 너비만큼 오른쪽부터 시작
+                    left:          showLineNumbers ? `calc(${resolvedGutterWidth} + ${resolvedGutterGap} + ${resolvedGutterGap})` : 0,
+                    right:         0,
+                    top:           0,
+                    pointerEvents: "none",
+                    zIndex:        0,
+                  }}
+                >
+                  {tokens.map((_, i) => {
+                    const isOdd         = i % 2 !== 0;
+                    const isHighlighted = highlightLines?.includes(i + 1) ?? false;
+                    const bg = isHighlighted
+                      ? highlightRowColor[theme]
+                      : showAlternatingRows && isOdd
+                        ? alternatingRowColor[theme]
+                        : undefined;
+                    return bg ? (
+                      <div
+                        key={i}
+                        style={{
+                          position: "absolute",
+                          top:      i * lineHeightPx,
+                          left:     0,
+                          right:    0,
+                          height:   lineHeightPx,
+                          backgroundColor: bg,
+                        }}
+                      />
+                    ) : null;
+                  })}
+                </div>
+              )}
+
               {/* 편집 가능한 코드 영역 */}
               <pre
                 ref={preRef}
                 contentEditable
                 suppressContentEditableWarning
                 spellCheck={false}
+                onCompositionStart={() => { isComposingRef.current = true; }}
+                onCompositionEnd={() => {
+                  isComposingRef.current = false;
+                  // 조합 완료 후 확정된 텍스트를 state에 반영
+                  handleInput();
+                }}
                 onInput={handleInput}
                 onKeyDown={handleKeyDown}
                 onPaste={handlePaste}

--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
 import { Highlight, themes } from "prism-react-renderer";
 import type { CodeViewProps } from "./CodeView.types";
 import { renderWithInvisibles } from "./CodeView.invisibles";
@@ -37,6 +37,11 @@ const caretColor = {
   dark: "rgba(255,255,255,0.85)",
 } as const;
 
+const selectionColor = {
+  light: "rgba(59,130,246,0.25)",
+  dark: "rgba(96,165,250,0.30)",
+} as const;
+
 const copyButtonColor = {
   light: { bg: "rgba(0,0,0,0.06)", text: "rgba(0,0,0,0.45)" },
   dark:  { bg: "rgba(255,255,255,0.08)", text: "rgba(255,255,255,0.45)" },
@@ -49,6 +54,37 @@ function getGutterWidth(lineCount: number): string {
   if (lineCount < 1000) return "2.75rem";
   return "3.5rem";
 }
+
+// ── 커서/선택 계산 헬퍼 (순수 함수) ─────────────────────────────────────────
+
+/** 문자열 offset → {row, col} */
+function offsetToPos(text: string, offset: number): { row: number; col: number } {
+  const before = text.slice(0, Math.min(offset, text.length));
+  const lines = before.split("\n");
+  return { row: lines.length - 1, col: (lines[lines.length - 1] ?? "").length };
+}
+
+/**
+ * col 인덱스 → 실제 픽셀 X (탭 너비 반영).
+ * CSS tab-size와 동일한 로직: 현재 컬럼에서 다음 tabSize 배수 스톱으로 이동.
+ */
+function colToX(lineText: string, col: number, charWidth: number, tabSz: number): number {
+  let x = 0;
+  const limit = Math.min(col, lineText.length);
+  for (let i = 0; i < limit; i++) {
+    if (lineText[i] === "\t") {
+      const currentCol = Math.round(x / charWidth);
+      const nextStop   = Math.ceil((currentCol + 1) / tabSz) * tabSz;
+      x = nextStop * charWidth;
+    } else {
+      x += charWidth;
+    }
+  }
+  if (col > lineText.length) x += (col - lineText.length) * charWidth;
+  return x;
+}
+
+// ── 컴포넌트 ──────────────────────────────────────────────────────────────────
 
 export function CodeView({
   code,
@@ -67,14 +103,23 @@ export function CodeView({
   showCopyButton = true,
   className = "",
 }: CodeViewProps) {
-  const [editValue, setEditValue]     = useState(code);
-  const [isFocused, setIsFocused]     = useState(false);
-  const [copyState, setCopyState]     = useState<"idle" | "copied">("idle");
+  const [editValue, setEditValue] = useState(code);
+  const [isFocused, setIsFocused] = useState(false);
+  const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+
+  // 커서/선택 추적
+  const [selInfo, setSelInfo] = useState({ start: 0, end: 0 });
+
+  // 문자 측정값 — charWidth: 1글자 픽셀 너비, lineHeight: 1줄 픽셀 높이,
+  //               gutterPixels: gutter 전체 픽셀 너비 (minWidth + paddingRight)
+  const [metrics, setMetrics] = useState({ charWidth: 0, lineHeight: 0, gutterPixels: 0 });
+
   const prevCodeRef   = useRef(code);
   const textareaRef   = useRef<HTMLTextAreaElement>(null);
   const containerRef  = useRef<HTMLDivElement>(null);
+  const charMeasureRef = useRef<HTMLSpanElement>(null); // 문자폭 측정용 hidden span
 
-  // code prop 변경 시 내부 상태 동기화 (외부에서 코드를 교체하는 경우)
+  // code prop 변경 시 내부 상태 동기화
   useEffect(() => {
     if (code !== prevCodeRef.current) {
       prevCodeRef.current = code;
@@ -82,9 +127,119 @@ export function CodeView({
     }
   }, [code]);
 
+  // ── 커서/선택 스타일 & 애니메이션 CSS 전역 1회 주입 ─────────────────────────
+  useLayoutEffect(() => {
+    if (!editable || typeof document === "undefined") return;
+    const id = "plastic-cv-style";
+    if (document.getElementById(id)) return;
+    const el = document.createElement("style");
+    el.id = id;
+    el.textContent = [
+      // 커서 깜박임
+      "@keyframes plastic-cv-blink{0%,100%{opacity:1}50%{opacity:0}}",
+      // textarea native 선택 영역 숨기기 (커스텀 overlay로 대체)
+      ".plastic-cv-ta::selection{background:transparent!important}",
+    ].join("");
+    document.head.appendChild(el);
+  }, [editable]);
+
+  // ── 문자 측정 (editable 전용) ────────────────────────────────────────────────
+  useLayoutEffect(() => {
+    if (!editable || !containerRef.current) return;
+
+    const doMeasure = () => {
+      const charEl   = charMeasureRef.current;
+      const lineEl   = containerRef.current?.querySelector<HTMLElement>("[data-cv-line]");
+      const gutterEl = containerRef.current?.querySelector<HTMLElement>("[data-cv-gutter]");
+      if (!charEl) return;
+
+      const cw = charEl.getBoundingClientRect().width;
+      const lh = lineEl   ? lineEl.getBoundingClientRect().height   : 0;
+      const gp = gutterEl ? gutterEl.getBoundingClientRect().width  : 0;
+
+      if (cw > 0) setMetrics({ charWidth: cw, lineHeight: lh, gutterPixels: gp });
+    };
+
+    doMeasure();
+
+    // 컨테이너 크기 변경 시 재측정 (폰트 크기 변경 대응)
+    const ro = new ResizeObserver(doMeasure);
+    ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, [editable, showLineNumbers, gutterWidthProp, gutterGapProp, tabSize]);
+
+  // ── 선택 영역 동기화 ──────────────────────────────────────────────────────────
+  const syncSel = useCallback(() => {
+    const ta = textareaRef.current;
+    if (ta) setSelInfo({ start: ta.selectionStart, end: ta.selectionEnd });
+  }, []);
+
   const displayCode = editable ? editValue : code;
 
-  // ── 복사 ────────────────────────────────────────────────────────────────
+  // ── 커서/선택 오버레이 렌더링 ─────────────────────────────────────────────────
+  function renderCursorOverlay() {
+    const { charWidth, lineHeight, gutterPixels } = metrics;
+    if (!editable || charWidth === 0 || lineHeight === 0) return null;
+
+    const codeLines  = editValue.split("\n");
+    const startPos   = offsetToPos(editValue, selInfo.start);
+    const endPos     = offsetToPos(editValue, selInfo.end);
+    const isCursor   = selInfo.start === selInfo.end;
+
+    if (isCursor) {
+      if (!isFocused) return null;
+      const x = gutterPixels + colToX(codeLines[startPos.row] ?? "", startPos.col, charWidth, tabSize);
+      const y = startPos.row * lineHeight;
+      return (
+        <div style={{ position: "absolute", inset: 0, pointerEvents: "none", overflow: "hidden" }}>
+          <div style={{
+            position:        "absolute",
+            left:            x,
+            top:             y,
+            width:           2,
+            height:          lineHeight,
+            backgroundColor: caretColor[theme],
+            animation:       "plastic-cv-blink 1.2s step-end infinite",
+          }} />
+        </div>
+      );
+    }
+
+    // 선택 영역 — 라인별 rect 계산
+    const rects: Array<{ row: number; x1: number; x2: number }> = [];
+    for (let row = startPos.row; row <= endPos.row; row++) {
+      const lineText  = codeLines[row] ?? "";
+      // 줄 끝 너비: 마지막 문자 오른쪽 + 1ch (EOL 포함)
+      const lineEndX  = colToX(lineText, lineText.length, charWidth, tabSize) + charWidth;
+      const x1 = row === startPos.row
+        ? colToX(lineText, startPos.col, charWidth, tabSize)
+        : 0;
+      const x2 = row === endPos.row
+        ? colToX(lineText, endPos.col, charWidth, tabSize)
+        : lineEndX;
+      rects.push({ row, x1, x2 });
+    }
+
+    return (
+      <div style={{ position: "absolute", inset: 0, pointerEvents: "none", overflow: "hidden" }}>
+        {rects.map((rect, i) => (
+          <div
+            key={i}
+            style={{
+              position:        "absolute",
+              left:            gutterPixels + rect.x1,
+              top:             rect.row * lineHeight,
+              width:           Math.max(0, rect.x2 - rect.x1),
+              height:          lineHeight,
+              backgroundColor: selectionColor[theme],
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  // ── 복사 ────────────────────────────────────────────────────────────────────
   function handleCopy() {
     navigator.clipboard.writeText(displayCode).then(() => {
       setCopyState("copied");
@@ -92,17 +247,18 @@ export function CodeView({
     });
   }
 
-  // ── 편집 이벤트 ──────────────────────────────────────────────────────────
+  // ── 편집 이벤트 ──────────────────────────────────────────────────────────────
   function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
     const next = e.target.value;
     setEditValue(next);
     onValueChange?.(next);
+    syncSel();
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    const el    = e.currentTarget;
-    const start = el.selectionStart;
-    const end   = el.selectionEnd;
+    const el     = e.currentTarget;
+    const start  = el.selectionStart;
+    const end    = el.selectionEnd;
     const indent = " ".repeat(tabSize);
 
     if (e.key === "Tab") {
@@ -112,7 +268,6 @@ export function CodeView({
       const endLine   = editValue.slice(0, end).split("\n").length - 1;
 
       if (startLine !== endLine) {
-        // 다중 라인 선택 — 각 줄 들여쓰기/내어쓰기
         let startDelta = 0;
         let totalDelta = 0;
         const newLines = lines.map((line, i) => {
@@ -140,10 +295,10 @@ export function CodeView({
           if (textareaRef.current) {
             textareaRef.current.selectionStart = newStart;
             textareaRef.current.selectionEnd   = newEnd;
+            syncSel();
           }
         });
       } else {
-        // 단일 커서 — 커서 위치에 indent 삽입
         const next = editValue.slice(0, start) + indent + editValue.slice(end);
         setEditValue(next);
         onValueChange?.(next);
@@ -151,15 +306,15 @@ export function CodeView({
           if (textareaRef.current) {
             textareaRef.current.selectionStart = start + tabSize;
             textareaRef.current.selectionEnd   = start + tabSize;
+            syncSel();
           }
         });
       }
     } else if (e.key === "Enter") {
-      // 자동 들여쓰기 — 현재 라인의 leading whitespace 유지
       e.preventDefault();
-      const currentLine     = editValue.slice(0, start).split("\n").pop() ?? "";
-      const leadingWs       = currentLine.match(/^(\s*)/)?.[1] ?? "";
-      const next            = editValue.slice(0, start) + "\n" + leadingWs + editValue.slice(end);
+      const currentLine  = editValue.slice(0, start).split("\n").pop() ?? "";
+      const leadingWs    = currentLine.match(/^(\s*)/)?.[1] ?? "";
+      const next         = editValue.slice(0, start) + "\n" + leadingWs + editValue.slice(end);
       setEditValue(next);
       onValueChange?.(next);
       const newCursorPos = start + 1 + leadingWs.length;
@@ -167,12 +322,13 @@ export function CodeView({
         if (textareaRef.current) {
           textareaRef.current.selectionStart = newCursorPos;
           textareaRef.current.selectionEnd   = newCursorPos;
+          syncSel();
         }
       });
     }
   }
 
-  // textarea 내부 스크롤을 외부 컨테이너에 동기화
+  // textarea 스크롤을 외부 컨테이너에 동기화
   function handleTextareaScroll(e: React.UIEvent<HTMLTextAreaElement>) {
     if (containerRef.current) {
       containerRef.current.scrollTop  = e.currentTarget.scrollTop;
@@ -194,44 +350,77 @@ export function CodeView({
         const textareaLeft = showLineNumbers ? `calc(${gutterWidth} + ${gutterPad})` : "0";
 
         return (
-          // 외부 div가 scroll 컨테이너 & position 기준점 역할
           <div
             ref={containerRef}
             className={[wordWrap ? "" : "overflow-x-auto", "rounded-lg text-sm", hlClassName, className]
               .filter(Boolean)
               .join(" ")}
-            style={{ ...style, tabSize, position: "relative", fontFamily: "ui-monospace, 'Cascadia Code', Menlo, monospace", fontVariantLigatures: "none", fontKerning: "none" }}
+            style={{
+              ...style,
+              tabSize,
+              position:            "relative",
+              fontFamily:          "ui-monospace, 'Cascadia Code', Menlo, monospace",
+              fontVariantLigatures: "none",
+              fontKerning:         "none",
+            }}
           >
-            {/* 복사 버튼 */}
-            {showCopyButton && <button
-              onClick={handleCopy}
-              aria-label="코드 복사"
-              style={{
-                position:   "absolute",
-                top:        "0.35rem",
-                right:      "0.35rem",
-                zIndex:     10,
-                padding:    "0.15rem 0.45rem",
-                borderRadius: "0.25rem",
-                border:     "none",
-                cursor:     "pointer",
-                fontFamily: "ui-sans-serif, system-ui, sans-serif",
-                fontSize:   "0.7rem",
-                lineHeight: 1.4,
-                background: copyButtonColor[theme].bg,
-                color:      copyButtonColor[theme].text,
-                userSelect: "none",
-                transition: "opacity 0.1s",
-              }}
-            >
-              {copyState === "copied" ? "✓ 복사됨" : "복사"}
-            </button>}
+            {/* 문자폭 측정용 hidden span — editable 모드에서만 사용 */}
+            {editable && (
+              <span
+                ref={charMeasureRef}
+                aria-hidden="true"
+                style={{
+                  position:   "absolute",
+                  top:        0,
+                  left:       0,
+                  visibility: "hidden",
+                  pointerEvents: "none",
+                  whiteSpace: "pre",
+                  userSelect: "none",
+                }}
+              >
+                {"M"}
+              </span>
+            )}
 
-            <pre style={{ overflow: "visible", margin: 0, padding: 0, whiteSpace: wordWrap ? "pre-wrap" : "pre", wordBreak: wordWrap ? "break-all" : "normal" }}>
+            {/* 복사 버튼 */}
+            {showCopyButton && (
+              <button
+                onClick={handleCopy}
+                aria-label="코드 복사"
+                style={{
+                  position:     "absolute",
+                  top:          "0.35rem",
+                  right:        "0.35rem",
+                  zIndex:       10,
+                  padding:      "0.15rem 0.45rem",
+                  borderRadius: "0.25rem",
+                  border:       "none",
+                  cursor:       "pointer",
+                  fontFamily:   "ui-sans-serif, system-ui, sans-serif",
+                  fontSize:     "0.7rem",
+                  lineHeight:   1.4,
+                  background:   copyButtonColor[theme].bg,
+                  color:        copyButtonColor[theme].text,
+                  userSelect:   "none",
+                  transition:   "opacity 0.1s",
+                }}
+              >
+                {copyState === "copied" ? "✓ 복사됨" : "복사"}
+              </button>
+            )}
+
+            <pre style={{
+              overflow:   "visible",
+              margin:     0,
+              padding:    0,
+              whiteSpace: wordWrap ? "pre-wrap" : "pre",
+              wordBreak:  wordWrap ? "break-all" : "normal",
+            }}>
               <code style={{ display: "block" }}>
                 {tokens.map((line, lineIndex) => {
                   const { className: lineClassName, style: lineStyle, ...lineRest } = getLineProps({ line });
-                  const isOdd        = lineIndex % 2 !== 0;
+                  const isOdd         = lineIndex % 2 !== 0;
                   const isHighlighted = highlightLines?.includes(lineIndex + 1) ?? false;
 
                   const rowBg = isHighlighted
@@ -243,6 +432,8 @@ export function CodeView({
                   return (
                     <div
                       key={lineIndex}
+                      // 첫 번째 줄에만 측정용 data attribute 부착
+                      {...(lineIndex === 0 ? { "data-cv-line": "" } : {})}
                       className={["flex", lineClassName].filter(Boolean).join(" ")}
                       style={{ ...lineStyle }}
                       {...lineRest}
@@ -250,15 +441,16 @@ export function CodeView({
                       {showLineNumbers && (
                         <span
                           aria-hidden="true"
+                          {...(lineIndex === 0 ? { "data-cv-gutter": "" } : {})}
                           style={{
-                            minWidth:    gutterWidth,
+                            minWidth:     gutterWidth,
                             paddingRight: gutterPad,
-                            boxSizing:   "content-box",
-                            textAlign:   "right",
-                            userSelect:  "none",
-                            color:       lineNumberColor[theme],
-                            flexShrink:  0,
-                            fontSize:    "0.85em",
+                            boxSizing:    "content-box",
+                            textAlign:    "right",
+                            userSelect:   "none",
+                            color:        lineNumberColor[theme],
+                            flexShrink:   0,
+                            fontSize:     "0.85em",
                           }}
                         >
                           {lineIndex + 1}
@@ -287,14 +479,21 @@ export function CodeView({
               </code>
             </pre>
 
+            {/* 커서/선택 오버레이 — 측정된 charWidth 기반 픽셀 정밀 배치 */}
+            {renderCursorOverlay()}
+
             {editable && (
               <textarea
                 ref={textareaRef}
+                className="plastic-cv-ta"
                 value={editValue}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
-                onFocus={() => setIsFocused(true)}
+                onFocus={() => { setIsFocused(true); syncSel(); }}
                 onBlur={() => setIsFocused(false)}
+                onSelect={syncSel}
+                onKeyUp={syncSel}
+                onMouseUp={syncSel}
                 onScroll={handleTextareaScroll}
                 aria-label="code editor"
                 spellCheck={false}
@@ -302,23 +501,23 @@ export function CodeView({
                 autoCorrect="off"
                 autoCapitalize="off"
                 style={{
-                  position:      "absolute",
-                  inset:         0,
-                  padding:       0,
-                  paddingLeft:   textareaLeft,
-                  background:    "transparent",
-                  color:         "transparent",
-                  caretColor:    caretColor[theme],
-                  resize:        "none",
-                  border:        "none",
-                  outline:       "none",
-                  fontFamily:    "inherit",
-                  fontSize:      "inherit",
-                  lineHeight:    "inherit",
-                  overflow:      "hidden",
-                  whiteSpace:    wordWrap ? "pre-wrap" : "pre",
-                  wordBreak:     wordWrap ? "break-all" : "normal",
-                  overflowWrap:  wordWrap ? "break-word" : "normal",
+                  position:     "absolute",
+                  inset:        0,
+                  padding:      0,
+                  paddingLeft:  textareaLeft,
+                  background:   "transparent",
+                  color:        "transparent",
+                  caretColor:   "transparent",   // native 커서 제거 — 오버레이로 대체
+                  resize:       "none",
+                  border:       "none",
+                  outline:      "none",
+                  fontFamily:   "inherit",
+                  fontSize:     "inherit",
+                  lineHeight:   "inherit",
+                  overflow:     "hidden",
+                  whiteSpace:   wordWrap ? "pre-wrap" : "pre",
+                  wordBreak:    wordWrap ? "break-all" : "normal",
+                  overflowWrap: wordWrap ? "break-word" : "normal",
                   tabSize,
                 }}
               />

--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -64,6 +64,7 @@ export function CodeView({
   wordWrap = false,
   gutterWidth: gutterWidthProp,
   gutterGap: gutterGapProp,
+  showCopyButton = true,
   className = "",
 }: CodeViewProps) {
   const [editValue, setEditValue]     = useState(code);
@@ -202,7 +203,7 @@ export function CodeView({
             style={{ ...style, tabSize, position: "relative", fontFamily: "ui-monospace, 'Cascadia Code', Menlo, monospace", fontVariantLigatures: "none", fontKerning: "none" }}
           >
             {/* 복사 버튼 */}
-            <button
+            {showCopyButton && <button
               onClick={handleCopy}
               aria-label="코드 복사"
               style={{
@@ -224,10 +225,10 @@ export function CodeView({
               }}
             >
               {copyState === "copied" ? "✓ 복사됨" : "복사"}
-            </button>
+            </button>}
 
             <pre style={{ overflow: "visible", margin: 0, padding: 0, whiteSpace: wordWrap ? "pre-wrap" : "pre", wordBreak: wordWrap ? "break-all" : "normal" }}>
-              <code>
+              <code style={{ display: "block" }}>
                 {tokens.map((line, lineIndex) => {
                   const { className: lineClassName, style: lineStyle, ...lineRest } = getLineProps({ line });
                   const isOdd        = lineIndex % 2 !== 0;

--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -40,46 +40,131 @@ function getGutterWidth(lineCount: number): string {
 // ── contenteditable 커서 헬퍼 ─────────────────────────────────────────────────
 
 /**
- * (targetNode, targetOffset) → root 내 선형 문자 오프셋.
- * root 아래의 텍스트 노드를 순서대로 순회하여 누적 길이를 반환한다.
+ * "유효 콘텐츠 노드" 목록을 반환한다.
+ *
+ * - text  : <pre> 아래의 일반 텍스트 노드 (칩 내부 텍스트는 제외)
+ * - chip  : data-char 속성이 있는 요소 (탭·공백·니모닉 칩).
+ *           브라우저는 contentEditable=false 칩을 1개의 커서 단위로 처리하고,
+ *           칩 내부 텍스트를 커서/선택 계산에 포함하지 않는다.
+ *           parent + indexInParent 를 함께 저장하여 element-based 커서 위치를 처리한다.
+ */
+type EffectiveNode =
+  | { type: "text"; node: Text }
+  | { type: "chip"; element: Element; parent: Element; indexInParent: number };
+
+function walkEffectiveNodes(root: Element): EffectiveNode[] {
+  const result: EffectiveNode[] = [];
+
+  function walk(node: Node, parent: Element): void {
+    if (node.nodeType === Node.TEXT_NODE) {
+      result.push({ type: "text", node: node as Text });
+      return;
+    }
+    const el = node as Element;
+    if (el.hasAttribute("data-char")) {
+      // 칩 요소: 1 문자로 계산하고 내부 텍스트는 순회하지 않는다
+      const siblings = Array.from(parent.childNodes);
+      result.push({
+        type: "chip",
+        element: el,
+        parent,
+        indexInParent: siblings.indexOf(el as ChildNode),
+      });
+      return;
+    }
+    for (const child of Array.from(el.childNodes)) walk(child, el);
+  }
+
+  for (const child of Array.from(root.childNodes)) walk(child, root);
+  return result;
+}
+
+/**
+ * (container, offset) → editValue 내 선형 문자 오프셋.
+ *
+ * container가 텍스트 노드인 경우: 일반 텍스트 오프셋.
+ * container가 요소인 경우: 칩 인접 위치 (contentEditable=false 처리).
  */
 function domPosToOffset(
   root: Element,
-  targetNode: Node,
-  targetOffset: number
+  container: Node,
+  offset: number,
 ): number {
+  const nodes = walkEffectiveNodes(root);
   let count = 0;
-  const iter = document.createNodeIterator(root, NodeFilter.SHOW_TEXT);
-  let n: Node | null;
-  while ((n = iter.nextNode())) {
-    if (n === targetNode) return count + targetOffset;
-    count += (n as Text).length;
+
+  for (const item of nodes) {
+    if (item.type === "text") {
+      if (item.node === container) return count + offset;
+      count += item.node.length;
+    } else {
+      // 커서가 칩의 부모 요소 안에서 child index 로 표현된 경우
+      if (
+        container.nodeType === Node.ELEMENT_NODE &&
+        (container as Element) === item.parent
+      ) {
+        if (offset === item.indexInParent)     return count;      // 칩 바로 앞
+        if (offset === item.indexInParent + 1) return count + 1;  // 칩 바로 뒤
+      }
+      count += 1;
+    }
   }
   return count;
 }
 
 /**
- * 선형 문자 오프셋 → root 내 { node, offset }.
- * 오프셋이 텍스트 범위를 벗어나면 마지막 노드의 끝을 반환한다.
+ * editValue 내 선형 문자 오프셋 → (node, offset) DOM 위치.
+ *
+ * 칩 앞/뒤는 parent 요소의 child index 로 표현한다.
  */
 function offsetToDomPos(
   root: Element,
-  charOffset: number
+  charOffset: number,
 ): { node: Node; offset: number } | null {
+  const nodes = walkEffectiveNodes(root);
   let remaining = charOffset;
-  const iter = document.createNodeIterator(root, NodeFilter.SHOW_TEXT);
-  let n: Node | null;
-  let lastNode: Node | null = null;
-  let lastLen = 0;
-  while ((n = iter.nextNode())) {
-    const len = (n as Text).length;
-    if (remaining <= len) return { node: n, offset: remaining };
-    remaining -= len;
-    lastNode = n;
-    lastLen = len;
+
+  for (const item of nodes) {
+    if (item.type === "text") {
+      if (remaining <= item.node.length) return { node: item.node, offset: remaining };
+      remaining -= item.node.length;
+    } else {
+      if (remaining === 0) {
+        // 칩 바로 앞: parent 요소에서 칩의 child index
+        return { node: item.parent, offset: item.indexInParent };
+      }
+      remaining -= 1;
+      // remaining이 0이 되면 다음 반복에서 "다음 노드의 앞" 위치로 자연스럽게 처리됨
+    }
   }
-  if (lastNode) return { node: lastNode, offset: lastLen };
+
+  // 범위 초과: 마지막 유효 노드 끝
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const last = nodes[i];
+    if (!last) continue;
+    if (last.type === "text")
+      return { node: last.node, offset: last.node.length };
+    if (last.type === "chip")
+      return { node: last.parent, offset: last.indexInParent + 1 };
+  }
   return null;
+}
+
+/**
+ * <pre contenteditable> DOM에서 실제 코드 문자열을 추출한다.
+ * 일반 텍스트 노드의 텍스트 + 칩의 data-char 값을 순서대로 결합한다.
+ * (pre.innerText는 칩의 니모닉 텍스트 "NUL" 등을 반환하므로 사용 불가)
+ */
+function extractCodeFromPre(pre: HTMLPreElement): string {
+  let result = "";
+  for (const item of walkEffectiveNodes(pre)) {
+    if (item.type === "text") {
+      result += item.node.data;
+    } else {
+      result += item.element.getAttribute("data-char") ?? "";
+    }
+  }
+  return result.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
 // ── 컴포넌트 ──────────────────────────────────────────────────────────────────
@@ -189,8 +274,9 @@ export function CodeView({
       savedCursorRef.current = { start, end };
     }
 
-    // innerText: <pre> 안의 텍스트를 줄바꿈 포함해 추출
-    const newValue = (pre.innerText ?? "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    // extractCodeFromPre: 일반 텍스트 + 칩의 data-char 를 결합하여 실제 코드 추출
+    // (pre.innerText 는 칩의 니모닉 텍스트 "NUL" 등을 포함하므로 사용 불가)
+    const newValue = extractCodeFromPre(pre);
     setEditValue(newValue);
     onValueChange?.(newValue);
   }
@@ -439,7 +525,9 @@ export function CodeView({
                       const { className: tc, style: ts } = getTokenProps({ token });
                       return (
                         <span key={ti} className={tc} style={ts}>
-                          {token.content}
+                          {showInvisibles
+                            ? renderWithInvisibles(token.content, theme, tabSize, true)
+                            : token.content}
                         </span>
                       );
                     })}

--- a/src/components/CodeView/CodeView.types.ts
+++ b/src/components/CodeView/CodeView.types.ts
@@ -31,5 +31,7 @@ export interface CodeViewProps {
   gutterWidth?: string;
   /** 라인번호와 코드 내용 사이 간격 (기본값: "1rem") */
   gutterGap?: string;
+  /** 복사 버튼 표시 여부 (기본값: true) */
+  showCopyButton?: boolean;
   className?: string;
 }


### PR DESCRIPTION
## Summary

### CodeView 편집 모드 — contenteditable 전면 재설계
textarea 오버레이 + charWidth 픽셀 계산 방식을 제거하고 `<pre contenteditable>`을 단일 편집/표시 레이어로 교체.

- **구조 변경**: `<pre contenteditable>` + 라인번호 컬럼(flex sibling). textarea, charMeasureRef, metrics, selInfo, 커서 오버레이 전부 제거
- **커서 싱크**: `domPosToOffset` / `offsetToDomPos` (Range API 기반) + `useLayoutEffect`로 React 재렌더 후 커서 복원
- **칩 완전 지원**: `renderWithInvisibles`에 `atomic` 파라미터 추가 — `contentEditable="false"` + `data-char` 속성으로 칩을 1개 원자 단위로 처리. `extractCodeFromPre`가 `data-char`에서 실제 문자 추출 (`pre.innerText` 대신)
- **IME 지원**: `isComposingRef` + `onCompositionStart/End`로 한글 등 조합 중 재렌더 차단
- **라인 배경 오버레이**: `lineHeightPx` 측정 + absolute 오버레이로 편집 모드에서도 `showAlternatingRows` / `highlightLines` 동작

### 이전 세션 내용 (이미 브랜치에 포함)
- 니모닉 칩 카테고리별 색상 7종 / 상하 패딩 / LFD 제외
- `showCopyButton` prop 추가
- `gutterWidth` / `gutterGap` prop 추가
- Playground language 드롭다운에 `markdown`, `text` 추가
- MIT `LICENSE` 파일 및 `package.json` license 필드

## Test plan
- [ ] 편집 모드에서 일반 타이핑 시 커서 위치 정확한지 확인
- [ ] 한글 IME 입력 시 조합 중 깨짐 없는지 확인
- [ ] `showInvisibles=true` + `editable=true` 조합에서 칩 클릭/커서 이동 정상 동작 확인
- [ ] Tab 들여쓰기 / Shift+Tab 내어쓰기 / Enter 자동 들여쓰기 확인
- [ ] 붙여넣기(Paste) 순수 텍스트로 정규화되는지 확인
- [ ] `showAlternatingRows` / `highlightLines` 편집 모드에서 표시되는지 확인
- [ ] 읽기 모드 기존 동작 회귀 없는지 확인

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY