### PR TITLE
fix(CodeView): 니모닉 칩을 자연 폭 단일 span으로 재설계 (#17)

### DIFF
--- a/src/components/CodeView/CodeView.invisibles.tsx
+++ b/src/components/CodeView/CodeView.invisibles.tsx
@@ -146,30 +146,20 @@ const MNEMONICS: Readonly<Record<string, string>> = {
   "\uFEFF": "BOM", // Zero-width no-break space / BOM
 };
 
-// 칩 외곽 컨테이너: 레이아웃상 정확히 1ch를 차지 (textarea와 동일)
-const CHIP_OUTER_STYLE = {
+// 니모닉 칩: 자연 폭의 단일 inline-block span.
+// 1ch 에 라벨을 우겨넣으려 시도하지 않고 가독성을 우선하여 이웃 문자와의
+// 시각적 겹침을 원천 차단한다 (VSCode/Monaco 와 동일한 절충).
+// `data-char` + contentEditable=false 로 커서/복사 관점에서는 여전히 1 문자 단위.
+const CHIP_STYLE = {
   display: "inline-block" as const,
-  width: "1ch",
-  height: "1em",
-  position: "relative" as const,
   verticalAlign: "middle" as const,
-  overflow: "visible" as const,
-};
-
-// 칩 본체: absolute로 1ch 컨테이너 중앙에 위치, 시각적으로만 오버플로우
-const CHIP_BASE_STYLE = {
-  position: "absolute" as const,
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
-  display: "inline-flex" as const,
-  alignItems: "center" as const,
   whiteSpace: "nowrap" as const,
+  padding: "0 3px",
+  margin: "0 1px",
+  borderRadius: "3px",
   fontSize: "0.6em",
   fontWeight: 700 as const,
   lineHeight: 1 as const,
-  padding: "2px 3px",
-  borderRadius: "3px",
   letterSpacing: "0.03em",
 };
 
@@ -255,18 +245,13 @@ export function renderWithInvisibles(
           aria-label={mnemonic}
           data-char={char}
           {...atomicProps}
-          style={CHIP_OUTER_STYLE}
+          style={{
+            ...CHIP_STYLE,
+            background: chipColors.background,
+            color: chipColors.color,
+          }}
         >
-          <span
-            aria-hidden="true"
-            style={{
-              ...CHIP_BASE_STYLE,
-              background: chipColors.background,
-              color: chipColors.color,
-            }}
-          >
-            {mnemonic}
-          </span>
+          {mnemonic}
         </span>
       );
     } else {


### PR DESCRIPTION
Closes #17

## 배경

`showInvisibles=true` 상태에서 제어 문자(예: `\u0000`, `\u001B`)가 "NUL", "ESC" 같은 니모닉 칩으로 렌더될 때, 칩이 좌·우 이웃 문자와 시각적으로 겹쳐서 가독성을 해치는 문제가 있었다.

## 원인

`CodeView.invisibles.tsx` 의 기존 칩 구조:

- 외곽 `<span>`: `width: 1ch`, `position: relative`, `overflow: visible`
- 내부 `<span>`: `position: absolute`, `transform: translate(-50%, -50%)`, `font-size: 0.6em`, `padding: 2px 3px`

내부 라벨 텍스트("NUL" 3글자 × 0.6em ≈ 1.8ch) + 좌우 padding + border-radius 공간이 1ch 외곽을 넘어서, 중앙 정렬 때문에 좌우 각각 약 0.4ch 씩 물리적으로 overflow 되어 이웃 글리프를 덮었다.

## 변경

`CHIP_OUTER_STYLE` + `CHIP_BASE_STYLE` 두 상수를 단일 `CHIP_STYLE` 로 통합하고, 칩을 **하나의** `inline-block` span 으로 렌더한다.

```tsx
<span
  title={`U+${hex} ${mnemonic}`}
  aria-label={mnemonic}
  data-char={char}
  {...atomicProps}
  style={{ ...CHIP_STYLE, background, color }}
>
  {mnemonic}
</span>
```

`CHIP_STYLE` 은 `display: inline-block`, `padding: 0 3px`, `margin: 0 1px`, `border-radius: 3px`, `font-size: 0.6em`, `font-weight: 700`, `line-height: 1`, `letter-spacing: 0.03em`, `vertical-align: middle`, `white-space: nowrap`.

## 보존되는 동작

- `data-char` 속성: 커스텀 walker 가 원본 문자를 추출할 수 있음
- `contentEditable=false` (atomic 모드): 브라우저가 칩 전체를 하나의 커서 단위로 취급
- `aria-label`, `title`: 접근성/툴팁

## 트레이드오프

칩이 자연 폭(약 2–3ch)을 차지하므로, 해당 제어 문자 한 개가 열 정렬에서 1ch 보다 넓게 보인다. VSCode/Monaco 동일한 절충이며, 가독성과 겹침 방지 효과가 열 정렬 손실보다 크다고 판단했다.

## 테스트 계획

- [ ] `showInvisibles=true` + `"a\u0000b\u001Bc"` 같은 샘플에서 칩이 좌우 글자와 겹치지 않는지 확인
- [ ] 편집 모드에서 칩 근처에 커서를 두고 ←/→ 키로 이동 시 칩이 1 문자 단위로 건너뛰어지는지 확인
- [ ] 복사 버튼 클릭 시 원본 문자가 그대로 클립보드에 복사되는지 확인 (기존 동작 유지)

## 참고

- 계획 문서: `docs/plans/001-codeview-rich-improvements.md` §2 니모닉 칩 재설계