### PR TITLE
fix(CodeView): tab/space 스팬의 userSelect:none 제거 (#18)

### DIFF
--- a/src/components/CodeView/CodeView.invisibles.tsx
+++ b/src/components/CodeView/CodeView.invisibles.tsx
@@ -219,7 +219,6 @@ export function renderWithInvisibles(
             width: `${tabSize}ch`,
             color: INVISIBLE_COLOR[theme],
             overflow: "hidden",
-            userSelect: "none",
           }}
         >
           →
@@ -236,7 +235,6 @@ export function renderWithInvisibles(
           {...atomicProps}
           style={{
             color: INVISIBLE_COLOR[theme],
-            userSelect: "none",
           }}
         >
           ·


### PR DESCRIPTION
Closes #18

## 배경

`showInvisibles=true` 상태에서 드래그로 텍스트를 선택할 때 tab 화살표(`→`)와 space 점(`·`) 위에는 선택 하이라이트가 표시되지 않았다. 해당 스팬에 `userSelect: "none"` 이 걸려 있기 때문이다.

원본 문자가 선택 영역에 포함되고 복사 시 `\t` / `" "` 로 치환되려면 먼저 선택 자체가 가능해야 한다.

## 변경

`src/components/CodeView/CodeView.invisibles.tsx`

- tab 스팬(L222)에서 `userSelect: "none"` 제거
- space 스팬(L239)에서 `userSelect: "none"` 제거

## 보존되는 동작

- `data-char` 속성은 유지 — walker/copy 로직이 원본 문자를 추출할 수 있음
- `display: inline-block` + `width: ${tabSize}ch` (tab) / 기본 흐름 (space) 유지

## 후속 작업

복사 시 화면에 보이는 `→` / `·` 대신 원본 `\t` / `" "` 가 클립보드에 들어가도록 하는 `onCopy` 핸들러는 #25 에서 처리한다. 이번 PR 단독으로는 Chrome/Safari 가 기본 선택 복사로 시각 기호 문자를 복사할 수 있다.

## 테스트 계획

- [ ] `showInvisibles=true` 에서 tab/space 포함 구간을 드래그 선택 → 해당 문자에도 하이라이트가 보이는지 확인
- [ ] 편집 모드 키 입력/커서 이동 회귀 없음

## 참고

- 계획 문서: `docs/plans/001-codeview-rich-improvements.md` §3 Selection 하이라이트