### PR TITLE
fix(CodeView): domPosToOffset Safari 칩 내부 endpoint 클램프 (#20)

### DIFF
--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -90,6 +90,32 @@ function domPosToOffset(
   container: Node,
   offset: number,
 ): number {
+  // Safari 보정: selection endpoint 가 contentEditable=false 칩(`[data-char]`)
+  // 내부 텍스트 노드나 칩 요소 자체로 떨어지는 경우가 있다. 이런 endpoint 를
+  // 칩 바로 앞/뒤 경계로 클램프하여 일관된 오프셋 계산을 보장한다.
+  {
+    let node: Node | null = container;
+    while (node && node !== root) {
+      if (
+        node.nodeType === Node.ELEMENT_NODE &&
+        (node as Element).hasAttribute("data-char")
+      ) {
+        const chip = node as Element;
+        const chipParent = chip.parentNode;
+        if (chipParent && chipParent.nodeType === Node.ELEMENT_NODE) {
+          const idx = Array.from(chipParent.childNodes).indexOf(chip as ChildNode);
+          // container === chip && offset > 0 이면 "칩 뒤", 그 외(칩 내부 깊숙이
+          // 떨어진 경우 포함)는 안전하게 "칩 앞"으로 클램프한다.
+          const afterChip = node === container && offset > 0;
+          container = chipParent as Element;
+          offset = afterChip ? idx + 1 : idx;
+        }
+        break;
+      }
+      node = node.parentNode;
+    }
+  }
+
   const nodes = walkEffectiveNodes(root);
   let count = 0;
 


### PR DESCRIPTION
Closes #20

## 배경

Safari 는 selection/range 의 endpoint 를 `contentEditable=false` 로 지정된 칩(니모닉/탭/공백) **내부** 텍스트 노드나 칩 요소 자체 위로 떨어뜨리는 경우가 있다. 이 경우 기존 `domPosToOffset` 은:

1. `walkEffectiveNodes` 가 칩 내부를 순회하지 않으므로 container 가 어느 effective 노드와도 매칭되지 않음
2. 함수 말미의 `return count` (총 문자 수) 가 반환되어 실제 클릭 위치와 무관한 오프셋이 생성됨

결과적으로 커서가 엉뚱한 곳으로 이동하거나 선택 구간이 왜곡되는 Safari 전용 회귀가 발생할 수 있었다.

## 변경

`src/components/CodeView/CodeView.tsx` 의 `domPosToOffset` 진입부에 조상 순회 클램프 블록을 추가.

- `container` 부터 `root` 직전까지 parentNode 를 따라가며 `[data-char]` 칩을 찾는다
- 발견 시 `(chipParent, idx)` 또는 `(chipParent, idx + 1)` 로 재할당
- `container === chip && offset > 0` → "칩 뒤"
- 그 외(칩 내부 깊이 떨어졌거나 `offset === 0`) → "칩 앞"
- 재할당 후 기존 `walkEffectiveNodes` 기반 로직을 그대로 수행

## 불변식

- 칩이 아닌 일반 텍스트/요소 노드에 대해서는 클램프 블록이 아무 일도 하지 않고 통과하므로 기존 동작에 영향 없음
- 클램프된 `(chipParent, idx)` 는 기존 로직의 "element-based 칩 인접 위치" 분기와 정확히 매칭되어 `count` / `count + 1` 이 반환됨

## 트레이드오프

"칩 안쪽을 클릭했을 때 칩 앞 vs 뒤" 를 결정하는 heuristic 은 완벽하지 않다. 중앙 분할(clientX 비교) 방식도 가능하나, 구현 복잡도 대비 체감 이득이 작다고 판단해 `offset > 0 ? after : before` 로 단순화했다. 칩은 원자 단위이므로 사용자도 대체로 칩 바깥을 클릭한다.

## 테스트 계획

- [ ] Safari 에서 칩을 직접 클릭 → 커서가 칩 바로 앞 또는 뒤에 배치되는지 확인
- [ ] Chrome/Firefox 회귀 없음 (클램프 블록이 트리거되지 않아야 함)
- [ ] 편집 중 커서 복원(`offsetToDomPos` + useLayoutEffect)이 정상 동작

## 참고

- 계획 문서: `docs/plans/001-codeview-rich-improvements.md` §3 Safari 보정