### PR TITLE
feat(CodeView): walkEffectiveNodes에 data-gutter skip과 lineRow 필드 추가 (#19)

### DIFF
--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -49,18 +49,32 @@ function getGutterWidth(lineCount: number): string {
  *           parent + indexInParent 를 함께 저장하여 element-based 커서 위치를 처리한다.
  */
 type EffectiveNode =
-  | { type: "text"; node: Text }
-  | { type: "chip"; element: Element; parent: Element; indexInParent: number };
+  | { type: "text"; node: Text; lineRow: Element | null }
+  | {
+      type: "chip";
+      element: Element;
+      parent: Element;
+      indexInParent: number;
+      lineRow: Element | null;
+    };
 
+/**
+ * Walker 불변식:
+ *   - `[data-gutter]` 서브트리는 진입하지 않고 전부 skip (라인 번호 컬럼 등).
+ *   - `[data-char]` 요소(칩)는 1 문자 단위의 chip 항목으로 push 하고 내부 순회 중단.
+ *   - 각 항목에 가장 가까운 `[data-line-row]` 조상을 `lineRow` 로 동봉한다.
+ *     `lineRow` 전환점은 copy 로직에서 라인 경계('\n') 삽입을 판정하는 데 쓰인다.
+ */
 function walkEffectiveNodes(root: Element): EffectiveNode[] {
   const result: EffectiveNode[] = [];
 
-  function walk(node: Node, parent: Element): void {
+  function walk(node: Node, parent: Element, lineRow: Element | null): void {
     if (node.nodeType === Node.TEXT_NODE) {
-      result.push({ type: "text", node: node as Text });
+      result.push({ type: "text", node: node as Text, lineRow });
       return;
     }
     const el = node as Element;
+    if (el.hasAttribute("data-gutter")) return;
     if (el.hasAttribute("data-char")) {
       // 칩 요소: 1 문자로 계산하고 내부 텍스트는 순회하지 않는다
       const siblings = Array.from(parent.childNodes);
@@ -69,13 +83,15 @@ function walkEffectiveNodes(root: Element): EffectiveNode[] {
         element: el,
         parent,
         indexInParent: siblings.indexOf(el as ChildNode),
+        lineRow,
       });
       return;
     }
-    for (const child of Array.from(el.childNodes)) walk(child, el);
+    const nextLineRow = el.hasAttribute("data-line-row") ? el : lineRow;
+    for (const child of Array.from(el.childNodes)) walk(child, el, nextLineRow);
   }
 
-  for (const child of Array.from(root.childNodes)) walk(child, root);
+  for (const child of Array.from(root.childNodes)) walk(child, root, null);
   return result;
 }
 


### PR DESCRIPTION
Closes #19

## 배경

후속 이슈들이 walker 결과에 의존한다:

- **#24 extractCodeFromPre** 재작성: 라인 경계에서 `\n` 삽입
- **#25 onCopy** 핸들러: selection 과 walker 결과를 교차하여 원본 문자 직렬화
- **#26 gutter 속성**: gutter 텍스트가 selection/copy 에 섞이지 않도록 walker 에서 skip

위 세 기능을 모두 받아내기 위해 walker 자체를 선제적으로 확장한다.

## 변경

`src/components/CodeView/CodeView.tsx` `walkEffectiveNodes`

1. **`[data-gutter]` 서브트리 skip**
   - `el.hasAttribute("data-gutter")` 면 내부 순회를 생략하고 return
   - gutter 는 아직 이 속성을 부여하지 않았지만 #21/#26 에서 부여할 예정. Walker 가 먼저 준비되어 있어도 기존 DOM 에는 해당 속성이 없어 동작 차이 없음

2. **`lineRow: Element | null` 필드 동봉**
   - `EffectiveNode` 의 두 variant 모두에 `lineRow` 필드 추가
   - `walk(node, parent, lineRow)` 시그니처로 재귀 중 현재 lineRow 를 전달
   - 요소 진입 시 `el.hasAttribute("data-line-row")` 이면 자기 자신을 새 lineRow 로 전환
   - 자식 순회에는 전환된 `nextLineRow` 를 내려보냄

## 불변식 / 회귀

- 기존 호출부(`domPosToOffset`, `offsetToDomPos`, `extractCodeFromPre`)는 `{type, node}`, `{type, parent, indexInParent}` 만 destructure 하므로 lineRow 필드 추가는 영향 없음
- 현재 DOM 에는 `data-gutter` / `data-line-row` 가 없어 실질 동작 변화 없음 (부가 속성 검사 오버헤드만 있음)
- 이후 #21 에서 속성을 부여하면 자동으로 기능 활성화

## 테스트 계획

- [ ] 현재 동작 그대로: 편집 모드 텍스트 입력 / 커서 이동 / 칩 건너뛰기 회귀 없음
- [ ] `npm run typecheck` 통과
- [ ] 단독으로는 시각 변화 없음

## 후속

- #21 에서 gutter 에 `data-gutter`, 라인 행에 `data-line-row` 부여
- #24 에서 `lineRow` 전환점 기반 `\n` 삽입으로 extract 재작성
- #25 에서 walker 결과를 selection 과 교차하여 onCopy 구현

## 참고

- 계획 문서: `docs/plans/001-codeview-rich-improvements.md` §5 walker 공유