### PR TITLE
refactor(CodeView): 렌더 구조 통일 (data-line-row) (#21)

### DIFF
--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useRef, Fragment } from "react";
+import { useState, useEffect, useLayoutEffect, useRef } from "react";
 import { Highlight, themes } from "prism-react-renderer";
 import type { CodeViewProps } from "./CodeView.types";
 import { renderWithInvisibles } from "./CodeView.invisibles";
@@ -168,17 +168,35 @@ function offsetToDomPos(
 
 /**
  * <pre contenteditable> DOM에서 실제 코드 문자열을 추출한다.
- * 일반 텍스트 노드의 텍스트 + 칩의 data-char 값을 순서대로 결합한다.
- * (pre.innerText는 칩의 니모닉 텍스트 "NUL" 등을 반환하므로 사용 불가)
+ *
+ * 라인 경계는 `<div data-line-row>` 블록 단위로 판정한다. 각 row 내부의
+ * effective node(일반 텍스트 + 칩 data-char) 를 이어붙이고, row 간은 '\n' 으로
+ * 조인한다. 빈 data-line-row 도 빈 라인으로 보존된다.
+ *
+ * row 내부에 브라우저가 집어넣은 `\n` 텍스트(Enter 직후 transient)는 그대로
+ * 유지되며, row-join 과 합쳐져 올바른 선형 문자열을 만든다.
+ *
+ * data-line-row 가 전혀 없는 상태(초기 렌더 전, 혹은 외부 조작으로 인한
+ * 비정상 구조) 에서는 기존 walker 평탄화 방식으로 fallback 한다.
  */
 function extractCodeFromPre(pre: HTMLPreElement): string {
-  let result = "";
-  for (const item of walkEffectiveNodes(pre)) {
-    if (item.type === "text") {
-      result += item.node.data;
-    } else {
-      result += item.element.getAttribute("data-char") ?? "";
+  const collectFrom = (root: Element): string => {
+    let out = "";
+    for (const item of walkEffectiveNodes(root)) {
+      if (item.type === "text") out += item.node.data;
+      else out += item.element.getAttribute("data-char") ?? "";
     }
+    return out;
+  };
+
+  const rows = pre.querySelectorAll(":scope > [data-line-row]");
+  let result: string;
+  if (rows.length === 0) {
+    result = collectFrom(pre);
+  } else {
+    const lines: string[] = [];
+    for (const row of Array.from(rows)) lines.push(collectFrom(row));
+    result = lines.join("\n");
   }
   return result.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
@@ -204,7 +222,6 @@ export function CodeView({
 }: CodeViewProps) {
   const [editValue, setEditValue] = useState(code);
   const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
-  const [lineHeightPx, setLineHeightPx] = useState(0);
 
   const prevCodeRef    = useRef(code);
   const preRef         = useRef<HTMLPreElement>(null);
@@ -213,19 +230,6 @@ export function CodeView({
   const savedCursorRef  = useRef<{ start: number; end: number } | null>(null);
   // IME 조합(한글 등) 중에는 React 재렌더를 막아 조합이 깨지지 않도록 함
   const isComposingRef  = useRef(false);
-
-  // 편집 모드 라인 높이 측정 (alternatingRows / highlightLines 오버레이용)
-  useLayoutEffect(() => {
-    if (!editable || !preRef.current) return;
-    const measure = () => {
-      const lh = parseFloat(getComputedStyle(preRef.current!).lineHeight);
-      if (lh > 0) setLineHeightPx(lh);
-    };
-    measure();
-    const ro = new ResizeObserver(measure);
-    ro.observe(preRef.current);
-    return () => ro.disconnect();
-  }, [editable]);
 
   // code prop 변경 시 내부 상태 동기화
   useEffect(() => {
@@ -425,202 +429,117 @@ export function CodeView({
           </button>
         ) : null;
 
-        // ── 편집 모드: <pre contenteditable> ─────────────────────────────────
-        if (editable) {
-          return (
-            <div
-              ref={containerRef}
-              className={baseContainerClass}
-              style={{ ...baseStyle, display: "flex", tabSize }}
-            >
-              {copyBtn}
+        // ── 통합 렌더: read/edit 모드 동일 DOM 구조 ─────────────────────────
+        // 구조:
+        //   <div flex onCopy={...}>
+        //     [copyBtn]
+        //     [<div data-gutter>...</div>]   ← showLineNumbers
+        //     <pre (편집 모드만 contentEditable + 이벤트)>
+        //       {tokens.map => <div data-line-row style={{bg}}>{tokens}</div>}
+        //     </pre>
+        //   </div>
+        const editableProps = editable
+          ? ({
+              contentEditable: true as const,
+              suppressContentEditableWarning: true,
+              spellCheck: false,
+              onCompositionStart: () => { isComposingRef.current = true; },
+              onCompositionEnd: () => {
+                isComposingRef.current = false;
+                handleInput();
+              },
+              onInput: handleInput,
+              onKeyDown: handleKeyDown,
+              onPaste: handlePaste,
+            })
+          : {};
 
-              {/* 라인 번호 컬럼 */}
-              {showLineNumbers && (
-                <div
-                  aria-hidden="true"
-                  style={{
-                    flexShrink:      0,
-                    width:           resolvedGutterWidth,
-                    paddingRight:    resolvedGutterGap,
-                    boxSizing:       "content-box" as const,
-                    textAlign:       "right" as const,
-                    color:           lineNumberColor[theme],
-                    fontSize:        "0.85em",
-                    lineHeight:      "inherit",
-                    userSelect:      "none" as const,
-                    pointerEvents:   "none" as const,
-                    // 수평 스크롤 시 번호 컬럼이 가려지지 않도록 sticky
-                    position:        "sticky" as const,
-                    left:            0,
-                    zIndex:          1,
-                    backgroundColor: style.backgroundColor as string,
-                  }}
-                >
-                  {tokens.map((_, i) => (
-                    <div key={i}>{i + 1}</div>
-                  ))}
-                </div>
-              )}
-
-              {/* 라인 배경 오버레이 (alternatingRows / highlightLines) */}
-              {lineHeightPx > 0 && (showAlternatingRows || (highlightLines && highlightLines.length > 0)) && (
-                <div
-                  aria-hidden="true"
-                  style={{
-                    position:      "absolute",
-                    // gutter 너비만큼 오른쪽부터 시작
-                    left:          showLineNumbers ? `calc(${resolvedGutterWidth} + ${resolvedGutterGap} + ${resolvedGutterGap})` : 0,
-                    right:         0,
-                    top:           0,
-                    pointerEvents: "none",
-                    zIndex:        0,
-                  }}
-                >
-                  {tokens.map((_, i) => {
-                    const isOdd         = i % 2 !== 0;
-                    const isHighlighted = highlightLines?.includes(i + 1) ?? false;
-                    const bg = isHighlighted
-                      ? highlightRowColor[theme]
-                      : showAlternatingRows && isOdd
-                        ? alternatingRowColor[theme]
-                        : undefined;
-                    return bg ? (
-                      <div
-                        key={i}
-                        style={{
-                          position: "absolute",
-                          top:      i * lineHeightPx,
-                          left:     0,
-                          right:    0,
-                          height:   lineHeightPx,
-                          backgroundColor: bg,
-                        }}
-                      />
-                    ) : null;
-                  })}
-                </div>
-              )}
-
-              {/* 편집 가능한 코드 영역 */}
-              <pre
-                ref={preRef}
-                contentEditable
-                suppressContentEditableWarning
-                spellCheck={false}
-                onCompositionStart={() => { isComposingRef.current = true; }}
-                onCompositionEnd={() => {
-                  isComposingRef.current = false;
-                  // 조합 완료 후 확정된 텍스트를 state에 반영
-                  handleInput();
-                }}
-                onInput={handleInput}
-                onKeyDown={handleKeyDown}
-                onPaste={handlePaste}
-                style={{
-                  flex:       1,
-                  margin:     0,
-                  padding:    0,
-                  outline:    "none",
-                  whiteSpace: wordWrap ? "pre-wrap" : "pre",
-                  wordBreak:  wordWrap ? "break-all" : "normal",
-                  background: "transparent",
-                  color:      "inherit",
-                  fontFamily: "inherit",
-                  fontSize:   "inherit",
-                  lineHeight: "inherit",
-                  tabSize,
-                  // Prism theme의 overflow 설정을 무력화
-                  overflow:   "visible",
-                }}
-              >
-                {tokens.map((line, li) => (
-                  <Fragment key={li}>
-                    {li > 0 && "\n"}
-                    {line.map((token, ti) => {
-                      const { className: tc, style: ts } = getTokenProps({ token });
-                      return (
-                        <span key={ti} className={tc} style={ts}>
-                          {showInvisibles
-                            ? renderWithInvisibles(token.content, theme, tabSize, true)
-                            : token.content}
-                        </span>
-                      );
-                    })}
-                  </Fragment>
-                ))}
-              </pre>
-            </div>
-          );
-        }
-
-        // ── 읽기 모드: 현재 구조 유지 ────────────────────────────────────────
         return (
           <div
             ref={containerRef}
             className={baseContainerClass}
-            style={{ ...baseStyle, tabSize }}
+            style={{ ...baseStyle, display: "flex", tabSize }}
           >
             {copyBtn}
 
-            <pre style={{
-              overflow:   "visible",
-              margin:     0,
-              padding:    0,
-              whiteSpace: wordWrap ? "pre-wrap" : "pre",
-              wordBreak:  wordWrap ? "break-all" : "normal",
-            }}>
-              <code style={{ display: "block" }}>
-                {tokens.map((line, lineIndex) => {
-                  const { className: lineClassName, style: lineStyle, ...lineRest } = getLineProps({ line });
-                  const isOdd         = lineIndex % 2 !== 0;
-                  const isHighlighted = highlightLines?.includes(lineIndex + 1) ?? false;
-                  const rowBg = isHighlighted
-                    ? highlightRowColor[theme]
-                    : showAlternatingRows && isOdd
-                      ? alternatingRowColor[theme]
-                      : undefined;
+            {showLineNumbers && (
+              <div
+                data-gutter="true"
+                aria-hidden="true"
+                style={{
+                  flexShrink:    0,
+                  minWidth:      resolvedGutterWidth,
+                  paddingRight:  resolvedGutterGap,
+                  boxSizing:     "content-box" as const,
+                  textAlign:     "right" as const,
+                  color:         lineNumberColor[theme],
+                  fontSize:      "0.85em",
+                  lineHeight:    "inherit",
+                  userSelect:    "none" as const,
+                  pointerEvents: "none" as const,
+                }}
+              >
+                {tokens.map((_, i) => (
+                  <div key={i}>{i + 1}</div>
+                ))}
+              </div>
+            )}
 
-                  return (
-                    <div
-                      key={lineIndex}
-                      className={["flex", lineClassName].filter(Boolean).join(" ")}
-                      style={{ ...lineStyle }}
-                      {...lineRest}
-                    >
-                      {showLineNumbers && (
-                        <span
-                          aria-hidden="true"
-                          style={{
-                            minWidth:     resolvedGutterWidth,
-                            paddingRight: resolvedGutterGap,
-                            boxSizing:    "content-box" as const,
-                            textAlign:    "right" as const,
-                            userSelect:   "none" as const,
-                            color:        lineNumberColor[theme],
-                            flexShrink:   0,
-                            fontSize:     "0.85em",
-                          }}
-                        >
-                          {lineIndex + 1}
+            <pre
+              ref={preRef}
+              {...editableProps}
+              style={{
+                flex:       1,
+                minWidth:   0,
+                margin:     0,
+                padding:    0,
+                outline:    editable ? "none" : undefined,
+                whiteSpace: wordWrap ? "pre-wrap" : "pre",
+                wordBreak:  wordWrap ? "break-all" : "normal",
+                background: "transparent",
+                color:      "inherit",
+                fontFamily: "inherit",
+                fontSize:   "inherit",
+                lineHeight: "inherit",
+                tabSize,
+                // Prism theme의 overflow 설정을 무력화
+                overflow:   "visible",
+              }}
+            >
+              {tokens.map((line, li) => {
+                const { className: lineClassName, style: lineStyle, ...lineRest } = getLineProps({ line });
+                const isOdd         = li % 2 !== 0;
+                const isHighlighted = highlightLines?.includes(li + 1) ?? false;
+                const rowBg = isHighlighted
+                  ? highlightRowColor[theme]
+                  : showAlternatingRows && isOdd
+                    ? alternatingRowColor[theme]
+                    : undefined;
+
+                return (
+                  <div
+                    key={li}
+                    data-line-row="true"
+                    className={lineClassName}
+                    style={{
+                      ...lineStyle,
+                      ...(rowBg ? { backgroundColor: rowBg } : {}),
+                    }}
+                    {...lineRest}
+                  >
+                    {line.map((token, ti) => {
+                      const { children: tokenContent, ...tokenSpanProps } = getTokenProps({ token });
+                      return (
+                        <span key={ti} {...tokenSpanProps}>
+                          {showInvisibles
+                            ? renderWithInvisibles(token.content, theme, tabSize, editable)
+                            : (editable ? token.content : tokenContent)}
                         </span>
-                      )}
-                      <span style={{ flex: 1, ...(rowBg ? { backgroundColor: rowBg } : {}) }}>
-                        {line.map((token, tokenIndex) => {
-                          const { children: tokenContent, ...tokenSpanProps } = getTokenProps({ token });
-                          return (
-                            <span key={tokenIndex} {...tokenSpanProps}>
-                              {showInvisibles
-                                ? renderWithInvisibles(token.content, theme, tabSize)
-                                : tokenContent}
-                            </span>
-                          );
-                        })}
-                      </span>
-                    </div>
-                  );
-                })}
-              </code>
+                      );
+                    })}
+                  </div>
+                );
+              })}
             </pre>
           </div>
         );


### PR DESCRIPTION
## Summary
- read/edit 모드의 DOM 구조를 `<div flex>` > `[data-gutter]` + `<pre>` > `<div data-line-row>` × N 단일 트리로 통합
- 편집 모드는 `<pre>` 에 contentEditable/onInput/onKeyDown/onPaste/onCompositionStart·End 만 추가 바인딩
- 각 `data-line-row` div 에 `backgroundColor` 를 직접 부여하여 alternating / highlightLines 를 per-line 스타일로 처리
- gutter 컬럼을 `minWidth`(탄력 폭) 기반으로 통일하고 `position: sticky` / `backgroundColor` / `zIndex` 를 제거해 read/edit 거동을 완전히 일치시킴
- `Fragment` + `"\n"` 평탄 구조를 제거하고 per-line div 경계를 채택
- Issue #17–#26 계획의 중심 리팩토링. 후속 PR (#22~#26) 이 이 구조 위에서 동작

## Details
- **`extractCodeFromPre`**: `pre.querySelectorAll(":scope > [data-line-row]")` 로 라인 경계를 식별한 뒤 각 row 의 effective node(텍스트 + 칩 `data-char`) 를 이어붙이고 row 간 `\n` 으로 조인. 빈 row (빈 라인) 와 row 내부에 브라우저가 삽입한 transient `\n` 을 모두 정확히 보존. row 가 없는 비정상 상태에서는 기존 평탄 walker 로 fallback.
- **오버레이 제거**: 기존 `position: absolute` + `top: i * lineHeightPx` 오버레이와 그에 따른 `lineHeightPx` state, `ResizeObserver` 기반 `useLayoutEffect` 를 삭제. Bug 1 의 `calc(gutter + gap + gap)` 좌측 패딩 중복도 자연 소멸.
- **커서 원자성 유지**: 칩 `data-char` + `contentEditable=false` 속성은 그대로 유지되므로 walker/offsetToDomPos/domPosToOffset 의 불변식은 변함 없음.
- **Prism 토큰 처리 통일**: 두 모드 공통으로 `getLineProps` + `getTokenProps` 를 사용. `showInvisibles` 일 때는 `renderWithInvisibles(token.content, theme, tabSize, editable)` 로 atomic 여부만 분기.

## Scope within plan
본 PR 는 docs/plans/001-codeview-rich-improvements.md 의 "§1 렌더 구조 통일" 및 관련 오버레이 제거까지 포함합니다. 이후 단계:
- #22: alternating/highlight bg per-line 이동 (사실상 본 PR 에 흡수됨 → 후속 정리 PR 또는 close 후보)
- #23: `lineHeightPx` / ResizeObserver 제거 (본 PR 에 포함됨 → 후속 PR trivial)
- #24: `extractCodeFromPre` 리파인 (본 PR 에 1차 구현 완료, 테스트/케이스 보강은 별도)
- #25: selection 기반 `onCopy` 구현 (본 PR 의 구조 위에서 진행)
- #26: gutter 접근성/선택 제외 보강

## Test plan
- [ ] `editable=true` / `false` 토글 시 gutter 폭·정렬·라인 번호 위치가 동일한지 확인
- [ ] `showAlternatingRows=true` 로 read/edit 전환 시 얼룩말 패턴이 gutter 직후부터 시작하는지 확인 (Bug 1 해소)
- [ ] `highlightLines=[2,5]` 에서 지정 라인 배경이 정확한 높이로 입혀지는지 확인
- [ ] 편집 모드에서 Enter → transient DOM 상태에서도 `handleInput` 이 올바른 문자열을 만들고 커서가 복원되는지 확인
- [ ] Tab / Shift+Tab 들여쓰기·내어쓰기 거동 회귀 없음
- [ ] IME (한글) 조합 중 편집이 깨지지 않음
- [ ] `showInvisibles=true` + editable 조합에서 칩이 여전히 1 커서 단위로 동작
- [ ] 100 라인+ / 1000 라인+ 코드에서 gutter clipping 없음
- [ ] `npm run typecheck` 통과

## Notes
- Base branch: `feat/19-walker-extend` (데이터 속성 walker 확장에 의존).
- Diff: +129 / -210 lines — 정리 비중이 더 큰 리팩토링.

🤖 Generated with [Claude Code](https://claude.com/claude-code)