### PR TITLE
feat(CodeView): selection 기반 onCopy 핸들러 (#25)

### DIFF
--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -367,11 +367,76 @@ export function CodeView({
   }
 
   // ── 복사 ────────────────────────────────────────────────────────────────────
-  function handleCopy() {
+  // "복사" 버튼 클릭: 전체 displayCode 를 클립보드에 쓰고 상태 배지를 업데이트한다.
+  function handleCopyAll() {
     navigator.clipboard.writeText(displayCode).then(() => {
       setCopyState("copied");
       setTimeout(() => setCopyState("idle"), 2000);
     });
+  }
+
+  // 선택 영역 Cmd+C / Ctrl+C 처리.
+  //
+  // 브라우저 기본 로직은 칩 내부에 표시된 니모닉 텍스트("NUL", "ESC", "→", "·") 를
+  // 그대로 직렬화해 원본 문자를 잃는다. 이 핸들러는 walker 를 이용해 effective
+  // content(텍스트 + 칩의 `data-char`) 를 재조립하고, `data-line-row` 경계에서
+  // `\n` 을 삽입해 라인 경계를 복원한다.
+  //
+  // 범위 계산:
+  //   - 텍스트 노드: 선택 Range 와의 교집합을 slice.
+  //   - 칩 요소: Range 와 "완전히 겹치는" 경우에만 data-char 한 글자로 포함
+  //     (contentEditable=false 로 원자 단위이므로 부분 선택은 의도된 적이 없다).
+  //
+  // gutter 서브트리는 walker 단에서 skip 되므로 라인 번호가 포함되지 않는다.
+  function handleCopyEvent(e: React.ClipboardEvent<HTMLDivElement>) {
+    const pre = preRef.current;
+    if (!pre) return;
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return;
+    const range = sel.getRangeAt(0);
+    // 선택이 pre 밖(예: 복사 버튼) 이면 기본 동작에 위임
+    if (!range.intersectsNode(pre)) return;
+
+    const items = walkEffectiveNodes(pre);
+    let output = "";
+    let prevLineRow: Element | null | undefined = undefined;
+
+    for (const item of items) {
+      let contribution = "";
+
+      if (item.type === "text") {
+        const node = item.node;
+        // node 전체가 range 범위 밖이면 skip
+        const startCmp = range.comparePoint(node, 0);
+        const endCmp   = range.comparePoint(node, node.length);
+        if (endCmp < 0 || startCmp > 0) continue;
+
+        const sliceStart = range.startContainer === node ? range.startOffset : 0;
+        const sliceEnd   = range.endContainer   === node ? range.endOffset   : node.length;
+        if (sliceEnd <= sliceStart) continue;
+        contribution = node.data.slice(sliceStart, sliceEnd);
+      } else {
+        // 칩: parent 내 [indexInParent, indexInParent+1] 구간이 range 에
+        // 완전히 포함될 때만 1 글자로 포함
+        const startCmp = range.comparePoint(item.parent, item.indexInParent);
+        const endCmp   = range.comparePoint(item.parent, item.indexInParent + 1);
+        if (startCmp < 0 || endCmp > 0) continue;
+        contribution = item.element.getAttribute("data-char") ?? "";
+      }
+
+      if (!contribution) continue;
+
+      // 이전에 기여한 항목과 라인이 달라졌으면 경계 '\n' 삽입
+      if (prevLineRow !== undefined && item.lineRow !== prevLineRow) {
+        output += "\n";
+      }
+      prevLineRow = item.lineRow;
+      output += contribution;
+    }
+
+    if (!output) return;
+    e.preventDefault();
+    e.clipboardData.setData("text/plain", output);
   }
 
   // ── 렌더 ─────────────────────────────────────────────────────────────────────
@@ -405,7 +470,7 @@ export function CodeView({
 
         const copyBtn = showCopyButton ? (
           <button
-            onClick={handleCopy}
+            onClick={handleCopyAll}
             aria-label="코드 복사"
             style={{
               position:     "absolute",
@@ -458,6 +523,7 @@ export function CodeView({
           <div
             ref={containerRef}
             className={baseContainerClass}
+            onCopy={handleCopyEvent}
             style={{ ...baseStyle, display: "flex", tabSize }}
           >
             {copyBtn}


### PR DESCRIPTION
## Summary
- contenteditable/읽기 모드 공통으로 동작하는 커스텀 `onCopy` 핸들러를 추가
- 칩 내부의 니모닉 텍스트("NUL", "ESC", "→", "·") 대신 `data-char` 속성에 담긴 **원본 문자**를 클립보드에 기록
- `data-line-row` 경계를 감지해 라인 간 `\n` 을 정확히 삽입
- 기존 전체 복사 함수(`handleCopy`) → `handleCopyAll` 로 리네임하여 역할을 구분

## Details
- `handleCopyEvent(e)` 는 containerRef 루트에 바인딩. 동작 순서:
  1. `window.getSelection()` 의 첫 Range 를 얻고, 해당 range 가 `pre` 와 교차하지 않으면 기본 동작에 위임 (복사 버튼 복사 등).
  2. `walkEffectiveNodes(pre)` 순회. walker 가 `[data-gutter]` 서브트리를 skip 하므로 라인 번호가 자동 배제됨.
  3. **텍스트 노드**: range 와의 교집합을 slice. `range.startContainer` / `range.endContainer` 일치 시 그 오프셋을, 아니면 0 / length 를 사용.
  4. **칩(`data-char`) 요소**: parent 내 `[indexInParent, indexInParent+1]` 구간이 range 에 **완전히 포함**될 때만 1 글자로 포함. 칩은 `contentEditable=false` 로 원자 단위라 부분 선택은 의도되지 않음.
  5. 이전에 기여한 항목의 `lineRow` 와 현재 `lineRow` 가 다르면 `output` 에 `"\n"` 삽입 → 다중 라인 복사 시 라인 경계 복원.
  6. `clipboardData.setData("text/plain", output)` + `preventDefault()`.

## Test plan
- [ ] 제어 문자 포함 코드(`"a\u0000b\u001Bc\td"`) 에서 전체 선택 후 복사 → 외부 에디터에 원본 문자 붙여넣기 확인
- [ ] `showInvisibles=true` 상태의 tab/space/chip 이 모두 정확히 복사됨
- [ ] 여러 줄 드래그 시 클립보드에 `\n` 포함, 라인 번호("1", "2", …) 는 포함되지 않음
- [ ] 편집/읽기 모드 둘 다 동일하게 동작
- [ ] 복사 버튼(전체 복사) 은 기존대로 displayCode 전체를 복사
- [ ] 선택이 비어 있거나 pre 밖이면 기본 복사 동작으로 폴백
- [ ] 부분 칩 선택(칩만 절반 걸친 경우) 은 해당 칩을 제외하고 복사
- [ ] TypeScript 검사 통과

## Base
- base: `feat/21-unify-render` (PR #32). `data-line-row` 구조 + walker lineRow 필드 의존.

🤖 Generated with [Claude Code](https://claude.com/claude-code)