### PR TITLE
feat(PipelineGraph): 컴파운드 DAG 뷰어 + 데모 (#186-#217)

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -11,8 +11,9 @@ import DataTablePage from "./pages/DataTablePage";
 import { StepperPage } from "./pages/StepperPage";
 import CommandPalettePage from "./pages/CommandPalettePage";
 import HexViewPage from "./pages/HexViewPage";
+import { PipelineGraphPage } from "./pages/PipelineGraphPage";
 
-type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview";
+type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph";
 
 interface SubItem { label: string; id: string }
 
@@ -149,6 +150,22 @@ const NAV: { id: Page; label: string; description: string; sections: SubItem[] }
     { label: "Selection", id: "selection" },
     { label: "Virtualized", id: "virtualized" },
     { label: "Dark Theme", id: "dark" },
+    { label: "Props", id: "props" },
+    { label: "Usage", id: "usage" },
+    { label: "Playground", id: "playground" },
+  ]},
+  { id: "pipelinegraph", label: "PipelineGraph", description: "스텝 기반 DAG 뷰어", sections: [
+    { label: "Basic", id: "basic" },
+    { label: "Direction", id: "direction" },
+    { label: "Grouping", id: "grouping" },
+    { label: "Loop", id: "loop" },
+    { label: "Fan-out", id: "fanout" },
+    { label: "Status palette", id: "status" },
+    { label: "Controlled", id: "controlled" },
+    { label: "Inspector", id: "inspector" },
+    { label: "Custom node render", id: "custom-node" },
+    { label: "Dark theme", id: "dark" },
+    { label: "Large graph", id: "large" },
     { label: "Props", id: "props" },
     { label: "Usage", id: "usage" },
     { label: "Playground", id: "playground" },
@@ -403,6 +420,7 @@ export function App() {
         {current === "stepper" && <StepperPage />}
         {current === "commandpalette" && <CommandPalettePage />}
         {current === "hexview" && <HexViewPage />}
+        {current === "pipelinegraph" && <PipelineGraphPage />}
       </main>
     </div>
   );

--- a/demo/src/pages/PipelineGraphPage.tsx
+++ b/demo/src/pages/PipelineGraphPage.tsx
@@ -185,16 +185,80 @@ export function PipelineGraphPage() {
         </div>
       </Section>
 
-      <Section id="direction" title="Direction" desc="LR / TB 레이아웃 비교.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      <Section
+        id="direction"
+        title="Direction"
+        desc="LR (기본, 좌→우) 과 TB (상→하) 레이아웃 비교."
+      >
+        <div style={{ display: "flex", gap: 16 }}>
+          <div style={{ flex: 1 }}>
+            <p className="text-xs text-gray-400 mb-1">LR</p>
+            <div style={{ height: 320 }}>
+              <PipelineGraph
+                nodes={BASIC.nodes}
+                edges={BASIC.edges}
+                direction="LR"
+                height="100%"
+              />
+            </div>
+          </div>
+          <div style={{ flex: 1 }}>
+            <p className="text-xs text-gray-400 mb-1">TB</p>
+            <div style={{ height: 320 }}>
+              <PipelineGraph
+                nodes={BASIC.nodes}
+                edges={BASIC.edges}
+                direction="TB"
+                height="100%"
+              />
+            </div>
+          </div>
+        </div>
       </Section>
 
-      <Section id="grouping" title="Grouping" desc="group 카드를 펼쳐 내부 스텝을 관찰.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      <Section
+        id="grouping"
+        title="Grouping"
+        desc="group 카드의 ▸ 를 눌러 내부 스텝을 펼칠 수 있습니다. 펼쳐진 카드는 점선 클러스터로 감싸집니다."
+      >
+        <div style={{ height: 420 }}>
+          <PipelineGraph
+            nodes={WITH_GROUP.nodes}
+            edges={WITH_GROUP.edges}
+            defaultExpansion={["validate"]}
+            height="100%"
+          />
+        </div>
       </Section>
 
-      <Section id="loop" title="Loop" desc="3D 스택 + 진행률 바 + 펼치기.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      <Section
+        id="loop"
+        title="Loop"
+        desc="loop 카드는 접힌 상태에서 3D 스택 그림자와 진행률 바를 보입니다. 펼치면 내부 바디가 클러스터 안에 드러납니다."
+      >
+        <div style={{ display: "flex", gap: 16 }}>
+          <div style={{ flex: 1 }}>
+            <p className="text-xs text-gray-400 mb-1">Collapsed</p>
+            <div style={{ height: 360 }}>
+              <PipelineGraph
+                nodes={WITH_LOOP.nodes}
+                edges={WITH_LOOP.edges}
+                height="100%"
+              />
+            </div>
+          </div>
+          <div style={{ flex: 1 }}>
+            <p className="text-xs text-gray-400 mb-1">Expanded</p>
+            <div style={{ height: 360 }}>
+              <PipelineGraph
+                nodes={WITH_LOOP.nodes}
+                edges={WITH_LOOP.edges}
+                defaultExpansion={["train"]}
+                height="100%"
+              />
+            </div>
+          </div>
+        </div>
       </Section>
 
       <Section id="fanout" title="Fan-out" desc="한 스텝이 N 개 하위 실행으로 분기.">

--- a/demo/src/pages/PipelineGraphPage.tsx
+++ b/demo/src/pages/PipelineGraphPage.tsx
@@ -1,5 +1,11 @@
+import { useState } from "react";
 import { PipelineGraph } from "plastic";
-import type { PipelineEdge, PipelineNode } from "plastic";
+import type {
+  PipelineEdge,
+  PipelineGraphInspectorConfig,
+  PipelineNode,
+  PipelineNodeStatus,
+} from "plastic";
 
 // ── 샘플 데이터 ────────────────────────────────────────────────────────────
 
@@ -145,6 +151,61 @@ export function makeLarge(n: number): {
   return { nodes, edges };
 }
 
+export const INSPECTOR_DEMO: {
+  nodes: PipelineNode[];
+  edges: PipelineEdge[];
+} = {
+  nodes: [
+    {
+      id: "load",
+      label: "Load",
+      status: "success",
+      timing: { startedAt: now - 40_000, endedAt: now - 35_000 },
+      input: { path: "/data/foo.csv", format: "csv" },
+      output: { rows: 1024, cols: 8 },
+    },
+    {
+      id: "transform",
+      label: "Transform",
+      status: "success",
+      timing: { startedAt: now - 35_000, endedAt: now - 30_000 },
+      input: { rows: 1024 },
+      output: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      internal: { timingBreakdown: { parse: 120, cast: 60, pack: 45 } },
+    },
+    {
+      id: "model",
+      label: "Model",
+      status: "failed",
+      timing: { startedAt: now - 30_000, endedAt: now - 29_500 },
+      input: { batch: 32 },
+      error: {
+        message: "ValueError: shape mismatch (got (32,8), expected (32,16))",
+        stack:
+          "  at Model.forward (model.py:142)\n  at train_step (train.py:88)\n  at main (run.py:21)",
+        cause: { kind: "ShapeError", expected: [32, 16], actual: [32, 8] },
+      },
+    },
+  ],
+  edges: [
+    { from: "load", to: "transform" },
+    { from: "transform", to: "model" },
+  ],
+};
+
+const STATUS_LEGEND: Array<{ status: PipelineNodeStatus; color: string; label: string }> = [
+  { status: "success", color: "#16a34a", label: "success" },
+  { status: "running", color: "#2563eb", label: "running (pulse)" },
+  { status: "pending", color: "#94a3b8", label: "pending" },
+  { status: "failed", color: "#dc2626", label: "failed" },
+  { status: "skipped", color: "#a78bfa", label: "skipped" },
+  { status: "cancelled", color: "#f59e0b", label: "cancelled" },
+];
+
 // ── 섹션 공통 ──────────────────────────────────────────────────────────────
 
 function Section({
@@ -170,6 +231,89 @@ function Section({
 }
 
 // ── 페이지 ─────────────────────────────────────────────────────────────────
+
+function ControlledDemo() {
+  const [sel, setSel] = useState<string | null>(null);
+  const ids = BASIC.nodes.map((n) => n.id);
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", marginBottom: 10 }}>
+        {ids.map((id) => (
+          <button
+            key={id}
+            onClick={() => setSel(id)}
+            className={[
+              "px-3 py-1 text-xs rounded border transition-colors",
+              sel === id
+                ? "border-blue-500 bg-blue-50 text-blue-700"
+                : "border-gray-300 bg-white text-gray-700 hover:bg-gray-50",
+            ].join(" ")}
+            type="button"
+          >
+            {id}
+          </button>
+        ))}
+        <button
+          onClick={() => setSel(null)}
+          className="px-3 py-1 text-xs rounded border border-gray-300 bg-white text-gray-500 hover:bg-gray-50"
+          type="button"
+        >
+          clear
+        </button>
+        <span className="ml-auto text-xs text-gray-500">
+          selection: <code className="px-1 py-0.5 bg-gray-100 rounded">{sel ?? "null"}</code>
+        </span>
+      </div>
+      <div style={{ height: 380 }}>
+        <PipelineGraph
+          nodes={BASIC.nodes}
+          edges={BASIC.edges}
+          selection={sel}
+          onSelectionChange={setSel}
+          height="100%"
+        />
+      </div>
+    </div>
+  );
+}
+
+function InspectorDemo() {
+  const [pos, setPos] = useState<"right" | "bottom" | "none">("right");
+  const cfg: PipelineGraphInspectorConfig = { position: pos };
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8, marginBottom: 10 }}>
+        {(["right", "bottom", "none"] as const).map((p) => (
+          <button
+            key={p}
+            onClick={() => setPos(p)}
+            className={[
+              "px-3 py-1 text-xs rounded border transition-colors",
+              pos === p
+                ? "border-blue-500 bg-blue-50 text-blue-700"
+                : "border-gray-300 bg-white text-gray-700 hover:bg-gray-50",
+            ].join(" ")}
+            type="button"
+          >
+            position = {p}
+          </button>
+        ))}
+      </div>
+      <div style={{ height: 440 }}>
+        <PipelineGraph
+          nodes={INSPECTOR_DEMO.nodes}
+          edges={INSPECTOR_DEMO.edges}
+          inspector={cfg}
+          defaultSelection="transform"
+          height="100%"
+        />
+      </div>
+      <p className="text-xs text-gray-400 mt-2">
+        Load / Transform 선택 시 Output 탭이 기본 노출됩니다. Model (failed) 선택 시 Error 탭이 자동 활성화됩니다.
+      </p>
+    </div>
+  );
+}
 
 export function PipelineGraphPage() {
   return (
@@ -261,20 +405,68 @@ export function PipelineGraphPage() {
         </div>
       </Section>
 
-      <Section id="fanout" title="Fan-out" desc="한 스텝이 N 개 하위 실행으로 분기.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      <Section
+        id="fanout"
+        title="Fan-out"
+        desc="한 스텝이 N 개 하위 실행으로 분기할 때 엣지 중앙에 fan-out 배지로 표현합니다."
+      >
+        <div style={{ height: 360 }}>
+          <PipelineGraph
+            nodes={WITH_FANOUT.nodes}
+            edges={WITH_FANOUT.edges}
+            height="100%"
+          />
+        </div>
       </Section>
 
-      <Section id="status" title="Status palette" desc="6 종 실행 상태와 running pulse 애니메이션.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      <Section
+        id="status"
+        title="Status palette"
+        desc="6 종 실행 상태. running 은 pulse 애니메이션으로 진행 중임을 표시합니다."
+      >
+        <div style={{ height: 260 }}>
+          <PipelineGraph
+            nodes={MIXED_STATUS.nodes}
+            edges={MIXED_STATUS.edges}
+            direction="LR"
+            height="100%"
+          />
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 12 }}>
+          {STATUS_LEGEND.map((s) => (
+            <div
+              key={s.status}
+              style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12 }}
+            >
+              <span
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: 2,
+                  background: s.color,
+                  display: "inline-block",
+                }}
+              />
+              <span className="text-gray-600">{s.label}</span>
+            </div>
+          ))}
+        </div>
       </Section>
 
-      <Section id="controlled" title="Controlled" desc="외부 state 로 selection 제어.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      <Section
+        id="controlled"
+        title="Controlled"
+        desc="외부 state 로 selection 을 제어합니다. 버튼으로 선택을 바꾸고 캔버스 클릭으로도 갱신됩니다."
+      >
+        <ControlledDemo />
       </Section>
 
-      <Section id="inspector" title="Inspector" desc="우측/하단/숨김 및 탭 구성.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      <Section
+        id="inspector"
+        title="Inspector"
+        desc="선택된 노드의 input / output / internal / logs / timing / error 를 탭으로 표시합니다."
+      >
+        <InspectorDemo />
       </Section>
 
       <Section id="custom-node" title="Custom node render" desc="renderNode 로 카드 완전 대체.">

--- a/demo/src/pages/PipelineGraphPage.tsx
+++ b/demo/src/pages/PipelineGraphPage.tsx
@@ -206,6 +206,8 @@ const STATUS_LEGEND: Array<{ status: PipelineNodeStatus; color: string; label: s
   { status: "cancelled", color: "#f59e0b", label: "cancelled" },
 ];
 
+const LARGE = makeLarge(200);
+
 // ── 섹션 공통 ──────────────────────────────────────────────────────────────
 
 function Section({
@@ -276,6 +278,41 @@ function ControlledDemo() {
     </div>
   );
 }
+
+const THUMBNAIL_SVG =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 64">
+      <defs>
+        <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stop-color="#60a5fa"/>
+          <stop offset="1" stop-color="#a78bfa"/>
+        </linearGradient>
+      </defs>
+      <rect width="120" height="64" fill="url(#g)"/>
+      <circle cx="36" cy="32" r="14" fill="#fff" opacity="0.6"/>
+      <rect x="56" y="20" width="46" height="6" rx="3" fill="#fff" opacity="0.8"/>
+      <rect x="56" y="32" width="36" height="4" rx="2" fill="#fff" opacity="0.55"/>
+      <rect x="56" y="42" width="28" height="4" rx="2" fill="#fff" opacity="0.4"/>
+    </svg>`,
+  );
+
+const CUSTOM_NODE_DEMO: { nodes: PipelineNode[]; edges: PipelineEdge[] } = {
+  nodes: [
+    { id: "decode", label: "Decode", status: "success" },
+    {
+      id: "render-frame",
+      label: "Render Frame",
+      status: "success",
+      output: { dataUrl: THUMBNAIL_SVG },
+    },
+    { id: "encode", label: "Encode", status: "running" },
+  ],
+  edges: [
+    { from: "decode", to: "render-frame" },
+    { from: "render-frame", to: "encode" },
+  ],
+};
 
 function InspectorDemo() {
   const [pos, setPos] = useState<"right" | "bottom" | "none">("right");
@@ -469,16 +506,84 @@ export function PipelineGraphPage() {
         <InspectorDemo />
       </Section>
 
-      <Section id="custom-node" title="Custom node render" desc="renderNode 로 카드 완전 대체.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      <Section
+        id="custom-node"
+        title="Custom node render"
+        desc="기본 카드를 완전히 대체하려면 renderNode prop 을 사용하세요. undefined 를 반환하면 기본 카드로 fallback 됩니다."
+      >
+        <div style={{ height: 260 }}>
+          <PipelineGraph
+            nodes={CUSTOM_NODE_DEMO.nodes}
+            edges={CUSTOM_NODE_DEMO.edges}
+            height="100%"
+            renderNode={(n) => {
+              if (n.id !== "render-frame") return undefined;
+              const src = (n.output as { dataUrl?: string } | undefined)?.dataUrl;
+              if (!src) return undefined;
+              return (
+                <div
+                  style={{
+                    width: "100%",
+                    height: "100%",
+                    padding: 6,
+                    boxSizing: "border-box",
+                  }}
+                >
+                  <img
+                    src={src}
+                    alt={n.label}
+                    style={{
+                      width: "100%",
+                      height: "100%",
+                      objectFit: "cover",
+                      borderRadius: 4,
+                      display: "block",
+                    }}
+                  />
+                </div>
+              );
+            }}
+          />
+        </div>
       </Section>
 
-      <Section id="dark" title="Dark theme" desc="theme=dark.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      <Section
+        id="dark"
+        title="Dark theme"
+        desc="theme prop 으로 라이트/다크 전환. 캔버스·카드·엣지·인스펙터 모두 어두운 톤으로 일관됩니다."
+      >
+        <div
+          style={{
+            padding: 12,
+            background: "#0f172a",
+            borderRadius: 10,
+          }}
+        >
+          <div style={{ height: 440 }}>
+            <PipelineGraph
+              nodes={WITH_LOOP.nodes}
+              edges={WITH_LOOP.edges}
+              theme="dark"
+              defaultExpansion={["train"]}
+              height="100%"
+            />
+          </div>
+        </div>
       </Section>
 
-      <Section id="large" title="Large graph" desc="200 노드 — 팬/줌 + fit 으로 탐색.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      <Section
+        id="large"
+        title="Large graph"
+        desc="200 노드 격자 그래프. 팬·줌으로 탐색하고 우하단 ⊙ (또는 키보드 0) 로 전체 보기로 돌아옵니다."
+      >
+        <div style={{ height: 640 }}>
+          <PipelineGraph
+            nodes={LARGE.nodes}
+            edges={LARGE.edges}
+            inspector={{ position: "none" }}
+            height="100%"
+          />
+        </div>
       </Section>
 
       <Section id="props" title="Props" desc="전체 prop 레퍼런스.">

--- a/demo/src/pages/PipelineGraphPage.tsx
+++ b/demo/src/pages/PipelineGraphPage.tsx
@@ -506,6 +506,20 @@ function Playground() {
     () => ({ position: inspectorPos }),
     [inspectorPos],
   );
+  const autoExpand = useMemo(
+    () =>
+      data.nodes
+        .filter((n) => n.kind === "group" || n.kind === "loop")
+        .map((n) => n.id),
+    [data],
+  );
+  const hasParallelRank = useMemo(() => {
+    const outDeg = new Map<string, number>();
+    for (const e of data.edges) outDeg.set(e.from, (outDeg.get(e.from) ?? 0) + 1);
+    for (const v of outDeg.values()) if (v > 1) return true;
+    return false;
+  }, [data]);
+  const hasCluster = autoExpand.length > 0;
 
   return (
     <div
@@ -585,6 +599,17 @@ function Playground() {
             onChange={(e) => setNodeSep(Number(e.target.value))}
             className="w-full"
           />
+          <p
+            style={{
+              marginTop: 4,
+              fontSize: 10,
+              color: hasParallelRank ? "#9ca3af" : "#f59e0b",
+            }}
+          >
+            {hasParallelRank
+              ? "같은 rank 노드 간 간격 (현재 preset 에서 효과 있음)"
+              : "현재 preset 은 선형이라 효과가 없음 — large-50/200 로 시도"}
+          </p>
         </Field>
 
         <Field label={`clusterPadding = ${clusterPadding}`}>
@@ -597,6 +622,17 @@ function Playground() {
             onChange={(e) => setClusterPadding(Number(e.target.value))}
             className="w-full"
           />
+          <p
+            style={{
+              marginTop: 4,
+              fontSize: 10,
+              color: hasCluster ? "#9ca3af" : "#f59e0b",
+            }}
+          >
+            {hasCluster
+              ? "expanded cluster 내부 패딩 (자동 펼침 적용됨)"
+              : "현재 preset 에 group/loop 없음 — with-group/with-loop 로 시도"}
+          </p>
         </Field>
 
         <Field label="Theme">
@@ -659,6 +695,7 @@ function Playground() {
       <main style={{ height: "70vh" }}>
         <LazyMount>
           <PipelineGraph
+            key={preset}
             nodes={data.nodes}
             edges={data.edges}
             direction={direction}
@@ -668,6 +705,7 @@ function Playground() {
             theme={theme}
             inspector={inspector}
             interactive={interactive}
+            defaultExpansion={autoExpand}
             height="100%"
           />
         </LazyMount>

--- a/demo/src/pages/PipelineGraphPage.tsx
+++ b/demo/src/pages/PipelineGraphPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { CodeView, PipelineGraph } from "plastic";
 import type {
   PipelineEdge,
@@ -308,6 +308,41 @@ function Section({
   );
 }
 
+function LazyMount({ children }: { children: React.ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    if (mounted) return;
+    const el = ref.current;
+    if (!el) return;
+    if (typeof IntersectionObserver === "undefined") {
+      setMounted(true);
+      return;
+    }
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            setMounted(true);
+            obs.disconnect();
+            break;
+          }
+        }
+      },
+      { rootMargin: "600px" },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [mounted]);
+
+  return (
+    <div ref={ref} style={{ width: "100%", height: "100%" }}>
+      {mounted ? children : null}
+    </div>
+  );
+}
+
 // ── 페이지 ─────────────────────────────────────────────────────────────────
 
 function ControlledDemo() {
@@ -343,13 +378,15 @@ function ControlledDemo() {
         </span>
       </div>
       <div style={{ height: 380 }}>
-        <PipelineGraph
-          nodes={BASIC.nodes}
-          edges={BASIC.edges}
-          selection={sel}
-          onSelectionChange={setSel}
-          height="100%"
-        />
+        <LazyMount>
+          <PipelineGraph
+            nodes={BASIC.nodes}
+            edges={BASIC.edges}
+            selection={sel}
+            onSelectionChange={setSel}
+            height="100%"
+          />
+        </LazyMount>
       </div>
     </div>
   );
@@ -413,13 +450,15 @@ function InspectorDemo() {
         ))}
       </div>
       <div style={{ height: 440 }}>
-        <PipelineGraph
-          nodes={INSPECTOR_DEMO.nodes}
-          edges={INSPECTOR_DEMO.edges}
-          inspector={cfg}
-          defaultSelection="transform"
-          height="100%"
-        />
+        <LazyMount>
+          <PipelineGraph
+            nodes={INSPECTOR_DEMO.nodes}
+            edges={INSPECTOR_DEMO.edges}
+            inspector={cfg}
+            defaultSelection="transform"
+            height="100%"
+          />
+        </LazyMount>
       </div>
       <p className="text-xs text-gray-400 mt-2">
         Load / Transform 선택 시 Output 탭이 기본 노출됩니다. Model (failed) 선택 시 Error 탭이 자동 활성화됩니다.
@@ -618,18 +657,20 @@ function Playground() {
       </aside>
 
       <main style={{ height: "70vh" }}>
-        <PipelineGraph
-          nodes={data.nodes}
-          edges={data.edges}
-          direction={direction}
-          rankSep={rankSep}
-          nodeSep={nodeSep}
-          clusterPadding={clusterPadding}
-          theme={theme}
-          inspector={inspector}
-          interactive={interactive}
-          height="100%"
-        />
+        <LazyMount>
+          <PipelineGraph
+            nodes={data.nodes}
+            edges={data.edges}
+            direction={direction}
+            rankSep={rankSep}
+            nodeSep={nodeSep}
+            clusterPadding={clusterPadding}
+            theme={theme}
+            inspector={inspector}
+            interactive={interactive}
+            height="100%"
+          />
+        </LazyMount>
       </main>
     </div>
   );
@@ -660,7 +701,9 @@ export function PipelineGraphPage() {
 
       <Section id="basic" title="Basic" desc="가장 단순한 4 스텝 직렬 파이프라인.">
         <div style={{ height: 360 }}>
-          <PipelineGraph nodes={BASIC.nodes} edges={BASIC.edges} height="100%" />
+          <LazyMount>
+            <PipelineGraph nodes={BASIC.nodes} edges={BASIC.edges} height="100%" />
+          </LazyMount>
         </div>
       </Section>
 
@@ -673,23 +716,27 @@ export function PipelineGraphPage() {
           <div style={{ flex: 1 }}>
             <p className="text-xs text-gray-400 mb-1">LR</p>
             <div style={{ height: 320 }}>
-              <PipelineGraph
-                nodes={BASIC.nodes}
-                edges={BASIC.edges}
-                direction="LR"
-                height="100%"
-              />
+              <LazyMount>
+                <PipelineGraph
+                  nodes={BASIC.nodes}
+                  edges={BASIC.edges}
+                  direction="LR"
+                  height="100%"
+                />
+              </LazyMount>
             </div>
           </div>
           <div style={{ flex: 1 }}>
             <p className="text-xs text-gray-400 mb-1">TB</p>
             <div style={{ height: 320 }}>
-              <PipelineGraph
-                nodes={BASIC.nodes}
-                edges={BASIC.edges}
-                direction="TB"
-                height="100%"
-              />
+              <LazyMount>
+                <PipelineGraph
+                  nodes={BASIC.nodes}
+                  edges={BASIC.edges}
+                  direction="TB"
+                  height="100%"
+                />
+              </LazyMount>
             </div>
           </div>
         </div>
@@ -701,12 +748,14 @@ export function PipelineGraphPage() {
         desc="group 카드의 ▸ 를 눌러 내부 스텝을 펼칠 수 있습니다. 펼쳐진 카드는 점선 클러스터로 감싸집니다."
       >
         <div style={{ height: 420 }}>
-          <PipelineGraph
-            nodes={WITH_GROUP.nodes}
-            edges={WITH_GROUP.edges}
-            defaultExpansion={["validate"]}
-            height="100%"
-          />
+          <LazyMount>
+            <PipelineGraph
+              nodes={WITH_GROUP.nodes}
+              edges={WITH_GROUP.edges}
+              defaultExpansion={["validate"]}
+              height="100%"
+            />
+          </LazyMount>
         </div>
       </Section>
 
@@ -719,22 +768,26 @@ export function PipelineGraphPage() {
           <div style={{ flex: 1 }}>
             <p className="text-xs text-gray-400 mb-1">Collapsed</p>
             <div style={{ height: 360 }}>
-              <PipelineGraph
-                nodes={WITH_LOOP.nodes}
-                edges={WITH_LOOP.edges}
-                height="100%"
-              />
+              <LazyMount>
+                <PipelineGraph
+                  nodes={WITH_LOOP.nodes}
+                  edges={WITH_LOOP.edges}
+                  height="100%"
+                />
+              </LazyMount>
             </div>
           </div>
           <div style={{ flex: 1 }}>
             <p className="text-xs text-gray-400 mb-1">Expanded</p>
             <div style={{ height: 360 }}>
-              <PipelineGraph
-                nodes={WITH_LOOP.nodes}
-                edges={WITH_LOOP.edges}
-                defaultExpansion={["train"]}
-                height="100%"
-              />
+              <LazyMount>
+                <PipelineGraph
+                  nodes={WITH_LOOP.nodes}
+                  edges={WITH_LOOP.edges}
+                  defaultExpansion={["train"]}
+                  height="100%"
+                />
+              </LazyMount>
             </div>
           </div>
         </div>
@@ -746,11 +799,13 @@ export function PipelineGraphPage() {
         desc="한 스텝이 N 개 하위 실행으로 분기할 때 엣지 중앙에 fan-out 배지로 표현합니다."
       >
         <div style={{ height: 360 }}>
-          <PipelineGraph
-            nodes={WITH_FANOUT.nodes}
-            edges={WITH_FANOUT.edges}
-            height="100%"
-          />
+          <LazyMount>
+            <PipelineGraph
+              nodes={WITH_FANOUT.nodes}
+              edges={WITH_FANOUT.edges}
+              height="100%"
+            />
+          </LazyMount>
         </div>
       </Section>
 
@@ -760,12 +815,14 @@ export function PipelineGraphPage() {
         desc="6 종 실행 상태. running 은 pulse 애니메이션으로 진행 중임을 표시합니다."
       >
         <div style={{ height: 260 }}>
-          <PipelineGraph
-            nodes={MIXED_STATUS.nodes}
-            edges={MIXED_STATUS.edges}
-            direction="LR"
-            height="100%"
-          />
+          <LazyMount>
+            <PipelineGraph
+              nodes={MIXED_STATUS.nodes}
+              edges={MIXED_STATUS.edges}
+              direction="LR"
+              height="100%"
+            />
+          </LazyMount>
         </div>
         <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 12 }}>
           {STATUS_LEGEND.map((s) => (
@@ -810,38 +867,40 @@ export function PipelineGraphPage() {
         desc="기본 카드를 완전히 대체하려면 renderNode prop 을 사용하세요. undefined 를 반환하면 기본 카드로 fallback 됩니다."
       >
         <div style={{ height: 260 }}>
-          <PipelineGraph
-            nodes={CUSTOM_NODE_DEMO.nodes}
-            edges={CUSTOM_NODE_DEMO.edges}
-            height="100%"
-            renderNode={(n) => {
-              if (n.id !== "render-frame") return undefined;
-              const src = (n.output as { dataUrl?: string } | undefined)?.dataUrl;
-              if (!src) return undefined;
-              return (
-                <div
-                  style={{
-                    width: "100%",
-                    height: "100%",
-                    padding: 6,
-                    boxSizing: "border-box",
-                  }}
-                >
-                  <img
-                    src={src}
-                    alt={n.label}
+          <LazyMount>
+            <PipelineGraph
+              nodes={CUSTOM_NODE_DEMO.nodes}
+              edges={CUSTOM_NODE_DEMO.edges}
+              height="100%"
+              renderNode={(n) => {
+                if (n.id !== "render-frame") return undefined;
+                const src = (n.output as { dataUrl?: string } | undefined)?.dataUrl;
+                if (!src) return undefined;
+                return (
+                  <div
                     style={{
                       width: "100%",
                       height: "100%",
-                      objectFit: "cover",
-                      borderRadius: 4,
-                      display: "block",
+                      padding: 6,
+                      boxSizing: "border-box",
                     }}
-                  />
-                </div>
-              );
-            }}
-          />
+                  >
+                    <img
+                      src={src}
+                      alt={n.label}
+                      style={{
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                        borderRadius: 4,
+                        display: "block",
+                      }}
+                    />
+                  </div>
+                );
+              }}
+            />
+          </LazyMount>
         </div>
       </Section>
 
@@ -858,13 +917,15 @@ export function PipelineGraphPage() {
           }}
         >
           <div style={{ height: 440 }}>
-            <PipelineGraph
-              nodes={WITH_LOOP.nodes}
-              edges={WITH_LOOP.edges}
-              theme="dark"
-              defaultExpansion={["train"]}
-              height="100%"
-            />
+            <LazyMount>
+              <PipelineGraph
+                nodes={WITH_LOOP.nodes}
+                edges={WITH_LOOP.edges}
+                theme="dark"
+                defaultExpansion={["train"]}
+                height="100%"
+              />
+            </LazyMount>
           </div>
         </div>
       </Section>
@@ -875,12 +936,14 @@ export function PipelineGraphPage() {
         desc="200 노드 격자 그래프. 팬·줌으로 탐색하고 우하단 ⊙ (또는 키보드 0) 로 전체 보기로 돌아옵니다."
       >
         <div style={{ height: 640 }}>
-          <PipelineGraph
-            nodes={LARGE.nodes}
-            edges={LARGE.edges}
-            inspector={{ position: "none" }}
-            height="100%"
-          />
+          <LazyMount>
+            <PipelineGraph
+              nodes={LARGE.nodes}
+              edges={LARGE.edges}
+              inspector={{ position: "none" }}
+              height="100%"
+            />
+          </LazyMount>
         </div>
       </Section>
 

--- a/demo/src/pages/PipelineGraphPage.tsx
+++ b/demo/src/pages/PipelineGraphPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { PipelineGraph } from "plastic";
+import { CodeView, PipelineGraph } from "plastic";
 import type {
   PipelineEdge,
   PipelineGraphInspectorConfig,
@@ -207,6 +207,80 @@ const STATUS_LEGEND: Array<{ status: PipelineNodeStatus; color: string; label: s
 ];
 
 const LARGE = makeLarge(200);
+
+const PROPS_ROWS: Array<[string, string, string, string]> = [
+  ["nodes", "PipelineNode[]", "—", "파이프라인 노드 배열 (필수)"],
+  ["edges", "PipelineEdge[]", "—", "노드 간 연결 (필수)"],
+  ["direction", '"LR" | "TB"', '"LR"', "Dagre 레이아웃 방향"],
+  ["rankSep", "number", "96", "Dagre rank 간 간격"],
+  ["nodeSep", "number", "48", "동일 rank 내 노드 간격"],
+  ["clusterPadding", "number", "24", "group/loop 클러스터 내부 패딩"],
+  ["selection", "string | null", "—", "Controlled 선택 id"],
+  ["defaultSelection", "string | null", "null", "초기 선택 (uncontrolled)"],
+  ["onSelectionChange", "(id) => void", "—", "선택 변경 콜백"],
+  ["expansion", "string[]", "—", "Controlled 펼침 id 집합"],
+  ["defaultExpansion", "string[]", "[]", "초기 펼침 (uncontrolled)"],
+  ["onExpansionChange", "(ids) => void", "—", "펼침 변경 콜백"],
+  ["viewport", "{x,y,zoom}", "—", "Controlled 뷰포트"],
+  ["defaultViewport", "{x,y,zoom}", "fit", "초기 뷰포트 (미지정 시 fit)"],
+  ["onViewportChange", "(vp) => void", "—", "뷰포트 변경 콜백"],
+  [
+    "inspector",
+    "{ position?, defaultSize?, defaultTab?, tabs? }",
+    "{position:\"right\"}",
+    "인스펙터 설정",
+  ],
+  ["renderInspectorValue", "(node, tab, v) => ReactNode", "—", "탭 값 커스텀 렌더"],
+  ["renderNode", "(node, ctx) => ReactNode", "—", "카드 커스텀 렌더"],
+  ["renderEdgeTooltip", "(edge) => ReactNode", "—", "엣지 hover 툴팁 커스텀"],
+  ["onNodeDoubleClick", "(node) => void", "—", "노드 더블클릭 콜백"],
+  ["theme", '"light" | "dark"', '"light"', "색상 테마"],
+  ["width", "number | string", '"100%"', "컨테이너 너비"],
+  ["height", "number | string", '"70vh"', "컨테이너 높이"],
+  ["interactive", "boolean", "true", "팬/줌/선택 활성"],
+  ["className", "string", "—", "추가 className"],
+];
+
+const USAGE_MIN = `import { PipelineGraph } from "plastic";
+
+const NODES = [
+  { id: "a", label: "Load", status: "success" },
+  { id: "b", label: "Run",  status: "running" },
+];
+const EDGES = [{ from: "a", to: "b" }];
+
+<PipelineGraph nodes={NODES} edges={EDGES} />`;
+
+const USAGE_CONTROLLED = `const [sel, setSel] = useState<string | null>(null);
+
+<PipelineGraph
+  nodes={NODES}
+  edges={EDGES}
+  selection={sel}
+  onSelectionChange={setSel}
+/>`;
+
+const USAGE_INSPECTOR = `<PipelineGraph
+  nodes={NODES}
+  edges={EDGES}
+  renderInspectorValue={(n, tab, v) => {
+    if (tab === "output" && v instanceof Uint8Array) {
+      return <ImagePreview bytes={v} />;
+    }
+    return undefined; // fallback: 기본 JSON 렌더
+  }}
+/>`;
+
+const USAGE_LIVE = `const [nodes, setNodes] = useState<PipelineNode[]>(INITIAL);
+
+useEffect(() => {
+  const t = setInterval(() => {
+    setNodes((prev) => simulateTick(prev));
+  }, 500);
+  return () => clearInterval(t);
+}, []);
+
+<PipelineGraph nodes={nodes} edges={EDGES} />`;
 
 // ── 섹션 공통 ──────────────────────────────────────────────────────────────
 
@@ -587,11 +661,61 @@ export function PipelineGraphPage() {
       </Section>
 
       <Section id="props" title="Props" desc="전체 prop 레퍼런스.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                {["Prop", "Type", "Default", "Description"].map((h) => (
+                  <th
+                    key={h}
+                    className="text-left px-4 py-2.5 text-xs font-semibold text-gray-500"
+                  >
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {PROPS_ROWS.map(([name, type, def, desc]) => (
+                <tr key={name}>
+                  <td className="px-4 py-2.5 font-mono text-xs text-gray-800">{name}</td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-gray-500">{type}</td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-gray-500">{def}</td>
+                  <td className="px-4 py-2.5 text-gray-600">{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </Section>
 
       <Section id="usage" title="Usage" desc="자주 쓰는 패턴 스니펫.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+        <div className="space-y-5">
+          <div>
+            <p className="text-sm text-gray-500 mb-2">
+              1) 최소 예시 — nodes / edges 만으로 동작합니다.
+            </p>
+            <CodeView code={USAGE_MIN} language="tsx" />
+          </div>
+          <div>
+            <p className="text-sm text-gray-500 mb-2">
+              2) Controlled selection — 외부 state 로 선택 동기화.
+            </p>
+            <CodeView code={USAGE_CONTROLLED} language="tsx" />
+          </div>
+          <div>
+            <p className="text-sm text-gray-500 mb-2">
+              3) 인스펙터 탭 커스텀 — 바이너리 · 이미지 등을 특수 렌더.
+            </p>
+            <CodeView code={USAGE_INSPECTOR} language="tsx" />
+          </div>
+          <div>
+            <p className="text-sm text-gray-500 mb-2">
+              4) 실시간 업데이트 — setInterval 로 node 상태를 스트리밍.
+            </p>
+            <CodeView code={USAGE_LIVE} language="tsx" />
+          </div>
+        </div>
       </Section>
 
       <Section id="playground" title="Playground" desc="실시간 prop 토글.">

--- a/demo/src/pages/PipelineGraphPage.tsx
+++ b/demo/src/pages/PipelineGraphPage.tsx
@@ -1,0 +1,241 @@
+import { PipelineGraph } from "plastic";
+import type { PipelineEdge, PipelineNode } from "plastic";
+
+// ── 샘플 데이터 ────────────────────────────────────────────────────────────
+
+const now = Date.now();
+
+export const BASIC: { nodes: PipelineNode[]; edges: PipelineEdge[] } = {
+  nodes: [
+    {
+      id: "ingest",
+      label: "Ingest",
+      status: "success",
+      timing: { startedAt: now - 60_000, endedAt: now - 50_000 },
+    },
+    {
+      id: "clean",
+      label: "Clean",
+      status: "success",
+      timing: { startedAt: now - 50_000, endedAt: now - 30_000 },
+    },
+    {
+      id: "analyze",
+      label: "Analyze",
+      status: "running",
+      timing: { startedAt: now - 30_000 },
+    },
+    { id: "export", label: "Export", status: "pending" },
+  ],
+  edges: [
+    { from: "ingest", to: "clean" },
+    { from: "clean", to: "analyze" },
+    { from: "analyze", to: "export" },
+  ],
+};
+
+export const WITH_GROUP: { nodes: PipelineNode[]; edges: PipelineEdge[] } = {
+  nodes: [
+    { id: "load", label: "Load", status: "success" },
+    {
+      id: "validate",
+      label: "Validate",
+      kind: "group",
+      status: "success",
+      children: ["v.schema", "v.bounds", "v.types"],
+    },
+    { id: "v.schema", label: "Schema", status: "success", parent: "validate" },
+    { id: "v.bounds", label: "Bounds", status: "success", parent: "validate" },
+    { id: "v.types", label: "Types", status: "success", parent: "validate" },
+    { id: "transform", label: "Transform", status: "running" },
+  ],
+  edges: [
+    { from: "load", to: "validate" },
+    { from: "validate", to: "transform" },
+    { from: "v.schema", to: "v.bounds" },
+    { from: "v.bounds", to: "v.types" },
+  ],
+};
+
+export const WITH_LOOP: { nodes: PipelineNode[]; edges: PipelineEdge[] } = {
+  nodes: [
+    { id: "prep", label: "Prepare batch", status: "success" },
+    {
+      id: "train",
+      label: "Train epoch",
+      kind: "loop",
+      status: "running",
+      iterations: 10,
+      currentIteration: 4,
+      children: ["t.fwd", "t.loss", "t.bwd"],
+    },
+    { id: "t.fwd", label: "Forward", status: "success", parent: "train" },
+    { id: "t.loss", label: "Loss", status: "running", parent: "train" },
+    { id: "t.bwd", label: "Backward", status: "pending", parent: "train" },
+    { id: "eval", label: "Evaluate", status: "pending" },
+  ],
+  edges: [
+    { from: "prep", to: "train" },
+    { from: "train", to: "eval" },
+    { from: "t.fwd", to: "t.loss" },
+    { from: "t.loss", to: "t.bwd" },
+  ],
+};
+
+export const WITH_FANOUT: { nodes: PipelineNode[]; edges: PipelineEdge[] } = {
+  nodes: [
+    { id: "load", label: "Load", status: "success" },
+    { id: "train", label: "Train", status: "success" },
+    { id: "eval", label: "Evaluate", status: "running" },
+    { id: "report", label: "Report", status: "pending" },
+  ],
+  edges: [
+    { from: "load", to: "train" },
+    {
+      from: "train",
+      to: "eval",
+      fanOut: { count: 10, label: "per-epoch metrics" },
+    },
+    { from: "eval", to: "report" },
+  ],
+};
+
+export const MIXED_STATUS: { nodes: PipelineNode[]; edges: PipelineEdge[] } = {
+  nodes: [
+    { id: "s1", label: "Success", status: "success" },
+    { id: "s2", label: "Running", status: "running" },
+    { id: "s3", label: "Pending", status: "pending" },
+    { id: "s4", label: "Failed", status: "failed" },
+    { id: "s5", label: "Skipped", status: "skipped" },
+    { id: "s6", label: "Cancelled", status: "cancelled" },
+  ],
+  edges: [
+    { from: "s1", to: "s2" },
+    { from: "s2", to: "s3" },
+    { from: "s3", to: "s4" },
+    { from: "s4", to: "s5" },
+    { from: "s5", to: "s6" },
+  ],
+};
+
+export function makeLarge(n: number): {
+  nodes: PipelineNode[];
+  edges: PipelineEdge[];
+} {
+  const COLS = 10;
+  const statuses: PipelineNode["status"][] = [
+    "success",
+    "success",
+    "success",
+    "running",
+    "pending",
+  ];
+  const nodes: PipelineNode[] = [];
+  const edges: PipelineEdge[] = [];
+  for (let i = 0; i < n; i++) {
+    nodes.push({
+      id: `n${i}`,
+      label: `Step ${i}`,
+      status: statuses[i % statuses.length],
+    });
+    const col = i % COLS;
+    if (col > 0) edges.push({ from: `n${i - 1}`, to: `n${i}` });
+    if (i >= COLS) edges.push({ from: `n${i - COLS}`, to: `n${i}` });
+  }
+  return { nodes, edges };
+}
+
+// ── 섹션 공통 ──────────────────────────────────────────────────────────────
+
+function Section({
+  id,
+  title,
+  desc,
+  children,
+}: {
+  id?: string;
+  title: string;
+  desc?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="mb-10">
+      <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-2">
+        {title}
+      </p>
+      {desc && <p className="text-sm text-gray-500 mb-3">{desc}</p>}
+      {children}
+    </section>
+  );
+}
+
+// ── 페이지 ─────────────────────────────────────────────────────────────────
+
+export function PipelineGraphPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-1">PipelineGraph</h1>
+      <p className="text-sm text-gray-500 mb-8">
+        스텝 기반 파이프라인을 DAG 로 시각화. 실행 상태·타이밍·profiling 데이터 인스펙션 지원.
+      </p>
+
+      <Section id="basic" title="Basic" desc="가장 단순한 4 스텝 직렬 파이프라인.">
+        <div style={{ height: 360 }}>
+          <PipelineGraph nodes={BASIC.nodes} edges={BASIC.edges} height="100%" />
+        </div>
+      </Section>
+
+      <Section id="direction" title="Direction" desc="LR / TB 레이아웃 비교.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+
+      <Section id="grouping" title="Grouping" desc="group 카드를 펼쳐 내부 스텝을 관찰.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+
+      <Section id="loop" title="Loop" desc="3D 스택 + 진행률 바 + 펼치기.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+
+      <Section id="fanout" title="Fan-out" desc="한 스텝이 N 개 하위 실행으로 분기.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+
+      <Section id="status" title="Status palette" desc="6 종 실행 상태와 running pulse 애니메이션.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+
+      <Section id="controlled" title="Controlled" desc="외부 state 로 selection 제어.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+
+      <Section id="inspector" title="Inspector" desc="우측/하단/숨김 및 탭 구성.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+
+      <Section id="custom-node" title="Custom node render" desc="renderNode 로 카드 완전 대체.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+
+      <Section id="dark" title="Dark theme" desc="theme=dark.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+
+      <Section id="large" title="Large graph" desc="200 노드 — 팬/줌 + fit 으로 탐색.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+
+      <Section id="props" title="Props" desc="전체 prop 레퍼런스.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+
+      <Section id="usage" title="Usage" desc="자주 쓰는 패턴 스니펫.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+
+      <Section id="playground" title="Playground" desc="실시간 prop 토글.">
+        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      </Section>
+    </div>
+  );
+}

--- a/demo/src/pages/PipelineGraphPage.tsx
+++ b/demo/src/pages/PipelineGraphPage.tsx
@@ -1,8 +1,10 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { CodeView, PipelineGraph } from "plastic";
 import type {
   PipelineEdge,
+  PipelineGraphDirection,
   PipelineGraphInspectorConfig,
+  PipelineGraphTheme,
   PipelineNode,
   PipelineNodeStatus,
 } from "plastic";
@@ -426,6 +428,228 @@ function InspectorDemo() {
   );
 }
 
+type PlaygroundPreset =
+  | "basic"
+  | "with-group"
+  | "with-loop"
+  | "with-fanout"
+  | "mixed-status"
+  | "large-50"
+  | "large-200";
+
+const PLAYGROUND_PRESETS: Record<
+  PlaygroundPreset,
+  { nodes: PipelineNode[]; edges: PipelineEdge[] }
+> = {
+  basic: BASIC,
+  "with-group": WITH_GROUP,
+  "with-loop": WITH_LOOP,
+  "with-fanout": WITH_FANOUT,
+  "mixed-status": MIXED_STATUS,
+  "large-50": makeLarge(50),
+  "large-200": LARGE,
+};
+
+function Playground() {
+  const [preset, setPreset] = useState<PlaygroundPreset>("basic");
+  const [direction, setDirection] = useState<PipelineGraphDirection>("LR");
+  const [rankSep, setRankSep] = useState<number>(96);
+  const [nodeSep, setNodeSep] = useState<number>(48);
+  const [clusterPadding, setClusterPadding] = useState<number>(24);
+  const [theme, setTheme] = useState<PipelineGraphTheme>("light");
+  const [inspectorPos, setInspectorPos] = useState<"right" | "bottom" | "none">(
+    "right",
+  );
+  const [interactive, setInteractive] = useState<boolean>(true);
+
+  const data = PLAYGROUND_PRESETS[preset];
+  const inspector = useMemo<PipelineGraphInspectorConfig>(
+    () => ({ position: inspectorPos }),
+    [inspectorPos],
+  );
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "280px 1fr",
+        gap: 12,
+      }}
+    >
+      <aside
+        style={{
+          border: "1px solid #e5e7eb",
+          borderRadius: 8,
+          padding: 14,
+          background: "#fafafa",
+          display: "flex",
+          flexDirection: "column",
+          gap: 14,
+          fontSize: 12,
+        }}
+      >
+        <Field label="Preset">
+          <select
+            value={preset}
+            onChange={(e) => setPreset(e.target.value as PlaygroundPreset)}
+            className="w-full px-2 py-1 text-xs rounded border border-gray-300 bg-white"
+          >
+            <option value="basic">basic (4)</option>
+            <option value="with-group">with-group</option>
+            <option value="with-loop">with-loop</option>
+            <option value="with-fanout">with-fanout</option>
+            <option value="mixed-status">mixed-status</option>
+            <option value="large-50">large-50</option>
+            <option value="large-200">large-200</option>
+          </select>
+        </Field>
+
+        <Field label="Direction">
+          <div style={{ display: "flex", gap: 8 }}>
+            {(["LR", "TB"] as const).map((d) => (
+              <label
+                key={d}
+                style={{ display: "flex", alignItems: "center", gap: 4 }}
+              >
+                <input
+                  type="radio"
+                  name="pg-direction"
+                  value={d}
+                  checked={direction === d}
+                  onChange={() => setDirection(d)}
+                />
+                {d}
+              </label>
+            ))}
+          </div>
+        </Field>
+
+        <Field label={`rankSep = ${rankSep}`}>
+          <input
+            type="range"
+            min={32}
+            max={160}
+            step={2}
+            value={rankSep}
+            onChange={(e) => setRankSep(Number(e.target.value))}
+            className="w-full"
+          />
+        </Field>
+
+        <Field label={`nodeSep = ${nodeSep}`}>
+          <input
+            type="range"
+            min={16}
+            max={96}
+            step={2}
+            value={nodeSep}
+            onChange={(e) => setNodeSep(Number(e.target.value))}
+            className="w-full"
+          />
+        </Field>
+
+        <Field label={`clusterPadding = ${clusterPadding}`}>
+          <input
+            type="range"
+            min={8}
+            max={48}
+            step={1}
+            value={clusterPadding}
+            onChange={(e) => setClusterPadding(Number(e.target.value))}
+            className="w-full"
+          />
+        </Field>
+
+        <Field label="Theme">
+          <div style={{ display: "flex", gap: 8 }}>
+            {(["light", "dark"] as const).map((t) => (
+              <label
+                key={t}
+                style={{ display: "flex", alignItems: "center", gap: 4 }}
+              >
+                <input
+                  type="radio"
+                  name="pg-theme"
+                  value={t}
+                  checked={theme === t}
+                  onChange={() => setTheme(t)}
+                />
+                {t}
+              </label>
+            ))}
+          </div>
+        </Field>
+
+        <Field label="Inspector position">
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            {(["right", "bottom", "none"] as const).map((p) => (
+              <label
+                key={p}
+                style={{ display: "flex", alignItems: "center", gap: 4 }}
+              >
+                <input
+                  type="radio"
+                  name="pg-inspector"
+                  value={p}
+                  checked={inspectorPos === p}
+                  onChange={() => setInspectorPos(p)}
+                />
+                {p}
+              </label>
+            ))}
+          </div>
+        </Field>
+
+        <Field label="Interactive">
+          <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <input
+              type="checkbox"
+              checked={interactive}
+              onChange={(e) => setInteractive(e.target.checked)}
+            />
+            팬/줌/선택 활성
+          </label>
+        </Field>
+
+        <p style={{ color: "#94a3b8", fontSize: 11, lineHeight: 1.4 }}>
+          preset·direction 변경 시 뷰포트는 유지됩니다. 새 레이아웃에 맞춰 보려면 우하단의{" "}
+          <code>⊙</code> 또는 키보드 <kbd>0</kbd> 으로 fit-to-content 를 실행하세요.
+        </p>
+      </aside>
+
+      <main style={{ height: "70vh" }}>
+        <PipelineGraph
+          nodes={data.nodes}
+          edges={data.edges}
+          direction={direction}
+          rankSep={rankSep}
+          nodeSep={nodeSep}
+          clusterPadding={clusterPadding}
+          theme={theme}
+          inspector={inspector}
+          interactive={interactive}
+          height="100%"
+        />
+      </main>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <p className="text-xs font-semibold text-gray-600 mb-1">{label}</p>
+      {children}
+    </div>
+  );
+}
+
 export function PipelineGraphPage() {
   return (
     <div>
@@ -718,8 +942,12 @@ export function PipelineGraphPage() {
         </div>
       </Section>
 
-      <Section id="playground" title="Playground" desc="실시간 prop 토글.">
-        <p className="text-sm text-gray-500 mb-3">(다음 이슈에서 채움)</p>
+      <Section
+        id="playground"
+        title="Playground"
+        desc="모든 주요 옵션을 실시간 토글하며 관찰할 수 있습니다."
+      >
+        <Playground />
       </Section>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
         "prism-react-renderer": "^2.3.0"
       },
       "devDependencies": {
@@ -26,6 +27,21 @@
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": ">=18.0.0"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "prism-react-renderer": "^2.3.0"
   },
   "devDependencies": {

--- a/src/components/PipelineGraph/PipelineGraph.tsx
+++ b/src/components/PipelineGraph/PipelineGraph.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useControllable } from "../_shared/useControllable";
 
@@ -6,9 +6,13 @@ import { PipelineGraphCluster } from "./PipelineGraphCluster";
 import { PipelineGraphEdge } from "./PipelineGraphEdge";
 import { PipelineGraphInspector } from "./PipelineGraphInspector";
 import { PipelineGraphNode } from "./PipelineGraphNode";
-import type { PipelineGraphProps } from "./PipelineGraph.types";
+import type {
+  PipelineGraphProps,
+  PipelineGraphViewport,
+} from "./PipelineGraph.types";
 import { normalize } from "./PipelineGraph.utils";
 import { useGraphLayout } from "./useGraphLayout";
+import { usePanZoom } from "./usePanZoom";
 import { palette as themePalette } from "./theme";
 
 export function PipelineGraph(props: PipelineGraphProps) {
@@ -32,6 +36,10 @@ export function PipelineGraph(props: PipelineGraphProps) {
     onNodeDoubleClick,
     inspector,
     renderInspectorValue,
+    viewport: viewportProp,
+    defaultViewport,
+    onViewportChange,
+    interactive = true,
   } = props;
 
   const normalized = useMemo(() => normalize(nodes, edges), [nodes, edges]);
@@ -59,6 +67,27 @@ export function PipelineGraph(props: PipelineGraphProps) {
   });
 
   const rootRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
+
+  const isViewportControlled = viewportProp !== undefined;
+  const [internalViewport, setInternalViewport] = useState<PipelineGraphViewport | null>(
+    defaultViewport ?? null,
+  );
+  const viewport = isViewportControlled ? viewportProp : internalViewport;
+  const setViewport = useCallback(
+    (v: PipelineGraphViewport) => {
+      if (!isViewportControlled) setInternalViewport(v);
+      onViewportChange?.(v);
+    },
+    [isViewportControlled, onViewportChange],
+  );
+
+  usePanZoom({
+    rootRef: canvasRef,
+    viewport,
+    setViewport,
+    interactive,
+  });
 
   const p = themePalette[theme];
   const isEmpty = nodes.length === 0;
@@ -93,8 +122,17 @@ export function PipelineGraph(props: PipelineGraphProps) {
     setSelectedId(null);
   }, [selectedId, layout.positions, normalized, setSelectedId]);
 
+  const transformStyle = viewport
+    ? {
+        transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+        transformOrigin: "0 0" as const,
+      }
+    : {};
+
   const canvas = (
     <div
+      ref={canvasRef}
+      data-pg-root="1"
       onClick={handleCanvasClick}
       style={{
         position: "relative",
@@ -105,6 +143,7 @@ export function PipelineGraph(props: PipelineGraphProps) {
         background: p.canvasBg,
         color: p.fg,
         boxSizing: "border-box",
+        touchAction: "none",
       }}
     >
       {isEmpty ? (
@@ -129,6 +168,7 @@ export function PipelineGraph(props: PipelineGraphProps) {
             top: 0,
             width: layout.bounds.width,
             height: layout.bounds.height,
+            ...transformStyle,
           }}
         >
           {layout.clusterBounds.map((cb) => {

--- a/src/components/PipelineGraph/PipelineGraph.tsx
+++ b/src/components/PipelineGraph/PipelineGraph.tsx
@@ -4,6 +4,7 @@ import { useControllable } from "../_shared/useControllable";
 
 import { PipelineGraphCluster } from "./PipelineGraphCluster";
 import { PipelineGraphEdge } from "./PipelineGraphEdge";
+import { PipelineGraphInspector } from "./PipelineGraphInspector";
 import { PipelineGraphNode } from "./PipelineGraphNode";
 import type { PipelineGraphProps } from "./PipelineGraph.types";
 import { normalize } from "./PipelineGraph.utils";
@@ -29,6 +30,7 @@ export function PipelineGraph(props: PipelineGraphProps) {
     defaultSelection,
     onSelectionChange,
     onNodeDoubleClick,
+    inspector,
   } = props;
 
   const normalized = useMemo(() => normalize(nodes, edges), [nodes, edges]);
@@ -59,6 +61,9 @@ export function PipelineGraph(props: PipelineGraphProps) {
 
   const p = themePalette[theme];
   const isEmpty = nodes.length === 0;
+  const inspectorConfig = inspector ?? {};
+  const inspectorPosition = inspectorConfig.position ?? "right";
+  const selectedNode = selectedId ? (normalized.byId.get(selectedId) ?? null) : null;
 
   const toggleExpand = useCallback(
     (id: string) => {
@@ -70,7 +75,7 @@ export function PipelineGraph(props: PipelineGraphProps) {
     [expandedArr, setExpandedArr],
   );
 
-  const handleBackgroundClick = () => setSelectedId(null);
+  const handleCanvasClick = () => setSelectedId(null);
 
   useEffect(() => {
     if (selectedId === null) return;
@@ -87,17 +92,14 @@ export function PipelineGraph(props: PipelineGraphProps) {
     setSelectedId(null);
   }, [selectedId, layout.positions, normalized, setSelectedId]);
 
-  return (
+  const canvas = (
     <div
-      ref={rootRef}
-      role="region"
-      aria-label="Pipeline graph"
-      className={className}
-      onClick={handleBackgroundClick}
+      onClick={handleCanvasClick}
       style={{
         position: "relative",
-        width,
-        height,
+        flex: 1,
+        minWidth: 0,
+        minHeight: 0,
         overflow: "hidden",
         background: p.canvasBg,
         color: p.fg,
@@ -172,6 +174,34 @@ export function PipelineGraph(props: PipelineGraphProps) {
           />
         </div>
       )}
+    </div>
+  );
+
+  return (
+    <div
+      ref={rootRef}
+      role="region"
+      aria-label="Pipeline graph"
+      className={className}
+      style={{
+        position: "relative",
+        width,
+        height,
+        overflow: "hidden",
+        display: "flex",
+        flexDirection: inspectorPosition === "bottom" ? "column" : "row",
+        background: p.canvasBg,
+        color: p.fg,
+        boxSizing: "border-box",
+      }}
+    >
+      {canvas}
+      <PipelineGraphInspector
+        selectedNode={selectedNode}
+        config={inspectorConfig}
+        theme={theme}
+        rootRef={rootRef}
+      />
     </div>
   );
 }

--- a/src/components/PipelineGraph/PipelineGraph.tsx
+++ b/src/components/PipelineGraph/PipelineGraph.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { useControllable } from "../_shared/useControllable";
 
@@ -10,10 +17,53 @@ import type {
   PipelineGraphProps,
   PipelineGraphViewport,
 } from "./PipelineGraph.types";
-import { normalize } from "./PipelineGraph.utils";
+import { clamp, fit, normalize } from "./PipelineGraph.utils";
 import { useGraphLayout } from "./useGraphLayout";
 import { usePanZoom } from "./usePanZoom";
-import { palette as themePalette } from "./theme";
+import { palette as themePalette, Z } from "./theme";
+
+interface ZoomControlButtonProps {
+  theme: "light" | "dark";
+  onClick: () => void;
+  label: string;
+  children: React.ReactNode;
+}
+
+function ZoomControlButton(props: ZoomControlButtonProps) {
+  const { theme, onClick, label, children } = props;
+  const p = themePalette[theme];
+  const [hover, setHover] = useState(false);
+  return (
+    <button
+      type="button"
+      data-pg-interactive="1"
+      aria-label={label}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      onPointerDown={(e) => e.stopPropagation()}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        width: 28,
+        height: 28,
+        border: `1px solid ${p.inspectorBorder}`,
+        borderRadius: 6,
+        background: hover ? p.controlHoverBg : p.controlBg,
+        color: p.controlFg,
+        cursor: "pointer",
+        fontSize: 14,
+        lineHeight: 1,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
 
 export function PipelineGraph(props: PipelineGraphProps) {
   const {
@@ -88,6 +138,52 @@ export function PipelineGraph(props: PipelineGraphProps) {
     setViewport,
     interactive,
   });
+
+  useLayoutEffect(() => {
+    if (viewport !== null) return;
+    if (isViewportControlled) return;
+    const el = canvasRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+    if (layout.bounds.width <= 0 || layout.bounds.height <= 0) return;
+    const next = fit(
+      { width: layout.bounds.width, height: layout.bounds.height },
+      { width: rect.width, height: rect.height },
+    );
+    setViewport(next);
+  }, [viewport, isViewportControlled, layout.bounds.width, layout.bounds.height, setViewport]);
+
+  const zoomBy = useCallback(
+    (factor: number) => {
+      const el = canvasRef.current;
+      const vp = viewport;
+      if (!el || !vp) return;
+      const rect = el.getBoundingClientRect();
+      const cx = rect.width / 2;
+      const cy = rect.height / 2;
+      const nextZoom = clamp(vp.zoom * factor, 0.25, 2.5);
+      if (nextZoom === vp.zoom) return;
+      const ratio = nextZoom / vp.zoom;
+      const nx = cx - (cx - vp.x) * ratio;
+      const ny = cy - (cy - vp.y) * ratio;
+      setViewport({ x: nx, y: ny, zoom: nextZoom });
+    },
+    [viewport, setViewport],
+  );
+
+  const fitNow = useCallback(() => {
+    const el = canvasRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    if (layout.bounds.width <= 0 || layout.bounds.height <= 0) return;
+    setViewport(
+      fit(
+        { width: layout.bounds.width, height: layout.bounds.height },
+        { width: rect.width, height: rect.height },
+      ),
+    );
+  }, [layout.bounds.width, layout.bounds.height, setViewport]);
 
   const p = themePalette[theme];
   const isEmpty = nodes.length === 0;
@@ -215,6 +311,30 @@ export function PipelineGraph(props: PipelineGraphProps) {
           />
         </div>
       )}
+      {!isEmpty && interactive ? (
+        <div
+          data-pg-interactive="1"
+          style={{
+            position: "absolute",
+            right: 12,
+            bottom: 12,
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+            zIndex: Z.controls,
+          }}
+        >
+          <ZoomControlButton theme={theme} onClick={() => zoomBy(1.2)} label="Zoom in">
+            +
+          </ZoomControlButton>
+          <ZoomControlButton theme={theme} onClick={() => zoomBy(1 / 1.2)} label="Zoom out">
+            −
+          </ZoomControlButton>
+          <ZoomControlButton theme={theme} onClick={fitNow} label="Fit">
+            ⊙
+          </ZoomControlButton>
+        </div>
+      ) : null}
     </div>
   );
 

--- a/src/components/PipelineGraph/PipelineGraph.tsx
+++ b/src/components/PipelineGraph/PipelineGraph.tsx
@@ -31,6 +31,7 @@ export function PipelineGraph(props: PipelineGraphProps) {
     onSelectionChange,
     onNodeDoubleClick,
     inspector,
+    renderInspectorValue,
   } = props;
 
   const normalized = useMemo(() => normalize(nodes, edges), [nodes, edges]);
@@ -201,6 +202,7 @@ export function PipelineGraph(props: PipelineGraphProps) {
         config={inspectorConfig}
         theme={theme}
         rootRef={rootRef}
+        {...(renderInspectorValue ? { renderInspectorValue } : {})}
       />
     </div>
   );

--- a/src/components/PipelineGraph/PipelineGraph.tsx
+++ b/src/components/PipelineGraph/PipelineGraph.tsx
@@ -1,5 +1,145 @@
-import type { PipelineGraphProps } from "./PipelineGraph.types";
+import { useMemo, useRef } from "react";
 
-export function PipelineGraph(_props: PipelineGraphProps) {
-  return <div />;
+import { useControllable } from "../_shared/useControllable";
+
+import { PipelineGraphCluster } from "./PipelineGraphCluster";
+import { PipelineGraphEdge } from "./PipelineGraphEdge";
+import { PipelineGraphNode } from "./PipelineGraphNode";
+import type { PipelineGraphProps } from "./PipelineGraph.types";
+import { normalize } from "./PipelineGraph.utils";
+import { useGraphLayout } from "./useGraphLayout";
+import { palette as themePalette } from "./theme";
+
+export function PipelineGraph(props: PipelineGraphProps) {
+  const {
+    nodes,
+    edges,
+    direction = "LR",
+    rankSep = 96,
+    nodeSep = 48,
+    clusterPadding = 24,
+    theme = "light",
+    width = "100%",
+    height = "70vh",
+    className,
+    expansion,
+    defaultExpansion,
+    onExpansionChange,
+  } = props;
+
+  const normalized = useMemo(() => normalize(nodes, edges), [nodes, edges]);
+
+  const [expandedArr, setExpandedArr] = useControllable<string[]>(
+    expansion,
+    defaultExpansion ?? [],
+    onExpansionChange,
+  );
+  const expanded = useMemo(() => new Set(expandedArr), [expandedArr]);
+
+  const layout = useGraphLayout({
+    normalized,
+    expanded,
+    direction,
+    rankSep,
+    nodeSep,
+    clusterPadding,
+  });
+
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const p = themePalette[theme];
+  const isEmpty = nodes.length === 0;
+
+  const toggleExpand = (id: string) => {
+    const next = new Set(expandedArr);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setExpandedArr([...next]);
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      role="region"
+      aria-label="Pipeline graph"
+      className={className}
+      style={{
+        position: "relative",
+        width,
+        height,
+        overflow: "hidden",
+        background: p.canvasBg,
+        color: p.fg,
+        boxSizing: "border-box",
+      }}
+    >
+      {isEmpty ? (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: p.mutedFg,
+            fontSize: 13,
+          }}
+        >
+          No nodes
+        </div>
+      ) : (
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            width: layout.bounds.width,
+            height: layout.bounds.height,
+          }}
+        >
+          {layout.clusterBounds.map((cb) => {
+            const node = normalized.byId.get(cb.id);
+            if (!node) return null;
+            return (
+              <PipelineGraphCluster
+                key={cb.id}
+                bounds={cb}
+                node={node}
+                clusterPadding={clusterPadding}
+                theme={theme}
+                onToggleExpand={toggleExpand}
+              />
+            );
+          })}
+          {layout.positions.map((pos) => {
+            const n = normalized.byId.get(pos.id);
+            const v = layout.visible.find((vv) => vv.id === pos.id);
+            if (!n || !v) return null;
+            return (
+              <PipelineGraphNode
+                key={pos.id}
+                node={v}
+                normalized={n}
+                byId={normalized.byId}
+                x={pos.x}
+                y={pos.y}
+                w={pos.w}
+                h={pos.h}
+                selected={false}
+                expanded={expanded.has(pos.id)}
+                theme={theme}
+                onSelect={() => {}}
+                onToggleExpand={toggleExpand}
+              />
+            );
+          })}
+          <PipelineGraphEdge
+            edgePoints={layout.edgePoints}
+            bounds={layout.bounds}
+            theme={theme}
+          />
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/components/PipelineGraph/PipelineGraph.tsx
+++ b/src/components/PipelineGraph/PipelineGraph.tsx
@@ -1,0 +1,5 @@
+import type { PipelineGraphProps } from "./PipelineGraph.types";
+
+export function PipelineGraph(_props: PipelineGraphProps) {
+  return <div />;
+}

--- a/src/components/PipelineGraph/PipelineGraph.tsx
+++ b/src/components/PipelineGraph/PipelineGraph.tsx
@@ -10,7 +10,7 @@ import {
 import { useControllable } from "../_shared/useControllable";
 
 import { PipelineGraphCluster } from "./PipelineGraphCluster";
-import { PipelineGraphEdge } from "./PipelineGraphEdge";
+import { PipelineGraphEdge, type HoveredEdge } from "./PipelineGraphEdge";
 import { PipelineGraphInspector } from "./PipelineGraphInspector";
 import { PipelineGraphNode } from "./PipelineGraphNode";
 import type {
@@ -21,6 +21,18 @@ import { clamp, fit, nextNodeInDirection, normalize } from "./PipelineGraph.util
 import { useGraphLayout } from "./useGraphLayout";
 import { usePanZoom } from "./usePanZoom";
 import { palette as themePalette, Z } from "./theme";
+
+function defaultEdgeTooltipText(edge: HoveredEdge): string {
+  if (edge.raws.length > 1) return `${edge.raws.length} connections`;
+  const raw0 = edge.raws[0];
+  if (raw0?.label) return raw0.label;
+  if (raw0?.fanOut) {
+    return raw0.fanOut.label
+      ? `${raw0.fanOut.label} (×${raw0.fanOut.count})`
+      : `×${raw0.fanOut.count}`;
+  }
+  return `${edge.from} → ${edge.to}`;
+}
 
 interface ZoomControlButtonProps {
   theme: "light" | "dark";
@@ -86,11 +98,14 @@ export function PipelineGraph(props: PipelineGraphProps) {
     onNodeDoubleClick,
     inspector,
     renderInspectorValue,
+    renderEdgeTooltip,
     viewport: viewportProp,
     defaultViewport,
     onViewportChange,
     interactive = true,
   } = props;
+
+  const [hoveredEdge, setHoveredEdge] = useState<HoveredEdge | null>(null);
 
   const normalized = useMemo(() => normalize(nodes, edges), [nodes, edges]);
 
@@ -381,9 +396,32 @@ export function PipelineGraph(props: PipelineGraphProps) {
             edgePoints={layout.edgePoints}
             bounds={layout.bounds}
             theme={theme}
+            onHoverChange={setHoveredEdge}
           />
         </div>
       )}
+      {hoveredEdge && viewport ? (
+        <div
+          style={{
+            position: "absolute",
+            left: viewport.x + hoveredEdge.mid.x * viewport.zoom + 8,
+            top: viewport.y + hoveredEdge.mid.y * viewport.zoom + 8,
+            background: p.tooltipBg,
+            color: p.tooltipFg,
+            padding: "6px 10px",
+            borderRadius: 6,
+            fontSize: 11,
+            pointerEvents: "none",
+            zIndex: Z.tooltip,
+            maxWidth: 240,
+            boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+          }}
+        >
+          {renderEdgeTooltip && hoveredEdge.raws[0]
+            ? (renderEdgeTooltip(hoveredEdge.raws[0]) ?? defaultEdgeTooltipText(hoveredEdge))
+            : defaultEdgeTooltipText(hoveredEdge)}
+        </div>
+      ) : null}
       {!isEmpty && interactive ? (
         <div
           data-pg-interactive="1"

--- a/src/components/PipelineGraph/PipelineGraph.tsx
+++ b/src/components/PipelineGraph/PipelineGraph.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { useControllable } from "../_shared/useControllable";
 
@@ -25,6 +25,10 @@ export function PipelineGraph(props: PipelineGraphProps) {
     expansion,
     defaultExpansion,
     onExpansionChange,
+    selection,
+    defaultSelection,
+    onSelectionChange,
+    onNodeDoubleClick,
   } = props;
 
   const normalized = useMemo(() => normalize(nodes, edges), [nodes, edges]);
@@ -35,6 +39,12 @@ export function PipelineGraph(props: PipelineGraphProps) {
     onExpansionChange,
   );
   const expanded = useMemo(() => new Set(expandedArr), [expandedArr]);
+
+  const [selectedId, setSelectedId] = useControllable<string | null>(
+    selection,
+    defaultSelection ?? null,
+    onSelectionChange,
+  );
 
   const layout = useGraphLayout({
     normalized,
@@ -50,12 +60,32 @@ export function PipelineGraph(props: PipelineGraphProps) {
   const p = themePalette[theme];
   const isEmpty = nodes.length === 0;
 
-  const toggleExpand = (id: string) => {
-    const next = new Set(expandedArr);
-    if (next.has(id)) next.delete(id);
-    else next.add(id);
-    setExpandedArr([...next]);
-  };
+  const toggleExpand = useCallback(
+    (id: string) => {
+      const next = new Set(expandedArr);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      setExpandedArr([...next]);
+    },
+    [expandedArr, setExpandedArr],
+  );
+
+  const handleBackgroundClick = () => setSelectedId(null);
+
+  useEffect(() => {
+    if (selectedId === null) return;
+    const shownIds = new Set(layout.positions.map((pp) => pp.id));
+    if (shownIds.has(selectedId)) return;
+    let cur = normalized.byId.get(selectedId);
+    while (cur?.parent) {
+      if (shownIds.has(cur.parent)) {
+        setSelectedId(cur.parent);
+        return;
+      }
+      cur = normalized.byId.get(cur.parent);
+    }
+    setSelectedId(null);
+  }, [selectedId, layout.positions, normalized, setSelectedId]);
 
   return (
     <div
@@ -63,6 +93,7 @@ export function PipelineGraph(props: PipelineGraphProps) {
       role="region"
       aria-label="Pipeline graph"
       className={className}
+      onClick={handleBackgroundClick}
       style={{
         position: "relative",
         width,
@@ -125,11 +156,12 @@ export function PipelineGraph(props: PipelineGraphProps) {
                 y={pos.y}
                 w={pos.w}
                 h={pos.h}
-                selected={false}
+                selected={selectedId === pos.id}
                 expanded={expanded.has(pos.id)}
                 theme={theme}
-                onSelect={() => {}}
+                onSelect={setSelectedId}
                 onToggleExpand={toggleExpand}
+                {...(onNodeDoubleClick ? { onDoubleClick: onNodeDoubleClick } : {})}
               />
             );
           })}

--- a/src/components/PipelineGraph/PipelineGraph.tsx
+++ b/src/components/PipelineGraph/PipelineGraph.tsx
@@ -17,7 +17,7 @@ import type {
   PipelineGraphProps,
   PipelineGraphViewport,
 } from "./PipelineGraph.types";
-import { clamp, fit, normalize } from "./PipelineGraph.utils";
+import { clamp, fit, nextNodeInDirection, normalize } from "./PipelineGraph.utils";
 import { useGraphLayout } from "./useGraphLayout";
 import { usePanZoom } from "./usePanZoom";
 import { palette as themePalette, Z } from "./theme";
@@ -203,6 +203,76 @@ export function PipelineGraph(props: PipelineGraphProps) {
 
   const handleCanvasClick = () => setSelectedId(null);
 
+  const handleCanvasKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const dirKey =
+      e.key === "ArrowUp"
+        ? "up"
+        : e.key === "ArrowDown"
+          ? "down"
+          : e.key === "ArrowLeft"
+            ? "left"
+            : e.key === "ArrowRight"
+              ? "right"
+              : null;
+    if (dirKey) {
+      e.preventDefault();
+      if (layout.positions.length === 0) return;
+      let nextId: string | null;
+      const firstPos = layout.positions[0];
+      if (!selectedId) {
+        nextId = firstPos ? firstPos.id : null;
+      } else {
+        nextId = nextNodeInDirection(selectedId, layout.positions, dirKey);
+      }
+      if (nextId) setSelectedId(nextId);
+      return;
+    }
+    if (e.key === "Escape") {
+      if (selectedId !== null) {
+        e.preventDefault();
+        setSelectedId(null);
+      }
+      return;
+    }
+    if (e.key === "Enter") {
+      if (!selectedId && layout.positions.length > 0) {
+        const first = layout.positions[0];
+        if (first) {
+          e.preventDefault();
+          setSelectedId(first.id);
+        }
+      }
+      return;
+    }
+    if (e.key === " " || e.code === "Space") {
+      if (selectedId) {
+        const sel = normalized.byId.get(selectedId);
+        if (sel && (sel.kind === "group" || sel.kind === "loop")) {
+          e.preventDefault();
+          e.stopPropagation();
+          toggleExpand(selectedId);
+          return;
+        }
+      }
+      return;
+    }
+    if (e.key === "+" || e.key === "=") {
+      e.preventDefault();
+      zoomBy(1.2);
+      return;
+    }
+    if (e.key === "-" || e.key === "_") {
+      e.preventDefault();
+      zoomBy(1 / 1.2);
+      return;
+    }
+    if (e.key === "0") {
+      e.preventDefault();
+      fitNow();
+      return;
+    }
+  };
+
   useEffect(() => {
     if (selectedId === null) return;
     const shownIds = new Set(layout.positions.map((pp) => pp.id));
@@ -229,7 +299,9 @@ export function PipelineGraph(props: PipelineGraphProps) {
     <div
       ref={canvasRef}
       data-pg-root="1"
+      tabIndex={0}
       onClick={handleCanvasClick}
+      onKeyDown={handleCanvasKeyDown}
       style={{
         position: "relative",
         flex: 1,
@@ -240,6 +312,7 @@ export function PipelineGraph(props: PipelineGraphProps) {
         color: p.fg,
         boxSizing: "border-box",
         touchAction: "none",
+        outline: "none",
       }}
     >
       {isEmpty ? (

--- a/src/components/PipelineGraph/PipelineGraph.tsx
+++ b/src/components/PipelineGraph/PipelineGraph.tsx
@@ -99,6 +99,7 @@ export function PipelineGraph(props: PipelineGraphProps) {
     inspector,
     renderInspectorValue,
     renderEdgeTooltip,
+    renderNode,
     viewport: viewportProp,
     defaultViewport,
     onViewportChange,
@@ -389,6 +390,7 @@ export function PipelineGraph(props: PipelineGraphProps) {
                 onSelect={setSelectedId}
                 onToggleExpand={toggleExpand}
                 {...(onNodeDoubleClick ? { onDoubleClick: onNodeDoubleClick } : {})}
+                {...(renderNode ? { renderNode } : {})}
               />
             );
           })}

--- a/src/components/PipelineGraph/PipelineGraph.types.ts
+++ b/src/components/PipelineGraph/PipelineGraph.types.ts
@@ -1,0 +1,192 @@
+import type { ReactNode } from "react";
+
+export type PipelineGraphTheme = "light" | "dark";
+
+export type PipelineGraphDirection = "LR" | "TB";
+
+export type PipelineNodeKind = "task" | "group" | "loop";
+
+export type PipelineNodeStatus =
+  | "pending"
+  | "running"
+  | "success"
+  | "failed"
+  | "skipped"
+  | "cancelled";
+
+export interface PipelineNodeTiming {
+  /** 시작 epoch ms */
+  startedAt?: number;
+  /** 종료 epoch ms (running 상태면 undefined) */
+  endedAt?: number;
+  /** 수동 duration 지정 (startedAt/endedAt 없이 사용 시, ms 단위) */
+  durationMs?: number;
+}
+
+export interface PipelineNodeLog {
+  /** 로그 라인 timestamp (epoch ms) */
+  t?: number;
+  level?: "debug" | "info" | "warn" | "error";
+  message: string;
+}
+
+export interface PipelineNodeError {
+  message: string;
+  stack?: string;
+  cause?: unknown;
+}
+
+export interface PipelineNode {
+  /** 전역 유일 id. */
+  id: string;
+  /** 카드 헤더에 표시될 이름. */
+  label: string;
+  /** 종류. 기본 "task". */
+  kind?: PipelineNodeKind;
+  /** 실행 상태. 기본 "pending". */
+  status?: PipelineNodeStatus;
+  /** 실행 타이밍. */
+  timing?: PipelineNodeTiming;
+  /** 부모 group/loop 의 id. 없으면 top-level. */
+  parent?: string;
+  /** group/loop 자식 id 목록. */
+  children?: string[];
+  /** kind === "loop" 일 때 총 반복 횟수. */
+  iterations?: number;
+  /** 현재 실행 중인 반복 번호 (1-based). running 일 때만 의미. */
+  currentIteration?: number;
+
+  /** 인스펙터 Input 탭 데이터. */
+  input?: unknown;
+  /** 인스펙터 Output 탭 데이터. */
+  output?: unknown;
+  /** 인스펙터 Internal 탭 데이터 (환경변수/파라미터/중간 상태 등). */
+  internal?: unknown;
+  /** 인스펙터 Logs 탭. */
+  logs?: string[] | PipelineNodeLog[];
+  /** 인스펙터 Error 탭 — failed 상태에서만 의미. */
+  error?: PipelineNodeError;
+
+  /** 카드 우상단 사용자 정의 배지. */
+  badge?: string;
+  /** status 색상을 덮어쓰는 accent. */
+  accentColor?: string;
+  /** 추가 className. */
+  className?: string;
+}
+
+export interface PipelineEdge {
+  /** 소스 노드 id. */
+  from: string;
+  /** 타깃 노드 id. */
+  to: string;
+  /** 엣지 레이블. */
+  label?: string;
+  /** Fan-out 표시 (한 소스가 N 개의 runtime 인스턴스로 분기). */
+  fanOut?: { count: number; label?: string };
+  /** 엣지 스타일. 기본 "solid". */
+  variant?: "solid" | "dashed" | "dotted";
+  /** 엣지 색상 오버라이드. */
+  color?: string;
+  /** 호버/클릭 시 인스펙터에 주입할 데이터. */
+  dataPreview?: unknown;
+}
+
+export interface PipelineGraphViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+export type PipelineInspectorTab =
+  | "input"
+  | "output"
+  | "internal"
+  | "logs"
+  | "timing"
+  | "error";
+
+export interface PipelineGraphInspectorConfig {
+  /** 패널 위치. 기본 "right". */
+  position?: "right" | "bottom" | "none";
+  /** 초기 너비/높이 (px). right = width, bottom = height. 기본 380 / 280. */
+  defaultSize?: number;
+  /** 기본 탭. 기본 "output" (또는 status === "failed" 일 때 "error"). */
+  defaultTab?: PipelineInspectorTab;
+  /** 보이게 할 탭만 필터. 기본 모두. */
+  tabs?: PipelineInspectorTab[];
+}
+
+export interface PipelineGraphProps {
+  /** 노드 배열. */
+  nodes: PipelineNode[];
+  /** 엣지 배열. */
+  edges: PipelineEdge[];
+
+  /** 레이아웃 방향. 기본 "LR". */
+  direction?: PipelineGraphDirection;
+  /** Dagre rank 간격. 기본 96. */
+  rankSep?: number;
+  /** Dagre node 간격(동일 rank 내). 기본 48. */
+  nodeSep?: number;
+  /** group/loop 클러스터 내부 패딩. 기본 24. */
+  clusterPadding?: number;
+
+  /** Controlled 선택. */
+  selection?: string | null;
+  /** 기본 선택 (uncontrolled). 기본 null. */
+  defaultSelection?: string | null;
+  /** 선택 변경 콜백. */
+  onSelectionChange?: (id: string | null) => void;
+
+  /** Controlled 펼침 집합. */
+  expansion?: string[];
+  /** 기본 펼침 (uncontrolled). 기본 []. */
+  defaultExpansion?: string[];
+  /** 펼침 변경 콜백. */
+  onExpansionChange?: (ids: string[]) => void;
+
+  /** Controlled 뷰포트 (팬/줌). */
+  viewport?: PipelineGraphViewport;
+  /** 기본 뷰포트. 미지정 시 fit-to-content. */
+  defaultViewport?: PipelineGraphViewport;
+  /** 뷰포트 변경 콜백. */
+  onViewportChange?: (vp: PipelineGraphViewport) => void;
+
+  /** 인스펙터 설정. */
+  inspector?: PipelineGraphInspectorConfig;
+  /**
+   * 인스펙터 탭 값 커스텀 렌더.
+   * undefined 반환 시 기본 렌더(CodeView JSON 등) 적용.
+   */
+  renderInspectorValue?: (
+    node: PipelineNode,
+    tab: PipelineInspectorTab,
+    value: unknown,
+  ) => ReactNode | undefined;
+
+  /** 노드 카드 커스텀 렌더. undefined 반환 시 기본 카드. */
+  renderNode?: (
+    node: PipelineNode,
+    ctx: { selected: boolean; expanded: boolean },
+  ) => ReactNode | undefined;
+
+  /** 엣지 hover tooltip 커스텀 렌더. */
+  renderEdgeTooltip?: (edge: PipelineEdge) => ReactNode | undefined;
+
+  /** 노드 더블클릭 콜백. */
+  onNodeDoubleClick?: (node: PipelineNode) => void;
+
+  /** 라이트/다크 테마. 기본 "light". */
+  theme?: PipelineGraphTheme;
+
+  /** 컨테이너 너비/높이. 기본 width: "100%", height: "70vh". */
+  width?: number | string;
+  height?: number | string;
+
+  /** 팬/줌/선택 비활성화. 기본 false. */
+  interactive?: boolean;
+
+  /** 추가 className. */
+  className?: string;
+}

--- a/src/components/PipelineGraph/PipelineGraph.utils.ts
+++ b/src/components/PipelineGraph/PipelineGraph.utils.ts
@@ -207,10 +207,34 @@ export function buildVisibleGraph(n: Normalized, expanded: Set<string>): Visible
     }
   }
 
+  const isExpandedCluster = (id: string): boolean => {
+    const nn = n.byId.get(id);
+    if (!nn) return false;
+    return (nn.kind === "group" || nn.kind === "loop") && expanded.has(id);
+  };
+  const leafOf = (clusterId: string, preferFirst: boolean): string => {
+    const visited = new Set<string>();
+    let cur = clusterId;
+    while (isExpandedCluster(cur) && !visited.has(cur)) {
+      visited.add(cur);
+      const cluster = n.byId.get(cur);
+      if (!cluster || cluster.children.length === 0) return cur;
+      const visibleChildren = cluster.children.filter((c) => shownIds.has(c));
+      if (visibleChildren.length === 0) return cur;
+      const next = preferFirst
+        ? visibleChildren[0]!
+        : visibleChildren[visibleChildren.length - 1]!;
+      cur = next;
+    }
+    return cur;
+  };
+
   const seen = new Map<string, VisibleEdge>();
   for (const e of n.edges) {
-    const f = visibleAncestorOf.get(e.from) ?? e.from;
-    const t = visibleAncestorOf.get(e.to) ?? e.to;
+    let f = visibleAncestorOf.get(e.from) ?? e.from;
+    let t = visibleAncestorOf.get(e.to) ?? e.to;
+    if (isExpandedCluster(f)) f = leafOf(f, false);
+    if (isExpandedCluster(t)) t = leafOf(t, true);
     if (f === t) continue;
     const key = `${f}->${t}`;
     const existing = seen.get(key);

--- a/src/components/PipelineGraph/PipelineGraph.utils.ts
+++ b/src/components/PipelineGraph/PipelineGraph.utils.ts
@@ -1,0 +1,349 @@
+import type {
+  PipelineEdge,
+  PipelineNode,
+  PipelineNodeKind,
+  PipelineNodeStatus,
+  PipelineNodeTiming,
+  PipelineGraphViewport,
+} from "./PipelineGraph.types";
+
+const WARN_PREFIX = "[PipelineGraph]";
+
+function warn(msg: string): void {
+  // eslint-disable-next-line no-console
+  console.warn(`${WARN_PREFIX} ${msg}`);
+}
+
+export interface NormalizedNode {
+  id: string;
+  label: string;
+  kind: PipelineNodeKind;
+  status: PipelineNodeStatus;
+  parent: string | null;
+  children: string[];
+  iterations: number | null;
+  currentIteration: number | null;
+  timing: PipelineNodeTiming | null;
+  raw: PipelineNode;
+}
+
+export interface Normalized {
+  byId: Map<string, NormalizedNode>;
+  topoNodes: NormalizedNode[];
+  edges: PipelineEdge[];
+}
+
+export function normalize(
+  nodes: PipelineNode[],
+  edges: PipelineEdge[],
+): Normalized {
+  const byId = new Map<string, NormalizedNode>();
+  const topoNodes: NormalizedNode[] = [];
+
+  // 1. id 중복 제거 + 1차 변환
+  for (const n of nodes) {
+    if (byId.has(n.id)) {
+      warn(`duplicate node id "${n.id}" — later entry dropped`);
+      continue;
+    }
+    const kind = n.kind ?? "task";
+    const iterations = kind === "loop"
+      ? (n.iterations ?? (warn(`loop "${n.id}" missing iterations — defaulting to 1`), 1))
+      : null;
+    const nn: NormalizedNode = {
+      id: n.id,
+      label: n.label,
+      kind,
+      status: n.status ?? "pending",
+      parent: n.parent ?? null,
+      children: n.children ? [...n.children] : [],
+      iterations,
+      currentIteration: n.currentIteration ?? null,
+      timing: n.timing ?? null,
+      raw: n,
+    };
+    byId.set(n.id, nn);
+    topoNodes.push(nn);
+  }
+
+  // 2. parent/children 양방향 보강 + 불일치 검증
+  for (const n of topoNodes) {
+    if (n.parent && !byId.has(n.parent)) {
+      warn(`node "${n.id}" parent "${n.parent}" not found — promoted to top-level`);
+      n.parent = null;
+      continue;
+    }
+    if (n.parent) {
+      const p = byId.get(n.parent)!;
+      if (!p.children.includes(n.id)) p.children.push(n.id);
+    }
+  }
+  for (const n of topoNodes) {
+    if (n.kind !== "group" && n.kind !== "loop") continue;
+    for (const childId of n.children) {
+      const c = byId.get(childId);
+      if (!c) {
+        warn(`group "${n.id}" references missing child "${childId}"`);
+        continue;
+      }
+      if (c.parent && c.parent !== n.id) {
+        warn(
+          `child "${childId}" parent mismatch (${c.parent} vs ${n.id}) — using children array`,
+        );
+      }
+      c.parent = n.id;
+    }
+  }
+
+  // 3. 엣지 유효성 + cycle 검사 (Kahn)
+  const validEdges: PipelineEdge[] = [];
+  const inDeg = new Map<string, number>();
+  for (const n of topoNodes) inDeg.set(n.id, 0);
+  for (const e of edges) {
+    if (!byId.has(e.from)) {
+      warn(`edge from "${e.from}" — source node not found, dropped`);
+      continue;
+    }
+    if (!byId.has(e.to)) {
+      warn(`edge to "${e.to}" — target node not found, dropped`);
+      continue;
+    }
+    validEdges.push(e);
+    inDeg.set(e.to, (inDeg.get(e.to) ?? 0) + 1);
+  }
+
+  // Kahn: in-degree 0 부터 BFS. 남은 엣지가 cycle 후보.
+  const queue: string[] = [];
+  const remain = new Map(inDeg);
+  for (const [id, d] of remain) if (d === 0) queue.push(id);
+  const seen = new Set<string>();
+  const outMap = new Map<string, PipelineEdge[]>();
+  for (const e of validEdges) {
+    const arr = outMap.get(e.from) ?? [];
+    arr.push(e);
+    outMap.set(e.from, arr);
+  }
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    seen.add(id);
+    for (const e of outMap.get(id) ?? []) {
+      const d = (remain.get(e.to) ?? 0) - 1;
+      remain.set(e.to, d);
+      if (d === 0) queue.push(e.to);
+    }
+  }
+  const kept: PipelineEdge[] = [];
+  for (const e of validEdges) {
+    if (seen.has(e.from) && seen.has(e.to)) {
+      kept.push(e);
+    } else {
+      warn(`cycle detected, dropped edge ${e.from}->${e.to}`);
+    }
+  }
+
+  return { byId, topoNodes, edges: kept };
+}
+
+/* ─────────────────────────────────────────────────────────── */
+
+export interface VisibleNode {
+  id: string;
+  kind: PipelineNodeKind;
+  label: string;
+}
+
+export interface VisibleEdge {
+  from: string;
+  to: string;
+  raws: PipelineEdge[];
+}
+
+export interface ClusterInfo {
+  id: string;
+  childIds: string[];
+  kind: "group" | "loop";
+}
+
+export interface VisibleGraph {
+  visible: VisibleNode[];
+  visibleEdges: VisibleEdge[];
+  clusters: ClusterInfo[];
+  visibleAncestorOf: Map<string, string>;
+}
+
+export function buildVisibleGraph(n: Normalized, expanded: Set<string>): VisibleGraph {
+  const visibleAncestorOf = new Map<string, string>();
+  for (const node of n.topoNodes) {
+    let cur = node.id;
+    let ptr: NormalizedNode | null = node;
+    while (ptr && ptr.parent) {
+      const parent = n.byId.get(ptr.parent);
+      if (!parent) break;
+      if (!expanded.has(parent.id)) cur = parent.id;
+      ptr = parent;
+    }
+    visibleAncestorOf.set(node.id, cur);
+  }
+
+  const shownIds = new Set(visibleAncestorOf.values());
+  const visible: VisibleNode[] = [];
+  for (const id of shownIds) {
+    const nn = n.byId.get(id);
+    if (!nn) continue;
+    if ((nn.kind === "group" || nn.kind === "loop") && expanded.has(id)) continue;
+    visible.push({ id: nn.id, kind: nn.kind, label: nn.label });
+  }
+
+  const clusters: ClusterInfo[] = [];
+  for (const id of shownIds) {
+    const nn = n.byId.get(id);
+    if (!nn) continue;
+    if ((nn.kind === "group" || nn.kind === "loop") && expanded.has(id)) {
+      clusters.push({
+        id,
+        kind: nn.kind,
+        childIds: nn.children.filter((c) => shownIds.has(c)),
+      });
+    }
+  }
+
+  const seen = new Map<string, VisibleEdge>();
+  for (const e of n.edges) {
+    const f = visibleAncestorOf.get(e.from) ?? e.from;
+    const t = visibleAncestorOf.get(e.to) ?? e.to;
+    if (f === t) continue;
+    const key = `${f}->${t}`;
+    const existing = seen.get(key);
+    if (existing) existing.raws.push(e);
+    else seen.set(key, { from: f, to: t, raws: [e] });
+  }
+
+  return {
+    visible,
+    visibleEdges: [...seen.values()],
+    clusters,
+    visibleAncestorOf,
+  };
+}
+
+/* ─────────────────────────────────────────────────────────── */
+
+export function fmtMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const m = Math.floor(ms / 60_000);
+  const s = Math.round((ms % 60_000) / 1000);
+  return `${m}m ${s}s`;
+}
+
+export function formatDuration(n: NormalizedNode): string {
+  const t = n.timing;
+  if (!t) return "";
+  if (t.durationMs != null) return fmtMs(t.durationMs);
+  if (t.startedAt != null && t.endedAt != null) return fmtMs(t.endedAt - t.startedAt);
+  if (t.startedAt != null) return "running…";
+  return "";
+}
+
+export function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export function catmullRom(pts: Point[], tension = 0.5): string {
+  if (pts.length < 2) return "";
+  let d = `M ${pts[0]!.x} ${pts[0]!.y}`;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i]!;
+    const p1 = pts[i]!;
+    const p2 = pts[i + 1]!;
+    const p3 = pts[i + 2] ?? p2;
+    const cp1x = p1.x + ((p2.x - p0.x) / 6) * tension * 2;
+    const cp1y = p1.y + ((p2.y - p0.y) / 6) * tension * 2;
+    const cp2x = p2.x - ((p3.x - p1.x) / 6) * tension * 2;
+    const cp2y = p2.y - ((p3.y - p1.y) / 6) * tension * 2;
+    d += ` C ${cp1x} ${cp1y} ${cp2x} ${cp2y} ${p2.x} ${p2.y}`;
+  }
+  return d;
+}
+
+export function midPoint(points: Point[]): Point {
+  if (points.length === 0) return { x: 0, y: 0 };
+  const mid = Math.floor(points.length / 2);
+  return points[mid]!;
+}
+
+export function labelPos(points: Point[]): Point {
+  const p = midPoint(points);
+  return { x: p.x, y: p.y - 6 };
+}
+
+export function fit(
+  bounds: { width: number; height: number },
+  container: { width: number; height: number },
+  padding = 40,
+): PipelineGraphViewport {
+  if (bounds.width <= 0 || bounds.height <= 0 || container.width <= 0 || container.height <= 0) {
+    return { x: 0, y: 0, zoom: 1 };
+  }
+  const zoom = Math.min(
+    (container.width - padding * 2) / bounds.width,
+    (container.height - padding * 2) / bounds.height,
+    1.5,
+  );
+  const zoomClamped = Math.max(0.25, zoom);
+  const x = (container.width - bounds.width * zoomClamped) / 2;
+  const y = (container.height - bounds.height * zoomClamped) / 2;
+  return { x, y, zoom: zoomClamped };
+}
+
+const CHAR_WIDTH = 7.2;
+const CARD_PAD_X = 28;
+
+export function measureNode(n: VisibleNode): { w: number; h: number } {
+  const labelW = Math.max(96, Math.min(240, n.label.length * CHAR_WIDTH + CARD_PAD_X));
+  const baseH = n.kind === "loop" ? 88 : n.kind === "group" ? 76 : 64;
+  return { w: labelW, h: baseH };
+}
+
+export interface LaidOutNode {
+  id: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export function nextNodeInDirection(
+  currentId: string,
+  positions: LaidOutNode[],
+  dir: "up" | "down" | "left" | "right",
+): string | null {
+  const cur = positions.find((p) => p.id === currentId);
+  if (!cur) return null;
+  const cx = cur.x + cur.w / 2;
+  const cy = cur.y + cur.h / 2;
+  const isHoriz = dir === "left" || dir === "right";
+  const sign = dir === "down" || dir === "right" ? 1 : -1;
+
+  const scored: Array<{ id: string; score: number }> = [];
+  for (const p of positions) {
+    if (p.id === currentId) continue;
+    const px = p.x + p.w / 2;
+    const py = p.y + p.h / 2;
+    const dx = px - cx;
+    const dy = py - cy;
+    const primary = isHoriz ? dx : dy;
+    if (sign * primary <= 0) continue;
+    const primaryD = Math.abs(primary);
+    const secondary = isHoriz ? Math.abs(dy) : Math.abs(dx);
+    scored.push({ id: p.id, score: primaryD + secondary * 2 });
+  }
+  scored.sort((a, b) => a.score - b.score);
+  return scored[0]?.id ?? null;
+}

--- a/src/components/PipelineGraph/PipelineGraphCluster.tsx
+++ b/src/components/PipelineGraph/PipelineGraphCluster.tsx
@@ -41,6 +41,7 @@ function PipelineGraphClusterImpl(props: PipelineGraphClusterProps) {
       }}
     >
       <div
+        data-pg-interactive="1"
         style={{
           position: "absolute",
           top: 4,
@@ -58,6 +59,7 @@ function PipelineGraphClusterImpl(props: PipelineGraphClusterProps) {
       >
         <button
           type="button"
+          data-pg-interactive="1"
           onClick={handleToggle}
           aria-label="collapse"
           style={{

--- a/src/components/PipelineGraph/PipelineGraphCluster.tsx
+++ b/src/components/PipelineGraph/PipelineGraphCluster.tsx
@@ -1,0 +1,95 @@
+import { memo, type MouseEvent } from "react";
+
+import type { PipelineGraphTheme } from "./PipelineGraph.types";
+import type { NormalizedNode } from "./PipelineGraph.utils";
+import { palette as themePalette, Z } from "./theme";
+
+export interface PipelineGraphClusterProps {
+  bounds: { id: string; x: number; y: number; w: number; h: number };
+  node: NormalizedNode;
+  clusterPadding: number;
+  theme: PipelineGraphTheme;
+  onToggleExpand: (id: string) => void;
+}
+
+const HEADER_H = 22;
+
+function PipelineGraphClusterImpl(props: PipelineGraphClusterProps) {
+  const { bounds, node, clusterPadding, theme, onToggleExpand } = props;
+  const p = themePalette[theme];
+
+  const handleToggle = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onToggleExpand(node.id);
+  };
+
+  return (
+    <div
+      data-cluster-id={node.id}
+      style={{
+        position: "absolute",
+        left: bounds.x - clusterPadding,
+        top: bounds.y - clusterPadding - HEADER_H,
+        width: bounds.w + clusterPadding * 2,
+        height: bounds.h + clusterPadding * 2 + HEADER_H,
+        background: p.clusterBg,
+        border: `1px dashed ${p.clusterBorder}`,
+        borderRadius: 10,
+        pointerEvents: "none",
+        zIndex: Z.cluster,
+        boxSizing: "border-box",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: 4,
+          left: 10,
+          right: 10,
+          height: HEADER_H - 4,
+          fontSize: 11,
+          color: p.mutedFg,
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          pointerEvents: "auto",
+          overflow: "hidden",
+        }}
+      >
+        <button
+          type="button"
+          onClick={handleToggle}
+          aria-label="collapse"
+          style={{
+            border: "none",
+            background: "transparent",
+            cursor: "pointer",
+            fontSize: 11,
+            color: p.mutedFg,
+            padding: 0,
+            lineHeight: 1,
+          }}
+        >
+          ▾
+        </button>
+        <span
+          style={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            flex: 1,
+          }}
+        >
+          {node.label}
+        </span>
+        {node.kind === "loop" && node.iterations != null ? (
+          <span style={{ fontVariantNumeric: "tabular-nums" }}>
+            ({node.iterations}×)
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export const PipelineGraphCluster = memo(PipelineGraphClusterImpl);

--- a/src/components/PipelineGraph/PipelineGraphEdge.tsx
+++ b/src/components/PipelineGraph/PipelineGraphEdge.tsx
@@ -1,14 +1,22 @@
-import { memo } from "react";
+import { memo, type MouseEvent as ReactMouseEvent } from "react";
 
-import type { PipelineGraphTheme } from "./PipelineGraph.types";
-import { catmullRom } from "./PipelineGraph.utils";
+import type { PipelineEdge, PipelineGraphTheme } from "./PipelineGraph.types";
+import { catmullRom, midPoint } from "./PipelineGraph.utils";
 import type { LaidOutEdge } from "./useGraphLayout";
 import { palette as themePalette, Z } from "./theme";
+
+export interface HoveredEdge {
+  from: string;
+  to: string;
+  raws: PipelineEdge[];
+  mid: { x: number; y: number };
+}
 
 export interface PipelineGraphEdgeProps {
   edgePoints: LaidOutEdge[];
   bounds: { width: number; height: number };
   theme: PipelineGraphTheme;
+  onHoverChange?: (edge: HoveredEdge | null) => void;
 }
 
 const MARKER_ID = "pg-arrow";
@@ -20,8 +28,26 @@ function dashFor(variant: "solid" | "dashed" | "dotted" | undefined): string | u
 }
 
 function PipelineGraphEdgeImpl(props: PipelineGraphEdgeProps) {
-  const { edgePoints, bounds, theme } = props;
+  const { edgePoints, bounds, theme, onHoverChange } = props;
   const p = themePalette[theme];
+
+  const handleEnter = (e: ReactMouseEvent<SVGGElement>, edge: LaidOutEdge) => {
+    e.currentTarget.dataset.hover = "1";
+    const path = e.currentTarget.querySelector("path");
+    if (path) path.setAttribute("stroke-width", "2.5");
+    onHoverChange?.({
+      from: edge.from,
+      to: edge.to,
+      raws: edge.raws,
+      mid: midPoint(edge.points),
+    });
+  };
+  const handleLeave = (e: ReactMouseEvent<SVGGElement>) => {
+    delete e.currentTarget.dataset.hover;
+    const path = e.currentTarget.querySelector("path");
+    if (path) path.setAttribute("stroke-width", "1.5");
+    onHoverChange?.(null);
+  };
 
   return (
     <svg
@@ -56,8 +82,17 @@ function PipelineGraphEdgeImpl(props: PipelineGraphEdgeProps) {
         const raw0 = e.raws[0];
         const stroke = raw0?.color ?? p.edgeFg;
         const dash = dashFor(raw0?.variant);
+        const fan = raw0?.fanOut;
+        const showDupBadge = e.raws.length > 1;
+        const mid = midPoint(e.points);
         return (
-          <g key={`${e.from}->${e.to}`} data-edge="1" style={{ pointerEvents: "stroke" }}>
+          <g
+            key={`${e.from}->${e.to}`}
+            data-edge="1"
+            style={{ pointerEvents: "stroke" }}
+            onMouseEnter={(ev) => handleEnter(ev, e)}
+            onMouseLeave={handleLeave}
+          >
             <path
               d={d}
               fill="none"
@@ -66,6 +101,44 @@ function PipelineGraphEdgeImpl(props: PipelineGraphEdgeProps) {
               strokeDasharray={dash}
               markerEnd={`url(#${MARKER_ID})`}
             />
+            {fan ? (
+              <g transform={`translate(${mid.x}, ${mid.y})`} style={{ pointerEvents: "all" }}>
+                <rect
+                  x={-20}
+                  y={-10}
+                  width={40}
+                  height={20}
+                  rx={10}
+                  fill={p.cardBg}
+                  stroke={p.edgeFg}
+                />
+                <text
+                  textAnchor="middle"
+                  y={4}
+                  fontSize={10}
+                  fontWeight={600}
+                  fill={p.fg}
+                >{`×${fan.count}`}</text>
+                {fan.label ? (
+                  <text textAnchor="middle" y={24} fontSize={10} fill={p.mutedFg}>
+                    {fan.label}
+                  </text>
+                ) : null}
+              </g>
+            ) : showDupBadge ? (
+              <g transform={`translate(${mid.x}, ${mid.y - 14})`} style={{ pointerEvents: "all" }}>
+                <circle r={8} fill={p.cardBg} stroke={p.edgeFg} />
+                <text
+                  textAnchor="middle"
+                  y={3}
+                  fontSize={10}
+                  fontWeight={600}
+                  fill={p.fg}
+                >
+                  {e.raws.length}
+                </text>
+              </g>
+            ) : null}
           </g>
         );
       })}

--- a/src/components/PipelineGraph/PipelineGraphEdge.tsx
+++ b/src/components/PipelineGraph/PipelineGraphEdge.tsx
@@ -73,7 +73,7 @@ function PipelineGraphEdgeImpl(props: PipelineGraphEdgeProps) {
           markerHeight={8}
           orient="auto"
         >
-          <path d="M 0 0 L 10 5 L 0 10 z" fill={p.edgeFg} />
+          <path d="M 0 0 L 10 5 L 0 10 z" fill={p.edgeArrowFill} />
         </marker>
       </defs>
       {edgePoints.map((e) => {

--- a/src/components/PipelineGraph/PipelineGraphEdge.tsx
+++ b/src/components/PipelineGraph/PipelineGraphEdge.tsx
@@ -57,7 +57,7 @@ function PipelineGraphEdgeImpl(props: PipelineGraphEdgeProps) {
         const stroke = raw0?.color ?? p.edgeFg;
         const dash = dashFor(raw0?.variant);
         return (
-          <g key={`${e.from}->${e.to}`} style={{ pointerEvents: "stroke" }}>
+          <g key={`${e.from}->${e.to}`} data-edge="1" style={{ pointerEvents: "stroke" }}>
             <path
               d={d}
               fill="none"

--- a/src/components/PipelineGraph/PipelineGraphEdge.tsx
+++ b/src/components/PipelineGraph/PipelineGraphEdge.tsx
@@ -1,0 +1,76 @@
+import { memo } from "react";
+
+import type { PipelineGraphTheme } from "./PipelineGraph.types";
+import { catmullRom } from "./PipelineGraph.utils";
+import type { LaidOutEdge } from "./useGraphLayout";
+import { palette as themePalette, Z } from "./theme";
+
+export interface PipelineGraphEdgeProps {
+  edgePoints: LaidOutEdge[];
+  bounds: { width: number; height: number };
+  theme: PipelineGraphTheme;
+}
+
+const MARKER_ID = "pg-arrow";
+
+function dashFor(variant: "solid" | "dashed" | "dotted" | undefined): string | undefined {
+  if (variant === "dashed") return "6 4";
+  if (variant === "dotted") return "2 3";
+  return undefined;
+}
+
+function PipelineGraphEdgeImpl(props: PipelineGraphEdgeProps) {
+  const { edgePoints, bounds, theme } = props;
+  const p = themePalette[theme];
+
+  return (
+    <svg
+      style={{
+        position: "absolute",
+        left: 0,
+        top: 0,
+        width: bounds.width,
+        height: bounds.height,
+        overflow: "visible",
+        pointerEvents: "none",
+        zIndex: Z.edges,
+      }}
+      aria-hidden
+    >
+      <defs>
+        <marker
+          id={MARKER_ID}
+          viewBox="0 0 10 10"
+          refX={9}
+          refY={5}
+          markerWidth={8}
+          markerHeight={8}
+          orient="auto"
+        >
+          <path d="M 0 0 L 10 5 L 0 10 z" fill={p.edgeFg} />
+        </marker>
+      </defs>
+      {edgePoints.map((e) => {
+        const d = catmullRom(e.points);
+        if (!d) return null;
+        const raw0 = e.raws[0];
+        const stroke = raw0?.color ?? p.edgeFg;
+        const dash = dashFor(raw0?.variant);
+        return (
+          <g key={`${e.from}->${e.to}`} style={{ pointerEvents: "stroke" }}>
+            <path
+              d={d}
+              fill="none"
+              stroke={stroke}
+              strokeWidth={1.5}
+              strokeDasharray={dash}
+              markerEnd={`url(#${MARKER_ID})`}
+            />
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export const PipelineGraphEdge = memo(PipelineGraphEdgeImpl);

--- a/src/components/PipelineGraph/PipelineGraphInspector.tsx
+++ b/src/components/PipelineGraph/PipelineGraphInspector.tsx
@@ -1,8 +1,20 @@
-import { useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
+
+import { CodeView } from "../CodeView";
 
 import type {
   PipelineGraphInspectorConfig,
   PipelineGraphTheme,
+  PipelineInspectorTab,
 } from "./PipelineGraph.types";
 import { clamp, type NormalizedNode } from "./PipelineGraph.utils";
 import { palette as themePalette, Z } from "./theme";
@@ -15,6 +27,54 @@ export interface PipelineGraphInspectorProps {
 }
 
 const DIVIDER_SIZE = 6;
+const TAB_ORDER: PipelineInspectorTab[] = [
+  "output",
+  "input",
+  "internal",
+  "logs",
+  "timing",
+  "error",
+];
+
+function isTabDisabled(tab: PipelineInspectorTab, node: NormalizedNode): boolean {
+  const raw = node.raw;
+  if (tab === "error") return node.status !== "failed";
+  if (tab === "logs") {
+    const logs = raw.logs;
+    return !logs || (Array.isArray(logs) && logs.length === 0);
+  }
+  return false;
+}
+
+function resolveValue(tab: PipelineInspectorTab, node: NormalizedNode): unknown {
+  const raw = node.raw;
+  switch (tab) {
+    case "input":
+      return raw.input;
+    case "output":
+      return raw.output;
+    case "internal":
+      return raw.internal;
+    case "logs":
+      return raw.logs;
+    case "timing":
+      return raw.timing;
+    case "error":
+      return raw.error;
+  }
+}
+
+function defaultRenderValue(value: unknown, theme: PipelineGraphTheme): ReactNode {
+  const p = themePalette[theme];
+  if (value === undefined) {
+    return <div style={{ color: p.mutedFg, fontSize: 12 }}>Nothing to show</div>;
+  }
+  if (typeof value === "string") {
+    return <CodeView code={value} language="markup" theme={theme} showLineNumbers={false} />;
+  }
+  const json = JSON.stringify(value, null, 2);
+  return <CodeView code={json} language="json" theme={theme} showLineNumbers={false} />;
+}
 
 export function PipelineGraphInspector(props: PipelineGraphInspectorProps) {
   const { selectedNode, config, theme, rootRef } = props;
@@ -23,6 +83,36 @@ export function PipelineGraphInspector(props: PipelineGraphInspectorProps) {
   const p = themePalette[theme];
   const [size, setSize] = useState(defaultSize);
   const dragRef = useRef<{ start: number; startSize: number } | null>(null);
+
+  const availableTabs = useMemo<PipelineInspectorTab[]>(() => {
+    const filter = config.tabs;
+    if (!filter) return TAB_ORDER;
+    const allowed = new Set(filter);
+    return TAB_ORDER.filter((t) => allowed.has(t));
+  }, [config.tabs]);
+
+  const firstEnabled = useMemo<PipelineInspectorTab | null>(() => {
+    if (!selectedNode) return null;
+    const preferred =
+      config.defaultTab ??
+      (selectedNode.status === "failed" ? "error" : "output");
+    if (
+      availableTabs.includes(preferred) &&
+      !isTabDisabled(preferred, selectedNode)
+    ) {
+      return preferred;
+    }
+    for (const t of availableTabs) {
+      if (!isTabDisabled(t, selectedNode)) return t;
+    }
+    return availableTabs[0] ?? null;
+  }, [selectedNode, availableTabs, config.defaultTab]);
+
+  const [activeTab, setActiveTab] = useState<PipelineInspectorTab | null>(firstEnabled);
+
+  useEffect(() => {
+    setActiveTab(firstEnabled);
+  }, [firstEnabled]);
 
   if (position === "none") return null;
 
@@ -54,21 +144,35 @@ export function PipelineGraphInspector(props: PipelineGraphInspectorProps) {
   };
 
   const isRight = position === "right";
-  const dividerStyle: React.CSSProperties = isRight
-    ? {
-        width: DIVIDER_SIZE,
-        height: "100%",
-        cursor: "col-resize",
-      }
-    : {
-        width: "100%",
-        height: DIVIDER_SIZE,
-        cursor: "row-resize",
-      };
-
-  const panelStyle: React.CSSProperties = isRight
+  const dividerStyle: CSSProperties = isRight
+    ? { width: DIVIDER_SIZE, height: "100%", cursor: "col-resize" }
+    : { width: "100%", height: DIVIDER_SIZE, cursor: "row-resize" };
+  const panelStyle: CSSProperties = isRight
     ? { width: size, height: "100%" }
     : { width: "100%", height: size };
+
+  const onTabKeyDown = (e: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (!selectedNode) return;
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    const dir = e.key === "ArrowRight" ? 1 : -1;
+    const start = activeTab ? availableTabs.indexOf(activeTab) : 0;
+    for (let i = 1; i <= availableTabs.length; i++) {
+      const idx = (start + dir * i + availableTabs.length) % availableTabs.length;
+      const t = availableTabs[idx];
+      if (!t) continue;
+      if (!isTabDisabled(t, selectedNode)) {
+        setActiveTab(t);
+        return;
+      }
+    }
+  };
+
+  const renderBody = (): ReactNode => {
+    if (!selectedNode || !activeTab) return null;
+    const value = resolveValue(activeTab, selectedNode);
+    return defaultRenderValue(value, theme);
+  };
 
   return (
     <>
@@ -104,12 +208,56 @@ export function PipelineGraphInspector(props: PipelineGraphInspectorProps) {
         }}
       >
         {selectedNode ? (
-          <div style={{ padding: 12, flex: 1, overflow: "auto" }}>
-            <div style={{ fontSize: 13, fontWeight: 600 }}>{selectedNode.label}</div>
-            <div style={{ fontSize: 11, color: p.mutedFg, marginTop: 2 }}>
-              {selectedNode.kind} · {selectedNode.status}
+          <>
+            <div style={{ padding: "10px 12px 6px", fontSize: 13, fontWeight: 600 }}>
+              {selectedNode.label}
+              <span style={{ fontWeight: 400, color: p.mutedFg, marginLeft: 8, fontSize: 11 }}>
+                {selectedNode.kind} · {selectedNode.status}
+              </span>
             </div>
-          </div>
+            <div
+              role="tablist"
+              style={{
+                display: "flex",
+                borderBottom: `1px solid ${p.inspectorBorder}`,
+                flexShrink: 0,
+              }}
+            >
+              {availableTabs.map((t) => {
+                const disabled = isTabDisabled(t, selectedNode);
+                const active = activeTab === t;
+                return (
+                  <button
+                    key={t}
+                    type="button"
+                    role="tab"
+                    aria-selected={active}
+                    disabled={disabled}
+                    onClick={() => setActiveTab(t)}
+                    onKeyDown={onTabKeyDown}
+                    style={{
+                      padding: "8px 12px",
+                      border: "none",
+                      background: "transparent",
+                      borderBottom: active
+                        ? `2px solid ${p.selectionRing}`
+                        : "2px solid transparent",
+                      color: disabled ? p.mutedFg : p.fg,
+                      cursor: disabled ? "not-allowed" : "pointer",
+                      fontSize: 12,
+                      textTransform: "capitalize",
+                      opacity: disabled ? 0.55 : 1,
+                    }}
+                  >
+                    {t}
+                  </button>
+                );
+              })}
+            </div>
+            <div role="tabpanel" style={{ padding: 12, overflow: "auto", flex: 1 }}>
+              {renderBody()}
+            </div>
+          </>
         ) : (
           <div
             style={{

--- a/src/components/PipelineGraph/PipelineGraphInspector.tsx
+++ b/src/components/PipelineGraph/PipelineGraphInspector.tsx
@@ -1,0 +1,130 @@
+import { useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+
+import type {
+  PipelineGraphInspectorConfig,
+  PipelineGraphTheme,
+} from "./PipelineGraph.types";
+import { clamp, type NormalizedNode } from "./PipelineGraph.utils";
+import { palette as themePalette, Z } from "./theme";
+
+export interface PipelineGraphInspectorProps {
+  selectedNode: NormalizedNode | null;
+  config: PipelineGraphInspectorConfig;
+  theme: PipelineGraphTheme;
+  rootRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const DIVIDER_SIZE = 6;
+
+export function PipelineGraphInspector(props: PipelineGraphInspectorProps) {
+  const { selectedNode, config, theme, rootRef } = props;
+  const position = config.position ?? "right";
+  const defaultSize = config.defaultSize ?? (position === "right" ? 380 : 280);
+  const p = themePalette[theme];
+  const [size, setSize] = useState(defaultSize);
+  const dragRef = useRef<{ start: number; startSize: number } | null>(null);
+
+  if (position === "none") return null;
+
+  const onDividerPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const startClient = position === "right" ? e.clientX : e.clientY;
+    const rect = rootRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const axis = position === "right" ? rect.width : rect.height;
+    const maxSize = axis * 0.8;
+    const minSize = axis * 0.2;
+    dragRef.current = { start: startClient, startSize: size };
+
+    const move = (ev: PointerEvent) => {
+      if (!dragRef.current) return;
+      const cur = position === "right" ? ev.clientX : ev.clientY;
+      const delta = dragRef.current.start - cur;
+      const next = clamp(dragRef.current.startSize + delta, minSize, maxSize);
+      setSize(next);
+    };
+    const up = () => {
+      dragRef.current = null;
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+  };
+
+  const isRight = position === "right";
+  const dividerStyle: React.CSSProperties = isRight
+    ? {
+        width: DIVIDER_SIZE,
+        height: "100%",
+        cursor: "col-resize",
+      }
+    : {
+        width: "100%",
+        height: DIVIDER_SIZE,
+        cursor: "row-resize",
+      };
+
+  const panelStyle: React.CSSProperties = isRight
+    ? { width: size, height: "100%" }
+    : { width: "100%", height: size };
+
+  return (
+    <>
+      <div
+        role="separator"
+        aria-orientation={isRight ? "vertical" : "horizontal"}
+        onPointerDown={onDividerPointerDown}
+        style={{
+          ...dividerStyle,
+          background: p.inspectorBorder,
+          flexShrink: 0,
+          zIndex: Z.inspector,
+          userSelect: "none",
+          touchAction: "none",
+        }}
+      />
+      <div
+        role="complementary"
+        aria-label="Inspector"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          ...panelStyle,
+          background: p.inspectorBg,
+          color: p.fg,
+          borderLeft: isRight ? `1px solid ${p.inspectorBorder}` : undefined,
+          borderTop: !isRight ? `1px solid ${p.inspectorBorder}` : undefined,
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden",
+          flexShrink: 0,
+          zIndex: Z.inspector,
+          boxSizing: "border-box",
+        }}
+      >
+        {selectedNode ? (
+          <div style={{ padding: 12, flex: 1, overflow: "auto" }}>
+            <div style={{ fontSize: 13, fontWeight: 600 }}>{selectedNode.label}</div>
+            <div style={{ fontSize: 11, color: p.mutedFg, marginTop: 2 }}>
+              {selectedNode.kind} · {selectedNode.status}
+            </div>
+          </div>
+        ) : (
+          <div
+            style={{
+              flex: 1,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: p.mutedFg,
+              fontSize: 12,
+            }}
+          >
+            No selection
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/PipelineGraph/PipelineGraphInspector.tsx
+++ b/src/components/PipelineGraph/PipelineGraphInspector.tsx
@@ -15,6 +15,7 @@ import type {
   PipelineGraphInspectorConfig,
   PipelineGraphTheme,
   PipelineInspectorTab,
+  PipelineNode,
   PipelineNodeError,
   PipelineNodeLog,
   PipelineNodeTiming,
@@ -27,6 +28,11 @@ export interface PipelineGraphInspectorProps {
   config: PipelineGraphInspectorConfig;
   theme: PipelineGraphTheme;
   rootRef: React.RefObject<HTMLDivElement | null>;
+  renderInspectorValue?: (
+    node: PipelineNode,
+    tab: PipelineInspectorTab,
+    value: unknown,
+  ) => ReactNode | undefined;
 }
 
 const DIVIDER_SIZE = 6;
@@ -267,7 +273,7 @@ function renderError(
 }
 
 export function PipelineGraphInspector(props: PipelineGraphInspectorProps) {
-  const { selectedNode, config, theme, rootRef } = props;
+  const { selectedNode, config, theme, rootRef, renderInspectorValue } = props;
   const position = config.position ?? "right";
   const defaultSize = config.defaultSize ?? (position === "right" ? 380 : 280);
   const p = themePalette[theme];
@@ -360,6 +366,9 @@ export function PipelineGraphInspector(props: PipelineGraphInspectorProps) {
 
   const renderBody = (): ReactNode => {
     if (!selectedNode || !activeTab) return null;
+    const value = resolveValue(activeTab, selectedNode);
+    const custom = renderInspectorValue?.(selectedNode.raw, activeTab, value);
+    if (custom !== undefined) return custom;
     switch (activeTab) {
       case "logs":
         return renderLogs(selectedNode.raw.logs, theme);
@@ -368,7 +377,7 @@ export function PipelineGraphInspector(props: PipelineGraphInspectorProps) {
       case "error":
         return renderError(selectedNode.raw.error, theme);
       default:
-        return defaultRenderValue(resolveValue(activeTab, selectedNode), theme);
+        return defaultRenderValue(value, theme);
     }
   };
 

--- a/src/components/PipelineGraph/PipelineGraphInspector.tsx
+++ b/src/components/PipelineGraph/PipelineGraphInspector.tsx
@@ -15,9 +15,12 @@ import type {
   PipelineGraphInspectorConfig,
   PipelineGraphTheme,
   PipelineInspectorTab,
+  PipelineNodeError,
+  PipelineNodeLog,
+  PipelineNodeTiming,
 } from "./PipelineGraph.types";
-import { clamp, type NormalizedNode } from "./PipelineGraph.utils";
-import { palette as themePalette, Z } from "./theme";
+import { clamp, fmtMs, type NormalizedNode } from "./PipelineGraph.utils";
+import { palette as themePalette, statusPalette, Z } from "./theme";
 
 export interface PipelineGraphInspectorProps {
   selectedNode: NormalizedNode | null;
@@ -74,6 +77,193 @@ function defaultRenderValue(value: unknown, theme: PipelineGraphTheme): ReactNod
   }
   const json = JSON.stringify(value, null, 2);
   return <CodeView code={json} language="json" theme={theme} showLineNumbers={false} />;
+}
+
+function levelColor(level: string | undefined, theme: PipelineGraphTheme): string {
+  const p = themePalette[theme];
+  if (level === "warn") return "#f59e0b";
+  if (level === "error") return "#ef4444";
+  if (level === "debug") return p.mutedFg;
+  return p.fg;
+}
+
+function renderLogs(
+  value: unknown,
+  theme: PipelineGraphTheme,
+): ReactNode {
+  const p = themePalette[theme];
+  if (!Array.isArray(value) || value.length === 0) {
+    return <div style={{ color: p.mutedFg, fontSize: 12 }}>Nothing to show</div>;
+  }
+  return (
+    <div style={{ fontFamily: "monospace", fontSize: 11 }}>
+      {(value as Array<string | PipelineNodeLog>).map((l, i) => {
+        const s: PipelineNodeLog = typeof l === "string" ? { message: l } : l;
+        return (
+          <div
+            key={i}
+            style={{
+              display: "flex",
+              gap: 8,
+              padding: "2px 0",
+              alignItems: "flex-start",
+            }}
+          >
+            {s.t != null ? (
+              <span style={{ color: p.mutedFg, width: 96, flexShrink: 0 }}>
+                {new Date(s.t).toISOString().slice(11, 23)}
+              </span>
+            ) : null}
+            {s.level ? (
+              <span
+                style={{
+                  color: levelColor(s.level, theme),
+                  width: 48,
+                  flexShrink: 0,
+                  textTransform: "uppercase",
+                }}
+              >
+                {s.level}
+              </span>
+            ) : null}
+            <span style={{ flex: 1, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+              {s.message}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function fmtTs(ms: number | undefined): string {
+  if (ms == null) return "—";
+  const d = new Date(ms);
+  const date = d.toISOString().slice(0, 10);
+  const time = d.toISOString().slice(11, 23);
+  return `${date} ${time}`;
+}
+
+function renderTiming(node: NormalizedNode, theme: PipelineGraphTheme): ReactNode {
+  const p = themePalette[theme];
+  const t: PipelineNodeTiming | null = node.timing;
+  const rows: Array<[string, string]> = [];
+  const duration =
+    t?.durationMs ??
+    (t?.startedAt != null && t.endedAt != null ? t.endedAt - t.startedAt : null);
+
+  if (t) {
+    rows.push(["started", fmtTs(t.startedAt)]);
+    rows.push(["ended", fmtTs(t.endedAt)]);
+    if (duration != null) rows.push(["duration", fmtMs(duration)]);
+  }
+  if (node.kind === "loop") {
+    rows.push(["iterations", String(node.iterations ?? "?")]);
+    if (node.currentIteration != null) {
+      rows.push(["current", String(node.currentIteration)]);
+    }
+    if (
+      duration != null &&
+      node.iterations != null &&
+      node.iterations > 0 &&
+      node.currentIteration != null &&
+      node.currentIteration > 0
+    ) {
+      rows.push(["avg / iter", fmtMs(duration / node.currentIteration)]);
+    }
+  }
+
+  if (rows.length === 0) {
+    return <div style={{ color: p.mutedFg, fontSize: 12 }}>Nothing to show</div>;
+  }
+
+  const timelineBar =
+    node.kind === "group" && t?.startedAt != null && duration != null && duration > 0 ? (
+      <div style={{ marginTop: 12 }}>
+        <div style={{ fontSize: 11, color: p.mutedFg, marginBottom: 6 }}>children</div>
+        <div
+          style={{
+            position: "relative",
+            height: 10 * Math.max(1, node.children.length),
+            background: p.border,
+            borderRadius: 2,
+          }}
+        />
+      </div>
+    ) : null;
+
+  return (
+    <div>
+      <table
+        style={{
+          width: "100%",
+          borderCollapse: "collapse",
+          fontSize: 12,
+          fontFamily: "monospace",
+        }}
+      >
+        <tbody>
+          {rows.map(([k, v]) => (
+            <tr key={k}>
+              <td
+                style={{
+                  color: p.mutedFg,
+                  padding: "2px 8px 2px 0",
+                  width: 96,
+                  verticalAlign: "top",
+                }}
+              >
+                {k}
+              </td>
+              <td style={{ padding: "2px 0" }}>{v}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {timelineBar}
+    </div>
+  );
+}
+
+function renderError(
+  err: PipelineNodeError | undefined,
+  theme: PipelineGraphTheme,
+): ReactNode {
+  const p = themePalette[theme];
+  if (!err) {
+    return <div style={{ color: p.mutedFg, fontSize: 12 }}>Nothing to show</div>;
+  }
+  const accent = statusPalette[theme].failed.accent;
+  return (
+    <div>
+      <div style={{ fontWeight: 600, color: accent, marginBottom: 8, fontSize: 13 }}>
+        {err.message}
+      </div>
+      {err.stack ? (
+        <CodeView
+          code={err.stack}
+          language="markup"
+          theme={theme}
+          showLineNumbers={false}
+        />
+      ) : null}
+      {err.cause !== undefined ? (
+        <details style={{ marginTop: 12 }}>
+          <summary style={{ cursor: "pointer", fontSize: 11, color: p.mutedFg }}>
+            cause
+          </summary>
+          <div style={{ marginTop: 6 }}>
+            <CodeView
+              code={JSON.stringify(err.cause, null, 2)}
+              language="json"
+              theme={theme}
+              showLineNumbers={false}
+            />
+          </div>
+        </details>
+      ) : null}
+    </div>
+  );
 }
 
 export function PipelineGraphInspector(props: PipelineGraphInspectorProps) {
@@ -170,8 +360,16 @@ export function PipelineGraphInspector(props: PipelineGraphInspectorProps) {
 
   const renderBody = (): ReactNode => {
     if (!selectedNode || !activeTab) return null;
-    const value = resolveValue(activeTab, selectedNode);
-    return defaultRenderValue(value, theme);
+    switch (activeTab) {
+      case "logs":
+        return renderLogs(selectedNode.raw.logs, theme);
+      case "timing":
+        return renderTiming(selectedNode, theme);
+      case "error":
+        return renderError(selectedNode.raw.error, theme);
+      default:
+        return defaultRenderValue(resolveValue(activeTab, selectedNode), theme);
+    }
   };
 
   return (

--- a/src/components/PipelineGraph/PipelineGraphNode.tsx
+++ b/src/components/PipelineGraph/PipelineGraphNode.tsx
@@ -1,0 +1,103 @@
+import { memo, type MouseEvent } from "react";
+
+import type { PipelineGraphTheme, PipelineNode } from "./PipelineGraph.types";
+import { formatDuration, type NormalizedNode, type VisibleNode } from "./PipelineGraph.utils";
+import { palette as themePalette, statusPalette } from "./theme";
+
+export interface PipelineGraphNodeProps {
+  node: VisibleNode;
+  normalized: NormalizedNode;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  selected: boolean;
+  expanded: boolean;
+  theme: PipelineGraphTheme;
+  onSelect: (id: string) => void;
+  onToggleExpand: (id: string) => void;
+  onDoubleClick?: (node: PipelineNode) => void;
+}
+
+function PipelineGraphNodeImpl(props: PipelineGraphNodeProps) {
+  const { node, normalized, x, y, w, h, selected, theme, onSelect, onDoubleClick } = props;
+  const p = themePalette[theme];
+  const s = statusPalette[theme][normalized.status];
+
+  const handleClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    onSelect(node.id);
+  };
+  const handleDoubleClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    onDoubleClick?.(normalized.raw);
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={-1}
+      data-node-id={node.id}
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
+      style={{
+        position: "absolute",
+        left: x,
+        top: y,
+        width: w,
+        height: h,
+        border: `1px solid ${p.border}`,
+        borderRadius: 8,
+        background: p.cardBg,
+        color: p.fg,
+        overflow: "hidden",
+        cursor: "pointer",
+        outline: selected ? `2px solid ${p.selectionRing}` : "none",
+        outlineOffset: 2,
+        transition: "outline 120ms",
+        boxSizing: "border-box",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          width: 4,
+          height: "100%",
+          background: s.accent,
+        }}
+      />
+      <header
+        style={{
+          padding: "8px 10px 6px 14px",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          fontSize: 13,
+        }}
+      >
+        <span aria-hidden style={{ color: s.accent }}>
+          {s.icon}
+        </span>
+        <span
+          style={{
+            flex: 1,
+            fontWeight: 500,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {normalized.label}
+        </span>
+      </header>
+      <div style={{ padding: "0 14px", fontSize: 11, color: p.mutedFg }} />
+      <footer style={{ padding: "4px 14px 8px", fontSize: 10, color: p.mutedFg }}>
+        {formatDuration(normalized)}
+      </footer>
+    </div>
+  );
+}
+
+export const PipelineGraphNode = memo(PipelineGraphNodeImpl);

--- a/src/components/PipelineGraph/PipelineGraphNode.tsx
+++ b/src/components/PipelineGraph/PipelineGraphNode.tsx
@@ -1,8 +1,21 @@
-import { memo, type MouseEvent } from "react";
+import { memo, useEffect, type MouseEvent } from "react";
 
 import type { PipelineGraphTheme, PipelineNode } from "./PipelineGraph.types";
 import { formatDuration, type NormalizedNode, type VisibleNode } from "./PipelineGraph.utils";
 import { palette as themePalette, statusPalette } from "./theme";
+
+const INJECTED = new WeakSet<Document>();
+function injectOnce(doc: Document): void {
+  if (INJECTED.has(doc)) return;
+  INJECTED.add(doc);
+  const s = doc.createElement("style");
+  s.setAttribute("data-pg-style", "1");
+  s.textContent = `
+@keyframes pg-pulse { 0%,100% { opacity: .4 } 50% { opacity: 1 } }
+[data-pg-running="1"] { animation: pg-pulse 1.2s ease-in-out infinite; }
+`;
+  doc.head.appendChild(s);
+}
 
 export interface PipelineGraphNodeProps {
   node: VisibleNode;
@@ -23,6 +36,12 @@ function PipelineGraphNodeImpl(props: PipelineGraphNodeProps) {
   const { node, normalized, x, y, w, h, selected, theme, onSelect, onDoubleClick } = props;
   const p = themePalette[theme];
   const s = statusPalette[theme][normalized.status];
+  const accent = normalized.raw.accentColor ?? s.accent;
+  const isRunning = normalized.status === "running";
+
+  useEffect(() => {
+    if (typeof document !== "undefined") injectOnce(document);
+  }, []);
 
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
@@ -59,13 +78,14 @@ function PipelineGraphNodeImpl(props: PipelineGraphNodeProps) {
       }}
     >
       <div
+        data-pg-running={isRunning ? "1" : "0"}
         style={{
           position: "absolute",
           left: 0,
           top: 0,
           width: 4,
           height: "100%",
-          background: s.accent,
+          background: accent,
         }}
       />
       <header
@@ -77,7 +97,7 @@ function PipelineGraphNodeImpl(props: PipelineGraphNodeProps) {
           fontSize: 13,
         }}
       >
-        <span aria-hidden style={{ color: s.accent }}>
+        <span aria-hidden style={{ color: accent }}>
           {s.icon}
         </span>
         <span

--- a/src/components/PipelineGraph/PipelineGraphNode.tsx
+++ b/src/components/PipelineGraph/PipelineGraphNode.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo, useEffect, type MouseEvent } from "react";
+import { Fragment, memo, useEffect, type MouseEvent, type ReactNode } from "react";
 
 import type { PipelineGraphTheme, PipelineNode } from "./PipelineGraph.types";
 import { formatDuration, type NormalizedNode, type VisibleNode } from "./PipelineGraph.utils";
@@ -31,6 +31,10 @@ export interface PipelineGraphNodeProps {
   onSelect: (id: string) => void;
   onToggleExpand: (id: string) => void;
   onDoubleClick?: (node: PipelineNode) => void;
+  renderNode?: (
+    node: PipelineNode,
+    ctx: { selected: boolean; expanded: boolean },
+  ) => ReactNode | undefined;
 }
 
 interface ChildAgg {
@@ -101,6 +105,7 @@ function PipelineGraphNodeImpl(props: PipelineGraphNodeProps) {
     onSelect,
     onToggleExpand,
     onDoubleClick,
+    renderNode,
   } = props;
   const p = themePalette[theme];
   const s = statusPalette[theme][normalized.status];
@@ -224,6 +229,75 @@ function PipelineGraphNodeImpl(props: PipelineGraphNodeProps) {
       </button>
     ) : null;
 
+  const custom = renderNode?.(normalized.raw, { selected, expanded });
+
+  const defaultInner = (
+    <>
+      <div
+        data-pg-running={isRunning ? "1" : "0"}
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          width: 4,
+          height: "100%",
+          background: accent,
+        }}
+      />
+      <header
+        style={{
+          padding: "8px 10px 6px 14px",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          fontSize: 13,
+        }}
+      >
+        <span aria-hidden style={{ color: accent }}>
+          {headerIcon}
+        </span>
+        <span
+          style={{
+            flex: 1,
+            fontWeight: 500,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {normalized.label}
+          {loopLabelSuffix}
+        </span>
+        {toggleButton}
+      </header>
+      <div style={{ padding: "0 14px", fontSize: 11, color: p.mutedFg }}>
+        {kind === "group" && agg ? formatAggregate(agg) : null}
+        {kind === "loop" && loopIter > 0 ? (
+          <div
+            style={{
+              marginTop: 4,
+              height: 4,
+              background: p.border,
+              borderRadius: 2,
+              overflow: "hidden",
+            }}
+          >
+            <div
+              style={{
+                width: `${loopPct}%`,
+                height: "100%",
+                background: accent,
+              }}
+            />
+          </div>
+        ) : null}
+      </div>
+      <footer style={{ padding: "4px 14px 8px", fontSize: 10, color: p.mutedFg }}>
+        {kind === "task" ? formatDuration(normalized) : groupFooter}
+      </footer>
+    </>
+  );
+
   return (
     <Fragment>
       {stackShadows}
@@ -235,68 +309,7 @@ function PipelineGraphNodeImpl(props: PipelineGraphNodeProps) {
         onDoubleClick={handleDoubleClick}
         style={cardStyle}
       >
-        <div
-          data-pg-running={isRunning ? "1" : "0"}
-          style={{
-            position: "absolute",
-            left: 0,
-            top: 0,
-            width: 4,
-            height: "100%",
-            background: accent,
-          }}
-        />
-        <header
-          style={{
-            padding: "8px 10px 6px 14px",
-            display: "flex",
-            alignItems: "center",
-            gap: 8,
-            fontSize: 13,
-          }}
-        >
-          <span aria-hidden style={{ color: accent }}>
-            {headerIcon}
-          </span>
-          <span
-            style={{
-              flex: 1,
-              fontWeight: 500,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {normalized.label}
-            {loopLabelSuffix}
-          </span>
-          {toggleButton}
-        </header>
-        <div style={{ padding: "0 14px", fontSize: 11, color: p.mutedFg }}>
-          {kind === "group" && agg ? formatAggregate(agg) : null}
-          {kind === "loop" && loopIter > 0 ? (
-            <div
-              style={{
-                marginTop: 4,
-                height: 4,
-                background: p.border,
-                borderRadius: 2,
-                overflow: "hidden",
-              }}
-            >
-              <div
-                style={{
-                  width: `${loopPct}%`,
-                  height: "100%",
-                  background: accent,
-                }}
-              />
-            </div>
-          ) : null}
-        </div>
-        <footer style={{ padding: "4px 14px 8px", fontSize: 10, color: p.mutedFg }}>
-          {kind === "task" ? formatDuration(normalized) : groupFooter}
-        </footer>
+        {custom !== undefined ? custom : defaultInner}
       </div>
     </Fragment>
   );

--- a/src/components/PipelineGraph/PipelineGraphNode.tsx
+++ b/src/components/PipelineGraph/PipelineGraphNode.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, type MouseEvent } from "react";
+import { Fragment, memo, useEffect, type MouseEvent } from "react";
 
 import type { PipelineGraphTheme, PipelineNode } from "./PipelineGraph.types";
 import { formatDuration, type NormalizedNode, type VisibleNode } from "./PipelineGraph.utils";
@@ -20,6 +20,7 @@ function injectOnce(doc: Document): void {
 export interface PipelineGraphNodeProps {
   node: VisibleNode;
   normalized: NormalizedNode;
+  byId: Map<string, NormalizedNode>;
   x: number;
   y: number;
   w: number;
@@ -32,16 +33,86 @@ export interface PipelineGraphNodeProps {
   onDoubleClick?: (node: PipelineNode) => void;
 }
 
+interface ChildAgg {
+  total: number;
+  counts: Record<string, number>;
+  minStart: number | null;
+  maxEnd: number | null;
+}
+
+function aggregateChildren(parent: NormalizedNode, byId: Map<string, NormalizedNode>): ChildAgg {
+  const counts: Record<string, number> = {
+    success: 0,
+    failed: 0,
+    running: 0,
+    pending: 0,
+    skipped: 0,
+    cancelled: 0,
+  };
+  let minStart: number | null = null;
+  let maxEnd: number | null = null;
+  let total = 0;
+  for (const id of parent.children) {
+    const c = byId.get(id);
+    if (!c) continue;
+    total++;
+    counts[c.status] = (counts[c.status] ?? 0) + 1;
+    const t = c.timing;
+    if (t?.startedAt != null) {
+      if (minStart == null || t.startedAt < minStart) minStart = t.startedAt;
+    }
+    if (t?.endedAt != null) {
+      if (maxEnd == null || t.endedAt > maxEnd) maxEnd = t.endedAt;
+    }
+  }
+  return { total, counts, minStart, maxEnd };
+}
+
+function formatAggregate(agg: ChildAgg): string {
+  if (agg.total === 0) return "empty";
+  const parts: string[] = [`${agg.total} steps`];
+  const keys: Array<[string, string]> = [
+    ["success", "succeeded"],
+    ["failed", "failed"],
+    ["running", "running"],
+    ["pending", "pending"],
+    ["skipped", "skipped"],
+    ["cancelled", "cancelled"],
+  ];
+  for (const [k, label] of keys) {
+    const c = agg.counts[k] ?? 0;
+    if (c > 0) parts.push(`${c} ${label}`);
+  }
+  return parts.join(" · ");
+}
+
 function PipelineGraphNodeImpl(props: PipelineGraphNodeProps) {
-  const { node, normalized, x, y, w, h, selected, theme, onSelect, onDoubleClick } = props;
+  const {
+    node,
+    normalized,
+    byId,
+    x,
+    y,
+    w,
+    h,
+    selected,
+    expanded,
+    theme,
+    onSelect,
+    onToggleExpand,
+    onDoubleClick,
+  } = props;
   const p = themePalette[theme];
   const s = statusPalette[theme][normalized.status];
   const accent = normalized.raw.accentColor ?? s.accent;
   const isRunning = normalized.status === "running";
+  const kind = node.kind;
 
   useEffect(() => {
     if (typeof document !== "undefined") injectOnce(document);
   }, []);
+
+  if (expanded && (kind === "group" || kind === "loop")) return null;
 
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
@@ -51,72 +122,183 @@ function PipelineGraphNodeImpl(props: PipelineGraphNodeProps) {
     e.stopPropagation();
     onDoubleClick?.(normalized.raw);
   };
+  const handleToggle = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onToggleExpand(node.id);
+  };
 
-  return (
-    <div
-      role="button"
-      tabIndex={-1}
-      data-node-id={node.id}
-      onClick={handleClick}
-      onDoubleClick={handleDoubleClick}
-      style={{
-        position: "absolute",
-        left: x,
-        top: y,
-        width: w,
-        height: h,
-        border: `1px solid ${p.border}`,
-        borderRadius: 8,
-        background: p.cardBg,
-        color: p.fg,
-        overflow: "hidden",
-        cursor: "pointer",
-        outline: selected ? `2px solid ${p.selectionRing}` : "none",
-        outlineOffset: 2,
-        transition: "outline 120ms",
-        boxSizing: "border-box",
-      }}
-    >
-      <div
-        data-pg-running={isRunning ? "1" : "0"}
+  const cardStyle = {
+    position: "absolute" as const,
+    left: x,
+    top: y,
+    width: w,
+    height: h,
+    border: `1px solid ${p.border}`,
+    borderRadius: 8,
+    background: p.cardBg,
+    color: p.fg,
+    overflow: "hidden",
+    cursor: "pointer",
+    outline: selected ? `2px solid ${p.selectionRing}` : "none",
+    outlineOffset: 2,
+    transition: "outline 120ms",
+    boxSizing: "border-box" as const,
+  };
+
+  const agg = kind === "group" ? aggregateChildren(normalized, byId) : null;
+  const loopIter = normalized.iterations ?? 0;
+  const loopCurrent = normalized.currentIteration ?? 0;
+  const loopPct = loopIter > 0 ? Math.min(100, (loopCurrent / loopIter) * 100) : 0;
+
+  const headerIcon =
+    kind === "loop" ? "⟳" : kind === "group" ? "▦" : s.icon;
+
+  const loopLabelSuffix =
+    kind === "loop"
+      ? isRunning
+        ? ` (${loopCurrent}/${loopIter})`
+        : ` (${loopIter}×)`
+      : "";
+
+  const groupFooter = agg
+    ? agg.minStart != null && agg.maxEnd != null
+      ? `${((agg.maxEnd - agg.minStart) / 1000).toFixed(1)}s total`
+      : ""
+    : "";
+
+  const stackShadows =
+    kind === "loop" ? (
+      <Fragment>
+        <div
+          aria-hidden
+          style={{
+            position: "absolute",
+            left: x + 4,
+            top: y + 4,
+            width: w,
+            height: h,
+            opacity: 0.5,
+            border: `1px solid ${p.border}`,
+            borderRadius: 8,
+            background: p.cardBg,
+            pointerEvents: "none",
+            boxSizing: "border-box",
+          }}
+        />
+        <div
+          aria-hidden
+          style={{
+            position: "absolute",
+            left: x + 8,
+            top: y + 8,
+            width: w,
+            height: h,
+            opacity: 0.25,
+            border: `1px solid ${p.border}`,
+            borderRadius: 8,
+            background: p.cardBg,
+            pointerEvents: "none",
+            boxSizing: "border-box",
+          }}
+        />
+      </Fragment>
+    ) : null;
+
+  const toggleButton =
+    kind === "group" || kind === "loop" ? (
+      <button
+        type="button"
+        onClick={handleToggle}
+        aria-label={expanded ? "collapse" : "expand"}
         style={{
-          position: "absolute",
-          left: 0,
-          top: 0,
-          width: 4,
-          height: "100%",
-          background: accent,
-        }}
-      />
-      <header
-        style={{
-          padding: "8px 10px 6px 14px",
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-          fontSize: 13,
+          border: "none",
+          background: "transparent",
+          cursor: "pointer",
+          fontSize: 12,
+          color: p.mutedFg,
+          padding: "0 2px",
+          lineHeight: 1,
         }}
       >
-        <span aria-hidden style={{ color: accent }}>
-          {s.icon}
-        </span>
-        <span
+        ▸
+      </button>
+    ) : null;
+
+  return (
+    <Fragment>
+      {stackShadows}
+      <div
+        role="button"
+        tabIndex={-1}
+        data-node-id={node.id}
+        onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
+        style={cardStyle}
+      >
+        <div
+          data-pg-running={isRunning ? "1" : "0"}
           style={{
-            flex: 1,
-            fontWeight: 500,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
+            position: "absolute",
+            left: 0,
+            top: 0,
+            width: 4,
+            height: "100%",
+            background: accent,
+          }}
+        />
+        <header
+          style={{
+            padding: "8px 10px 6px 14px",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            fontSize: 13,
           }}
         >
-          {normalized.label}
-        </span>
-      </header>
-      <div style={{ padding: "0 14px", fontSize: 11, color: p.mutedFg }} />
-      <footer style={{ padding: "4px 14px 8px", fontSize: 10, color: p.mutedFg }}>
-        {formatDuration(normalized)}
-      </footer>
-    </div>
+          <span aria-hidden style={{ color: accent }}>
+            {headerIcon}
+          </span>
+          <span
+            style={{
+              flex: 1,
+              fontWeight: 500,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {normalized.label}
+            {loopLabelSuffix}
+          </span>
+          {toggleButton}
+        </header>
+        <div style={{ padding: "0 14px", fontSize: 11, color: p.mutedFg }}>
+          {kind === "group" && agg ? formatAggregate(agg) : null}
+          {kind === "loop" && loopIter > 0 ? (
+            <div
+              style={{
+                marginTop: 4,
+                height: 4,
+                background: p.border,
+                borderRadius: 2,
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  width: `${loopPct}%`,
+                  height: "100%",
+                  background: accent,
+                }}
+              />
+            </div>
+          ) : null}
+        </div>
+        <footer style={{ padding: "4px 14px 8px", fontSize: 10, color: p.mutedFg }}>
+          {kind === "task" ? formatDuration(normalized) : groupFooter}
+        </footer>
+      </div>
+    </Fragment>
   );
 }
 

--- a/src/components/PipelineGraph/index.ts
+++ b/src/components/PipelineGraph/index.ts
@@ -1,0 +1,16 @@
+export { PipelineGraph } from "./PipelineGraph";
+export type {
+  PipelineGraphProps,
+  PipelineGraphTheme,
+  PipelineGraphDirection,
+  PipelineGraphViewport,
+  PipelineGraphInspectorConfig,
+  PipelineInspectorTab,
+  PipelineNode,
+  PipelineNodeKind,
+  PipelineNodeStatus,
+  PipelineNodeTiming,
+  PipelineNodeLog,
+  PipelineNodeError,
+  PipelineEdge,
+} from "./PipelineGraph.types";

--- a/src/components/PipelineGraph/theme.ts
+++ b/src/components/PipelineGraph/theme.ts
@@ -9,6 +9,7 @@ export interface PipelinePalette {
   selectionRing: string;
   edgeFg: string;
   edgeFgDim: string;
+  edgeArrowFill: string;
   clusterBg: string;
   clusterBorder: string;
   inspectorBg: string;
@@ -36,6 +37,7 @@ export const palette: Record<PipelineGraphTheme, PipelinePalette> = {
     selectionRing: "#2563eb",
     edgeFg: "rgba(0,0,0,0.45)",
     edgeFgDim: "rgba(0,0,0,0.18)",
+    edgeArrowFill: "#4b5563",
     clusterBg: "rgba(0,0,0,0.025)",
     clusterBorder: "rgba(0,0,0,0.10)",
     inspectorBg: "#ffffff",
@@ -55,6 +57,7 @@ export const palette: Record<PipelineGraphTheme, PipelinePalette> = {
     selectionRing: "#60a5fa",
     edgeFg: "rgba(255,255,255,0.55)",
     edgeFgDim: "rgba(255,255,255,0.22)",
+    edgeArrowFill: "#cbd5e1",
     clusterBg: "rgba(255,255,255,0.03)",
     clusterBorder: "rgba(255,255,255,0.10)",
     inspectorBg: "#111827",

--- a/src/components/PipelineGraph/theme.ts
+++ b/src/components/PipelineGraph/theme.ts
@@ -1,0 +1,96 @@
+import type { PipelineGraphTheme, PipelineNodeStatus } from "./PipelineGraph.types";
+
+export interface PipelinePalette {
+  canvasBg: string;
+  cardBg: string;
+  border: string;
+  fg: string;
+  mutedFg: string;
+  selectionRing: string;
+  edgeFg: string;
+  edgeFgDim: string;
+  clusterBg: string;
+  clusterBorder: string;
+  inspectorBg: string;
+  inspectorBorder: string;
+  tooltipBg: string;
+  tooltipFg: string;
+  controlBg: string;
+  controlFg: string;
+  controlHoverBg: string;
+}
+
+export interface StatusTokens {
+  accent: string;
+  fg: string;
+  icon: string;
+}
+
+export const palette: Record<PipelineGraphTheme, PipelinePalette> = {
+  light: {
+    canvasBg: "#f9fafb",
+    cardBg: "#ffffff",
+    border: "rgba(0,0,0,0.10)",
+    fg: "#111827",
+    mutedFg: "#6b7280",
+    selectionRing: "#2563eb",
+    edgeFg: "rgba(0,0,0,0.45)",
+    edgeFgDim: "rgba(0,0,0,0.18)",
+    clusterBg: "rgba(0,0,0,0.025)",
+    clusterBorder: "rgba(0,0,0,0.10)",
+    inspectorBg: "#ffffff",
+    inspectorBorder: "rgba(0,0,0,0.08)",
+    tooltipBg: "rgba(17,24,39,0.95)",
+    tooltipFg: "#f9fafb",
+    controlBg: "rgba(255,255,255,0.9)",
+    controlFg: "#374151",
+    controlHoverBg: "rgba(0,0,0,0.06)",
+  },
+  dark: {
+    canvasBg: "#0b0f19",
+    cardBg: "#1a1f2e",
+    border: "rgba(255,255,255,0.10)",
+    fg: "#e5e7eb",
+    mutedFg: "#9ca3af",
+    selectionRing: "#60a5fa",
+    edgeFg: "rgba(255,255,255,0.55)",
+    edgeFgDim: "rgba(255,255,255,0.22)",
+    clusterBg: "rgba(255,255,255,0.03)",
+    clusterBorder: "rgba(255,255,255,0.10)",
+    inspectorBg: "#111827",
+    inspectorBorder: "rgba(255,255,255,0.10)",
+    tooltipBg: "rgba(249,250,251,0.95)",
+    tooltipFg: "#111827",
+    controlBg: "rgba(26,31,46,0.9)",
+    controlFg: "#d1d5db",
+    controlHoverBg: "rgba(255,255,255,0.06)",
+  },
+};
+
+export const statusPalette: Record<PipelineGraphTheme, Record<PipelineNodeStatus, StatusTokens>> = {
+  light: {
+    pending: { accent: "#9ca3af", fg: "#374151", icon: "●" },
+    running: { accent: "#3b82f6", fg: "#1e3a8a", icon: "▶" },
+    success: { accent: "#10b981", fg: "#065f46", icon: "✓" },
+    failed: { accent: "#ef4444", fg: "#7f1d1d", icon: "✕" },
+    skipped: { accent: "#d1d5db", fg: "#6b7280", icon: "↷" },
+    cancelled: { accent: "#f59e0b", fg: "#92400e", icon: "⏹" },
+  },
+  dark: {
+    pending: { accent: "#6b7280", fg: "#9ca3af", icon: "●" },
+    running: { accent: "#60a5fa", fg: "#93c5fd", icon: "▶" },
+    success: { accent: "#34d399", fg: "#6ee7b7", icon: "✓" },
+    failed: { accent: "#f87171", fg: "#fca5a5", icon: "✕" },
+    skipped: { accent: "#9ca3af", fg: "#d1d5db", icon: "↷" },
+    cancelled: { accent: "#fbbf24", fg: "#fcd34d", icon: "⏹" },
+  },
+};
+
+export const Z = {
+  cluster: 0,
+  nodes: 1,
+  edges: 2,
+  controls: 10,
+  inspector: 20,
+  tooltip: 30,
+} as const;

--- a/src/components/PipelineGraph/useGraphLayout.ts
+++ b/src/components/PipelineGraph/useGraphLayout.ts
@@ -1,0 +1,139 @@
+import { useMemo } from "react";
+import * as dagre from "@dagrejs/dagre";
+
+import type { PipelineEdge, PipelineGraphDirection } from "./PipelineGraph.types";
+import {
+  buildVisibleGraph,
+  measureNode,
+  type ClusterInfo,
+  type Normalized,
+  type VisibleNode,
+} from "./PipelineGraph.utils";
+
+export interface UseGraphLayoutOptions {
+  normalized: Normalized;
+  expanded: Set<string>;
+  direction: PipelineGraphDirection;
+  rankSep: number;
+  nodeSep: number;
+  clusterPadding: number;
+}
+
+export interface LaidOutNode {
+  id: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface LaidOutEdge {
+  from: string;
+  to: string;
+  points: { x: number; y: number }[];
+  raws: PipelineEdge[];
+}
+
+export interface GraphLayout {
+  positions: LaidOutNode[];
+  clusterBounds: LaidOutNode[];
+  edgePoints: LaidOutEdge[];
+  bounds: { width: number; height: number };
+  visible: VisibleNode[];
+  clusters: ClusterInfo[];
+}
+
+const EMPTY: GraphLayout = {
+  positions: [],
+  clusterBounds: [],
+  edgePoints: [],
+  bounds: { width: 0, height: 0 },
+  visible: [],
+  clusters: [],
+};
+
+export function useGraphLayout(opts: UseGraphLayoutOptions): GraphLayout {
+  const { normalized, expanded, direction, rankSep, nodeSep, clusterPadding } = opts;
+
+  return useMemo<GraphLayout>(() => {
+    if (normalized.topoNodes.length === 0) return EMPTY;
+
+    const vg = buildVisibleGraph(normalized, expanded);
+    if (vg.visible.length === 0) return EMPTY;
+
+    const g = new dagre.graphlib.Graph({ compound: true, multigraph: false });
+    g.setGraph({
+      rankdir: direction,
+      ranksep: rankSep,
+      nodesep: nodeSep,
+      marginx: 16,
+      marginy: 16,
+    });
+    g.setDefaultEdgeLabel(() => ({}));
+
+    for (const n of vg.visible) {
+      const s = measureNode(n);
+      g.setNode(n.id, { width: s.w, height: s.h });
+    }
+
+    for (const c of vg.clusters) {
+      g.setNode(c.id, { paddingX: clusterPadding, paddingY: clusterPadding });
+    }
+    for (const c of vg.clusters) {
+      for (const child of c.childIds) g.setParent(child, c.id);
+    }
+
+    for (const e of vg.visibleEdges) {
+      g.setEdge(e.from, e.to, {});
+    }
+
+    dagre.layout(g);
+
+    const positions: LaidOutNode[] = vg.visible.map((n) => {
+      const o = g.node(n.id);
+      return {
+        id: n.id,
+        x: o.x - o.width / 2,
+        y: o.y - o.height / 2,
+        w: o.width,
+        h: o.height,
+      };
+    });
+
+    const clusterBounds: LaidOutNode[] = vg.clusters.map((c) => {
+      const o = g.node(c.id);
+      return {
+        id: c.id,
+        x: o.x - o.width / 2,
+        y: o.y - o.height / 2,
+        w: o.width,
+        h: o.height,
+      };
+    });
+
+    const edgePoints: LaidOutEdge[] = vg.visibleEdges.map((e) => {
+      const o = g.edge(e.from, e.to);
+      return {
+        from: e.from,
+        to: e.to,
+        points: o?.points ?? [],
+        raws: e.raws,
+      };
+    });
+
+    const gr = g.graph();
+    const bounds = {
+      width: gr.width ?? 0,
+      height: gr.height ?? 0,
+    };
+
+    return {
+      positions,
+      clusterBounds,
+      edgePoints,
+      bounds,
+      visible: vg.visible,
+      clusters: vg.clusters,
+    };
+  }, [normalized, expanded, direction, rankSep, nodeSep, clusterPadding]);
+}

--- a/src/components/PipelineGraph/usePanZoom.ts
+++ b/src/components/PipelineGraph/usePanZoom.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from "react";
+
+import type { PipelineGraphViewport } from "./PipelineGraph.types";
+import { clamp } from "./PipelineGraph.utils";
+
+export interface UsePanZoomOptions {
+  rootRef: React.RefObject<HTMLElement | null>;
+  viewport: PipelineGraphViewport | null;
+  setViewport: (v: PipelineGraphViewport) => void;
+  interactive: boolean;
+}
+
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 2.5;
+
+export function usePanZoom(opts: UsePanZoomOptions): void {
+  const { rootRef, viewport, setViewport, interactive } = opts;
+
+  const vpRef = useRef<PipelineGraphViewport | null>(viewport);
+  vpRef.current = viewport;
+
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el || !interactive) return;
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const vp = vpRef.current;
+      if (!vp) return;
+      const rect = el.getBoundingClientRect();
+      const cx = e.clientX - rect.left;
+      const cy = e.clientY - rect.top;
+      const scale = Math.exp(-e.deltaY * 0.001);
+      const nextZoom = clamp(vp.zoom * scale, MIN_ZOOM, MAX_ZOOM);
+      if (nextZoom === vp.zoom) return;
+      const ratio = nextZoom / vp.zoom;
+      const nx = cx - (cx - vp.x) * ratio;
+      const ny = cy - (cy - vp.y) * ratio;
+      setViewport({ x: nx, y: ny, zoom: nextZoom });
+    };
+
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, [rootRef, interactive, setViewport]);
+}

--- a/src/components/PipelineGraph/usePanZoom.ts
+++ b/src/components/PipelineGraph/usePanZoom.ts
@@ -13,11 +13,22 @@ export interface UsePanZoomOptions {
 const MIN_ZOOM = 0.25;
 const MAX_ZOOM = 2.5;
 
+function isBackground(target: EventTarget | null): boolean {
+  if (!target) return true;
+  if (!(target instanceof Element)) return true;
+  return !target.closest(
+    "[data-node-id], [data-pg-interactive], [data-edge], button, input, textarea, select, a",
+  );
+}
+
 export function usePanZoom(opts: UsePanZoomOptions): void {
   const { rootRef, viewport, setViewport, interactive } = opts;
 
   const vpRef = useRef<PipelineGraphViewport | null>(viewport);
   vpRef.current = viewport;
+  const setViewportRef = useRef(setViewport);
+  setViewportRef.current = setViewport;
+  const spaceDownRef = useRef(false);
 
   useEffect(() => {
     const el = rootRef.current;
@@ -36,10 +47,86 @@ export function usePanZoom(opts: UsePanZoomOptions): void {
       const ratio = nextZoom / vp.zoom;
       const nx = cx - (cx - vp.x) * ratio;
       const ny = cy - (cy - vp.y) * ratio;
-      setViewport({ x: nx, y: ny, zoom: nextZoom });
+      setViewportRef.current({ x: nx, y: ny, zoom: nextZoom });
+    };
+
+    let drag: { startX: number; startY: number; vp0: PipelineGraphViewport } | null = null;
+
+    const onPointerDown = (e: PointerEvent) => {
+      const vp = vpRef.current;
+      if (!vp) return;
+      const fromBackground = isBackground(e.target);
+      if (!fromBackground && !spaceDownRef.current) return;
+      try {
+        el.setPointerCapture(e.pointerId);
+      } catch {
+        /* no-op */
+      }
+      drag = { startX: e.clientX, startY: e.clientY, vp0: vp };
+      el.style.cursor = "grabbing";
+      e.preventDefault();
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      if (!drag) return;
+      const dx = e.clientX - drag.startX;
+      const dy = e.clientY - drag.startY;
+      setViewportRef.current({ ...drag.vp0, x: drag.vp0.x + dx, y: drag.vp0.y + dy });
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      if (!drag) return;
+      drag = null;
+      try {
+        el.releasePointerCapture(e.pointerId);
+      } catch {
+        /* no-op */
+      }
+      el.style.cursor = spaceDownRef.current ? "grab" : "";
     };
 
     el.addEventListener("wheel", onWheel, { passive: false });
-    return () => el.removeEventListener("wheel", onWheel);
-  }, [rootRef, interactive, setViewport]);
+    el.addEventListener("pointerdown", onPointerDown);
+    el.addEventListener("pointermove", onPointerMove);
+    el.addEventListener("pointerup", onPointerUp);
+    el.addEventListener("pointercancel", onPointerUp);
+    return () => {
+      el.removeEventListener("wheel", onWheel);
+      el.removeEventListener("pointerdown", onPointerDown);
+      el.removeEventListener("pointermove", onPointerMove);
+      el.removeEventListener("pointerup", onPointerUp);
+      el.removeEventListener("pointercancel", onPointerUp);
+    };
+  }, [rootRef, interactive]);
+
+  useEffect(() => {
+    if (!interactive) return;
+    const down = (e: KeyboardEvent) => {
+      if (e.code !== "Space") return;
+      const tgt = document.activeElement;
+      if (
+        tgt instanceof HTMLInputElement ||
+        tgt instanceof HTMLTextAreaElement ||
+        (tgt as HTMLElement | null)?.isContentEditable
+      )
+        return;
+      if (!tgt?.closest?.('[data-pg-root="1"]')) return;
+      spaceDownRef.current = true;
+      const el = rootRef.current;
+      if (el) el.style.cursor = "grab";
+      e.preventDefault();
+    };
+    const up = (e: KeyboardEvent) => {
+      if (e.code !== "Space") return;
+      spaceDownRef.current = false;
+      const el = rootRef.current;
+      if (el) el.style.cursor = "";
+    };
+    window.addEventListener("keydown", down);
+    window.addEventListener("keyup", up);
+    return () => {
+      window.removeEventListener("keydown", down);
+      window.removeEventListener("keyup", up);
+    };
+  }, [rootRef, interactive]);
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,6 +7,7 @@ export * from "./DataTable";
 export * from "./Dialog";
 export * from "./HexView";
 export * from "./PathInput";
+export * from "./PipelineGraph";
 export * from "./Popover";
 export * from "./Stepper";
 export * from "./Toast";


### PR DESCRIPTION
## Summary
- **PipelineGraph 컴포넌트 신규 추가** — dagre(@dagrejs/dagre v3) 기반 compound 레이아웃, task / group / loop 3종 노드, status 6종 팔레트, running pulse, SVG 엣지(색상·dash·fanOut 배지·hover 툴팁), Inspector (6탭 + 드래그 divider + position right/bottom/none), pan/zoom/fit, 키보드 네비게이션, controlled selection/expansion/viewport, renderNode / renderInspectorValue / renderEdgeTooltip 확장 훅, light/dark 테마.
- **데모 페이지 14 섹션 추가** — `/#/pipelinegraph` 에서 Basic / Direction / Grouping / Loop / Fan-out / Status / Controlled / Inspector / Custom node / Dark / Large(200 nodes) / Props / Usage / Playground. `demo/src/App.tsx` 의 NAV + 해시 라우팅에 등록.
- **리뷰 중 발견된 버그 4건 함께 수정** — dagre compound parent 를 edge endpoint 로 넘기면 크래시하던 문제, 다크 테마 화살표가 배경에 묻히던 문제, 14 그래프 동시 마운트로 첫 진입이 무거운 문제(IntersectionObserver 기반 LazyMount), Playground 의 nodeSep / clusterPadding 이 기본 preset 에선 효과 없던 UX 문제.

## Scope 이슈
Closes #186 #187 #188 #189 #190 #191 #192 #193 #194 #195 #196 #197 #198 #199 #200 #201 #202 #203 #204 #205 #206 #207 #208 #209 #210 #211 #212 #213 #214 #215 #216 #217

## 주요 파일
- `src/components/PipelineGraph/` — 컴포넌트 전체 (`PipelineGraph.tsx`, `PipelineGraphNode/Cluster/Edge/Inspector.tsx`, `useGraphLayout`, `usePanZoom`, `PipelineGraph.utils.ts`, `theme.ts`, `PipelineGraph.types.ts`)
- `demo/src/pages/PipelineGraphPage.tsx` — 데모 페이지 (955 lines, 14 섹션)
- `demo/src/App.tsx` — NAV / 라우팅 등록
- `package.json` — `@dagrejs/dagre ^3.0.0` 추가

## Test plan
- [x] \`npm run typecheck\` 통과
- [x] \`cd demo && npm run build\` 통과
- [x] \`cd demo && npm run dev\` → \`#/pipelinegraph\` 진입 시 흰 화면 / 프리즈 없이 Basic 섹션 즉시 렌더
- [x] 스크롤 내리며 각 섹션 PipelineGraph 가 정상 레이아웃 (특히 Grouping / Loop expanded / Dark 섹션에서 dagre 크래시 없음)
- [x] Large 섹션(200 nodes) 은 스크롤이 근처까지 도달했을 때만 마운트
- [x] Dark 섹션 / Playground theme=dark 에서 엣지 화살표 머리가 명확히 보임
- [x] Playground 에서 \`with-group\` / \`with-loop\` preset 선택 시 자동으로 펼쳐지고 clusterPadding slider 조정이 보임, \`large-50/200\` 에서 nodeSep slider 조정이 보임
- [x] Inspector 섹션에서 노드 선택 시 탭이 자동 활성 (Transform → Output, Model failed → Error)
- [x] Custom node 섹션에서 render-frame 노드가 이미지 썸네일로 대체됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)