### PR TITLE
docs(plans): 013~022 컴포넌트 상세 설계 문서 10건

### DIFF
--- a/docs/plans/013-select-component.md
+++ b/docs/plans/013-select-component.md
@@ -1,0 +1,1397 @@
+# Select 컴포넌트 설계문서
+
+## Context
+
+plastic 라이브러리에 "하나의 값을 드롭다운 목록에서 선택하는 폼/툴바 프리미티브" `Select` 를 추가한다. 역할 비유: Radix `Select`, HeadlessUI `Listbox`, Ant Design `Select` (single), shadcn/ui `Select`, 그리고 VSCode 의 세팅 드롭다운. 목적은 기존 `CommandPalette` (검색+명령 실행) 와는 구분되는, "옵션이 유한한 enumerable 값 중 하나를 고르는" 전형적인 폼 컨트롤을 제공하는 것.
+
+참고 (prior art — UX 근거):
+- **Radix `Select`** — Trigger + Content + Item compound, Portal popup, type-ahead, 접근성 WAI-ARIA 1.2 combobox pattern.
+- **HeadlessUI `Listbox`** — render-prop + headless, keyboard + type-ahead, disabled item skip.
+- **Ant Design `Select`** — grouped options, custom render (`optionRender`, `labelRender`), size variants.
+- **shadcn/ui `Select`** — Radix 기반 + Tailwind. 토큰 기반 theming.
+- **native `<select>`** — 비교 기준: 플랫폼 일관 키보드 (type-ahead, ArrowUp/Down), 그러나 스타일 제약 + custom render 불가.
+- **VSCode settings dropdown** — 짧은 옵션 리스트, Enter 선택, Escape 닫기, 키보드 우선.
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/_shared/useControllable.ts` — controlled/uncontrolled 이중 API 표준 훅.
+- `src/components/Popover/PopoverContent.tsx` — Portal + floating positioning + 진입/퇴장 애니메이션 패턴. Select popup 은 동일 Portal 전략을 재사용.
+- `src/components/Popover/` 전반 — `useFloating`, `useAnimationState`, `useFocusTrap` 등의 공용 훅 위치.
+- `src/components/CommandPalette/CommandPaletteInput.tsx` — ArrowUp/Down + activeIndex 제어 + `aria-activedescendant` 패턴. Select 의 type-ahead 와 listbox 이동이 유사 구조.
+- `src/components/CommandPalette/fuzzyMatch.ts` — 문자열 필터 참조 (Select 는 "startsWith" 스타일의 typeahead 만 쓰므로 직접 사용은 안 함, 패턴 참조만).
+- `src/components/index.ts` — 배럴에 `export * from "./Select";` 를 추가할 위치.
+- `demo/src/App.tsx` — NAV / 라우팅 / 사이드바 패턴 (`Page` 유니온 + `NAV` 배열 + 우측 패널 서브섹션).
+- `demo/src/pages/CommandPalettePage.tsx` — 최신 데모 페이지 구조 (Section / Card / 섹션별 id).
+- `tsconfig.json` — `strict`, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax` 제약.
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+<Select.Root
+  value={lang}                     // controlled
+  onValueChange={setLang}
+  placeholder="언어 선택…"
+  theme="light"
+  disabled={false}
+>
+  <Select.Trigger aria-label="언어">
+    <Select.Value />               {/* 현재 값 or placeholder */}
+    <Select.Icon />                {/* ▾ 아이콘 */}
+  </Select.Trigger>
+
+  <Select.Content side="bottom" sideOffset={4} maxHeight={320}>
+    <Select.Group label="프론트엔드">
+      <Select.Item value="ts">TypeScript</Select.Item>
+      <Select.Item value="js">JavaScript</Select.Item>
+    </Select.Group>
+    <Select.Separator />
+    <Select.Group label="백엔드">
+      <Select.Item value="py">Python</Select.Item>
+      <Select.Item value="go">Go</Select.Item>
+      <Select.Item value="rs" disabled>Rust (준비 중)</Select.Item>
+    </Select.Group>
+  </Select.Content>
+</Select.Root>
+```
+
+렌더 결과 (개념):
+```
+┌──────────────────────┐
+│  TypeScript       ▾  │  ← Trigger (button, role=combobox)
+└──────────────────────┘
+          │ (open)
+          ▼
+┌──────────────────────┐
+│  프론트엔드          │  ← Group label
+│  ✓ TypeScript        │  ← Item (selected, aria-selected=true)
+│    JavaScript        │
+│  ────────────────    │  ← Separator
+│  백엔드              │
+│    Python            │
+│    Go                │
+│    Rust (disabled)   │  ← Item (disabled, 건너뜀)
+└──────────────────────┘
+```
+
+핵심 설계 원칙:
+- **compound 컴포넌트**. `Root`/`Trigger`/`Value`/`Icon`/`Content`/`Group`/`Label`/`Item`/`ItemIndicator`/`Separator` 를 Context 로 묶는다. Radix 의 명명 관례를 따른다.
+- **Portal 기반 popup**. 팝업은 DOM 계층을 벗어나 `document.body` 로 Portal. `overflow:hidden` 부모 / `transform` 스태킹 컨텍스트 / iframe 같은 clipping 이슈를 회피.
+- **controlled/uncontrolled 이중 API**. `value`/`defaultValue`/`onValueChange` + `open`/`defaultOpen`/`onOpenChange` 두 축 모두. `useControllable` 재사용.
+- **런타임 의존 zero**. React + DOM 만. Popover 에서 이미 쓰던 `useFloating` 자체 구현을 공유.
+- **접근성 · 키보드 우선**. Trigger 는 `role="combobox"` + `aria-haspopup="listbox"` + `aria-expanded`, Content 는 `role="listbox"`, Item 은 `role="option"`. 포커스는 active item 의 `aria-activedescendant` 로 표현 (virtual focus).
+- **type-ahead 내장**. 팝업 열린 상태에서 알파벳 키 입력 시 500 ms 버퍼링 → startsWith 일치 첫 항목으로 이동.
+- **light/dark**. palette token 두 벌. 기본 `light`.
+- **v1 은 단일 선택만**. multi-select 는 v1.1.
+- **custom render 지원**. `<Select.Item>` 의 children 이 자유이므로 아이콘/부제/키캡 자유 배치.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. 단일 값 선택 드롭다운.
+2. Trigger 클릭 + 키보드(Enter/Space/ArrowDown)로 open, Escape/바깥 클릭으로 close.
+3. controlled/uncontrolled 이중 API (`value` / `defaultValue` / `onValueChange`).
+4. open 상태도 controlled/uncontrolled 이중 API (`open` / `defaultOpen` / `onOpenChange`).
+5. 키보드 탐색: ArrowUp/ArrowDown, Home, End, Enter/Space, Escape, PageUp/PageDown(10 step).
+6. Type-ahead: 알파벳 키 연속 입력 500 ms 버퍼 → 일치 항목 포커스.
+7. 그룹(`Select.Group` + `Select.Label`)과 구분선(`Select.Separator`) 지원.
+8. disabled item 은 선택/포커스 스킵.
+9. Portal 기반 popup. 기본 side=`bottom`, `sideOffset=4`, flip fallback.
+10. 팝업 open 시 현재 선택된 항목으로 스크롤 + 가상 포커스 이동.
+11. Trigger 가 폼 안에서 `<button type="button">` 으로 동작 (submit 방지).
+12. 커스텀 render: `<Select.Item>` children 자유, `<Select.ItemIndicator>` 로 체크 표식 슬롯 제공.
+13. Light / Dark 테마.
+14. `disabled` (Root 전체 비활성), `required` (hidden native input 으로 폼 validation 연동).
+15. hidden native `<input type="hidden" name={name} value={value}>` — `name` prop 주어졌을 때만 렌더하여 form 제출과 호환.
+
+### Non-goals (v1 제외)
+- **multi-select**: 별도 `MultiSelect` 컴포넌트 또는 `Select` 의 `mode="multiple"` v1.1. v1 은 단일만.
+- **검색 입력 내장**: Trigger 를 텍스트 입력으로 바꾸는 autocomplete 는 별도 `Combobox` 컴포넌트로. v1 Select 의 type-ahead 는 "팝업 열린 상태에서 알파벳 키로 점프" 수준.
+- **비동기 옵션 로딩**: `options` prop 기반 async 소스 v1 제외. children 선언형만.
+- **가상화(virtualized)**: 1000 개 이상 옵션을 다루는 경우 virtualization 필요하지만 v1 은 단순 DOM 렌더. v1.1 에서 `virtualize` prop.
+- **자동 width 매칭**: 팝업 width = trigger width 가 기본이되, 강제 옵션은 v1 내에서 `matchTriggerWidth={false}` 로 fallback.
+- **createable (new option on the fly)**: v1 제외.
+- **nested submenu (cascading select)**: v1 제외.
+- **native `<select>` 위임 모드**: mobile 일부 환경에서 native UI 가 더 나을 수 있으나 v1 은 모두 커스텀 popup. v1.1 에서 `nativeOnMobile` 고려.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Select/Select.types.ts`
+
+```ts
+import type { ReactNode, CSSProperties, HTMLAttributes, ButtonHTMLAttributes } from "react";
+import type { Side, Align } from "../_shared/useFloating";
+
+export type SelectTheme = "light" | "dark";
+
+/** Select 값은 문자열. 숫자/객체를 쓰고 싶으면 사용자가 string 으로 직렬화하여 전달. */
+export type SelectValue = string;
+
+export interface SelectRootProps {
+  /** 제어 값. 지정 시 controlled. */
+  value?: SelectValue;
+  /** 기본 값. uncontrolled. */
+  defaultValue?: SelectValue;
+  /** 값 변경 콜백. 사용자가 아이템을 선택하면 호출. */
+  onValueChange?: (value: SelectValue) => void;
+
+  /** 제어 open. 지정 시 controlled. */
+  open?: boolean;
+  /** 기본 open. uncontrolled. */
+  defaultOpen?: boolean;
+  /** open 상태 변경 콜백. */
+  onOpenChange?: (open: boolean) => void;
+
+  /** 선택 값이 없을 때 Trigger 에 표시될 placeholder. */
+  placeholder?: string;
+
+  /** 전체 비활성화 (Trigger + 키보드 + popup). */
+  disabled?: boolean;
+
+  /** form 제출 연동용. 지정 시 hidden input 렌더. */
+  name?: string;
+  /** form validation 용 required. hidden input 에 전달. */
+  required?: boolean;
+
+  /** 라이트/다크. 기본 "light". */
+  theme?: SelectTheme;
+
+  /** 자식: Trigger + Content. */
+  children: ReactNode;
+}
+
+export interface SelectTriggerProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "type" | "onClick"> {
+  /** 추가 className / style */
+  className?: string;
+  style?: CSSProperties;
+  /** 기본 아이콘 대신 커스텀 요소 삽입. children 자유. */
+  children?: ReactNode;
+}
+
+export interface SelectValueProps {
+  /** 선택 값이 없을 때의 fallback. Root 의 placeholder 와 중복되면 이 쪽이 우선. */
+  placeholder?: string;
+  /** 현재 선택된 value 를 어떻게 표시할지 커스터마이즈. 미지정 시 선택된 Item 의 children 를 표시. */
+  children?: (value: SelectValue | undefined) => ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface SelectIconProps {
+  /** 기본 ▾ 아이콘 대체 요소. */
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface SelectContentProps {
+  /** 팝업 방향. 기본 "bottom". flip fallback 존재. */
+  side?: Side;                     // "top" | "bottom" | "left" | "right"
+  /** 팝업 정렬. 기본 "start". */
+  align?: Align;                   // "start" | "center" | "end"
+  /** trigger 와 팝업 사이 간격 px. 기본 4. */
+  sideOffset?: number;
+  /** align 방향 offset px. 기본 0. */
+  alignOffset?: number;
+  /** 팝업 최대 높이 (px). 기본 320. 초과 시 내부 스크롤. */
+  maxHeight?: number;
+  /** 팝업 width 를 trigger width 에 맞출지. 기본 true. */
+  matchTriggerWidth?: boolean;
+  /** 최소 width (px). matchTriggerWidth=false 일 때 유효. */
+  minWidth?: number;
+  /** 팝업 바깥 클릭 시 닫기. 기본 true. */
+  closeOnOutsideClick?: boolean;
+  /** Escape 로 닫기. 기본 true. */
+  closeOnEscape?: boolean;
+
+  /** 추가 className / style (popup root) */
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}
+
+export interface SelectGroupProps {
+  /** 그룹 헤더 라벨. 문자열 또는 노드. 지정 시 `<Select.Label>` 자동 렌더. */
+  label?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}
+
+export interface SelectLabelProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface SelectItemProps {
+  /** 이 Item 이 표현하는 값. Root 의 value 와 일치하면 selected. */
+  value: SelectValue;
+  /** 비활성화. 선택/포커스 스킵. */
+  disabled?: boolean;
+  /** type-ahead 매칭용 텍스트. 미지정 시 children 의 text 를 toString 으로 추출. */
+  textValue?: string;
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}
+
+export interface SelectItemIndicatorProps {
+  /** selected 일 때만 렌더. children 미지정 시 기본 ✓ 아이콘. */
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface SelectSeparatorProps {
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.2 배럴
+
+```ts
+// src/components/Select/index.ts
+export { Select } from "./Select";
+export type {
+  SelectRootProps,
+  SelectTriggerProps,
+  SelectValueProps,
+  SelectIconProps,
+  SelectContentProps,
+  SelectGroupProps,
+  SelectLabelProps,
+  SelectItemProps,
+  SelectItemIndicatorProps,
+  SelectSeparatorProps,
+  SelectTheme,
+  SelectValue,
+} from "./Select.types";
+```
+
+그리고 `src/components/index.ts` 에 `export * from "./Select";` 한 줄 추가.
+
+### 2.3 Compound namespace
+
+```ts
+// Select.tsx
+export const Select = {
+  Root: SelectRoot,
+  Trigger: SelectTrigger,
+  Value: SelectValue,
+  Icon: SelectIcon,
+  Content: SelectContent,
+  Group: SelectGroup,
+  Label: SelectLabel,
+  Item: SelectItem,
+  ItemIndicator: SelectItemIndicator,
+  Separator: SelectSeparator,
+};
+```
+
+각 서브컴포넌트의 `displayName` 은 `"Select.Root"`, `"Select.Trigger"`, `"Select.Content"` 등 명시.
+
+---
+
+## 3. 도메인 모델
+
+### 3.1 값 표현
+
+- **value 는 string 만.** React 에서 이질적 타입(숫자, 객체, Symbol)을 Item 의 `value` 로 받으면 참조 비교가 필요해지고 serialization 경계가 불명확해진다. 사용자는 `String(n)` 형태로 직렬화해서 넘기고, `onValueChange` 에서 다시 파싱하는 방식을 권장.
+- 빈 문자열 `""` 은 "선택 없음" 이 아니라 "빈 문자열이라는 값 하나". "선택 없음" 은 `value === undefined` 로 표현.
+- `placeholder` 는 value 가 undefined 일 때만 Trigger 에 노출.
+
+### 3.2 Item 레지스트리
+
+Root 는 Content 아래의 모든 `<Select.Item>` 을 마운트 순서대로 수집해야 한다 (키보드 탐색 순서 / type-ahead 매칭에 필요). 두 가지 접근:
+
+1. **React.Children.toArray 로 선언형 파싱** — 단순 구조엔 쉬우나 `<Group>` 중첩, 조건부 렌더, fragment 안에 Item 이 섞이면 어긋남.
+2. **imperative 레지스트리** — 각 Item 이 마운트 시 Context 의 `registerItem(ref)` 호출, unmount 시 해제. DOM 순서는 Item 이 실제로 마운트된 element 의 document order (`compareDocumentPosition`) 로 정렬.
+
+→ **(2)** 채택. `Select.Item` 은 `useLayoutEffect` 에서 자신의 `value`, `textValue`, `disabled`, DOM ref 를 Root 의 레지스트리에 등록. Root 는 order-sorted array 를 유지.
+
+```ts
+interface RegisteredItem {
+  value: SelectValue;
+  textValue: string;
+  disabled: boolean;
+  node: HTMLElement;
+  id: string;             // useId 로 생성, aria-activedescendant 용
+}
+
+interface SelectItemRegistry {
+  items: RegisteredItem[];
+  register: (item: RegisteredItem) => () => void;  // returns unregister
+  updateActive: (value: SelectValue | null) => void;
+  findIndex: (value: SelectValue | null) => number;
+}
+```
+
+레지스트리는 `useRef` 로 mutable 배열 유지하되, 키보드 탐색 시 `sortByDocumentOrder()` 를 lazy 호출.
+
+### 3.3 Context
+
+```ts
+interface SelectContextValue {
+  // 값
+  value: SelectValue | undefined;
+  setValue: (v: SelectValue) => void;
+
+  // open
+  open: boolean;
+  setOpen: (o: boolean) => void;
+
+  // 파생
+  disabled: boolean;
+  theme: SelectTheme;
+  placeholder: string | undefined;
+
+  // active item (virtual focus)
+  activeValue: SelectValue | null;
+  setActiveValue: (v: SelectValue | null) => void;
+
+  // 레지스트리
+  registerItem: (item: RegisteredItem) => () => void;
+  getItems: () => RegisteredItem[];
+  getActiveId: () => string | undefined;
+
+  // refs
+  triggerRef: React.MutableRefObject<HTMLButtonElement | null>;
+  contentRef: React.MutableRefObject<HTMLDivElement | null>;
+  listboxId: string;
+  triggerId: string;
+
+  // form
+  name: string | undefined;
+  required: boolean;
+
+  // type-ahead
+  onTypeAhead: (char: string) => void;
+}
+
+const SelectContext = createContext<SelectContextValue | null>(null);
+```
+
+`useSelectContext()` 는 null 이면 `"Select.X must be used within <Select.Root>"` throw.
+
+---
+
+## 4. 시각 / 구조 설계
+
+### 4.1 DOM 구조
+
+```
+<Select.Root>
+  <button
+    type="button"
+    role="combobox"
+    aria-haspopup="listbox"
+    aria-expanded="{open}"
+    aria-controls="{listboxId}"
+    aria-labelledby={...}
+    id="{triggerId}"
+    class="sel-trigger"
+  >
+    <span class="sel-value">{displayText or placeholder}</span>
+    <svg class="sel-icon">▾</svg>
+  </button>
+
+  {name && (
+    <input type="hidden" name={name} value={value ?? ""} required={required} />
+  )}
+
+  {open && (
+    <Portal>
+      <div
+        role="listbox"
+        id="{listboxId}"
+        aria-labelledby="{triggerId}"
+        aria-activedescendant="{activeItemId}"
+        tabindex="-1"
+        class="sel-content"
+        style={{ position: "absolute", top, left, width, maxHeight, overflowY: "auto" }}
+      >
+        <div role="group" aria-labelledby="{groupLabelId}" class="sel-group">
+          <div role="presentation" id="{groupLabelId}" class="sel-label">프론트엔드</div>
+          <div role="option" id="{itemId}" aria-selected="{value===itemValue}" aria-disabled="{disabled}" data-active="{isActive}" class="sel-item">
+            <span class="sel-item-indicator">✓</span>
+            <span class="sel-item-text">TypeScript</span>
+          </div>
+          <!-- ... -->
+        </div>
+        <div role="separator" class="sel-separator" />
+        <!-- ... -->
+      </div>
+    </Portal>
+  )}
+</Select.Root>
+```
+
+### 4.2 포지셔닝
+
+Popover 에서 쓰이는 `useFloating(triggerRef, { side, align, sideOffset, alignOffset })` 을 재사용한다. 이 훅은:
+- Trigger 의 `getBoundingClientRect()` + 팝업의 측정된 크기 → 절대 좌표 계산.
+- viewport 초과 시 flip fallback (bottom 이 모자라면 top).
+- 사용자는 `document.body` 의 절대 좌표를 받는다 (Portal 에 렌더하므로).
+
+`matchTriggerWidth` 가 true 면 Content 마운트 시 `width = trigger.offsetWidth` 로 설정. false 면 `width: max-content, minWidth`.
+
+### 4.3 애니메이션
+
+Popover 와 동일 전략: `useAnimationState({ open, exitDuration })` 로 `entering` / `exiting` 단계를 구분. 진입 시 `opacity 0→1` + `translateY(-4px)→0` 150 ms. 퇴장 시 역방향 100 ms.
+
+### 4.4 스크롤 잠금
+
+open 상태에서 body 스크롤은 **잠그지 않는다** (Dialog 와 달리 Select 는 비모달). 대신 Content 는 `maxHeight` 를 넘으면 내부 세로 스크롤. 스크롤 시 팝업 위치가 자동으로 따라가도록 `useFloating` 이 `scroll`/`resize` 리스너를 설치.
+
+### 4.5 palette 토큰
+
+```ts
+// Select/colors.ts
+export const selectPalette = {
+  light: {
+    triggerBg:        "#ffffff",
+    triggerBgHover:   "#f9fafb",
+    triggerBorder:    "#d1d5db",
+    triggerBorderHover: "#9ca3af",
+    triggerFg:        "#111827",
+    triggerFgMuted:   "#9ca3af",             // placeholder
+    triggerFocusRing: "#2563eb",
+
+    contentBg:        "#ffffff",
+    contentBorder:    "rgba(0,0,0,0.08)",
+    contentShadow:    "0 10px 32px rgba(0,0,0,0.12)",
+
+    itemFg:           "#111827",
+    itemBgHover:      "#f3f4f6",
+    itemBgActive:     "#e5edff",             // keyboard active
+    itemFgSelected:   "#2563eb",
+    itemFgDisabled:   "#9ca3af",
+    itemIndicatorFg:  "#2563eb",
+
+    labelFg:          "#6b7280",
+    separatorBg:      "rgba(0,0,0,0.08)",
+  },
+  dark: {
+    triggerBg:        "#1f2937",
+    triggerBgHover:   "#374151",
+    triggerBorder:    "rgba(255,255,255,0.12)",
+    triggerBorderHover: "rgba(255,255,255,0.24)",
+    triggerFg:        "#e5e7eb",
+    triggerFgMuted:   "#6b7280",
+    triggerFocusRing: "#60a5fa",
+
+    contentBg:        "#1f2937",
+    contentBorder:    "rgba(255,255,255,0.08)",
+    contentShadow:    "0 10px 32px rgba(0,0,0,0.45)",
+
+    itemFg:           "#e5e7eb",
+    itemBgHover:      "#374151",
+    itemBgActive:     "#1e3a8a",
+    itemFgSelected:   "#60a5fa",
+    itemFgDisabled:   "#6b7280",
+    itemIndicatorFg:  "#60a5fa",
+
+    labelFg:          "#9ca3af",
+    separatorBg:      "rgba(255,255,255,0.08)",
+  },
+} as const;
+```
+
+---
+
+## 5. 핵심 동작 로직
+
+### 5.1 open / close 시퀀스
+
+**open**:
+1. Trigger 에서 `onClick` 또는 `onKeyDown` (Enter/Space/ArrowDown/ArrowUp).
+2. `setOpen(true)`.
+3. open=true 최초 렌더 시 `Content` 의 `useLayoutEffect` 에서:
+   - 현재 선택값이 있으면 그 item 을 `activeValue` 로 지정.
+   - 없으면 첫 번째 enabled item.
+   - 해당 item 을 `scrollIntoView({ block: "nearest" })`.
+4. `Content` 에 `tabIndex=-1` 상태로 `focus()` — 실제 DOM focus 는 listbox 로 이동, 그러나 Item 들엔 tabindex 없음. 가상 포커스(`aria-activedescendant`) 만 설정.
+
+**close**:
+1. Escape, outside click, 선택(Enter/클릭), Tab 키 중 하나.
+2. `setOpen(false)`.
+3. `useLayoutEffect` 로 Trigger 에 focus 복원 (단, 원인이 outside click 이거나 blur 로 인한 경우는 복원하지 않음 — 사용자가 이미 다른 곳에 focus 를 준 경우를 보호).
+
+```ts
+function handleClose(reason: "escape" | "select" | "outside" | "blur" | "tab") {
+  setOpen(false);
+  if (reason === "escape" || reason === "select") {
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  }
+}
+```
+
+### 5.2 선택 시퀀스
+
+1. Item 클릭 또는 Enter (activeValue 기준).
+2. disabled item 이면 무동작.
+3. `setValue(item.value)` → controlled 면 onChange 콜백만, uncontrolled 면 내부 state + 콜백.
+4. `handleClose("select")`.
+
+### 5.3 type-ahead 버퍼
+
+팝업 open 상태에서 알파벳/숫자 키를 누르면:
+- `bufferRef.current += char.toLowerCase()`.
+- `window.setTimeout` 500 ms 후 버퍼 리셋.
+- 매 입력마다: `items.find(it => !it.disabled && it.textValue.toLowerCase().startsWith(buffer))` → 찾으면 activeValue 갱신 + scrollIntoView.
+
+CommandPalette 의 fuzzy 와 달리 Select 는 "startsWith" 만 — 이는 VSCode/native select 의 UX 와 일치.
+
+```ts
+const bufferRef = useRef("");
+const timerRef = useRef<number | null>(null);
+
+function onTypeAhead(char: string) {
+  if (!/^[\w\s-]$/.test(char)) return;
+  bufferRef.current += char.toLowerCase();
+  if (timerRef.current != null) window.clearTimeout(timerRef.current);
+  timerRef.current = window.setTimeout(() => {
+    bufferRef.current = "";
+  }, 500);
+  const items = getItems();
+  const startFrom = activeValueRef.current
+    ? items.findIndex((i) => i.value === activeValueRef.current)
+    : -1;
+  // 현재 위치 다음부터 검색 (동일 char 반복 시 다음 매칭으로 순환)
+  const ordered = [...items.slice(startFrom + 1), ...items.slice(0, startFrom + 1)];
+  const match = ordered.find(
+    (i) => !i.disabled && i.textValue.toLowerCase().startsWith(bufferRef.current),
+  );
+  if (match) {
+    setActiveValue(match.value);
+    match.node.scrollIntoView({ block: "nearest" });
+  }
+}
+```
+
+### 5.4 outside click
+
+Content 마운트 시 `document.addEventListener("mousedown", handler)` — event.target 이 Content 내부, Trigger 내부 모두 아니면 close. Popover 와 동일 패턴. Trigger 가 원인인 경우 Trigger 자체가 toggle 하므로 outside 로 간주하지 않기 위해 명시적으로 Trigger ref 체크.
+
+### 5.5 scroll-to-active
+
+`activeValue` 가 바뀔 때마다 해당 node 를 `scrollIntoView({ block: "nearest", inline: "nearest" })`. `nearest` 를 쓰면 이미 보이는 경우 스크롤 안 일어남. popup 초기 open 시는 선택된 항목을 "centered" 로 보이게 하고 싶으면 `block: "center"` — v1 은 `nearest` 로 단순화.
+
+---
+
+## 6. 제약
+
+- **children 이 Item/Group/Separator 외 조합** — 임의 노드를 허용하되 role 부여 없이 pass-through. 단 `<Select.Item>` 은 반드시 `<Select.Content>` 하위 (Context 체크로 강제).
+- **동일 value 중복** — 레지스트리에서 경고 로그(`dev only`), 동작은 첫 번째 매칭 Item 기준.
+- **빈 Content** — Item 0 개: 팝업은 열리지만 "No options" 플레이스홀더 텍스트 없이 빈 상자. 사용자가 필요하면 placeholder element 를 children 으로 직접 배치.
+- **Trigger 가 disabled 인 상태에서 keyboard 로 open 시도** — 무시.
+- **Root disabled + 이미 open 인 상태에서 disabled 로 전환** — 즉시 close.
+- **controlled value 가 레지스트리에 없는 값** — Trigger 는 "fallback 표시" (placeholder + 내부 콘솔 dev warn). 예: 옵션이 비동기로 로드되기 전 이미 value 가 세팅된 경우.
+- **Content 가 open 상태에서 unmount** — cleanup 에서 event listener 해제. 리렌더 레이스 시 listener leak 방지.
+
+---
+
+## 7. 키보드
+
+### 7.1 Trigger 에 포커스 있을 때
+
+| 키 | 동작 |
+|---|---|
+| `Enter` / `Space` | open, activeValue=선택값 또는 첫 enabled item |
+| `ArrowDown` | open, activeValue=선택값 다음 또는 첫 enabled |
+| `ArrowUp` | open, activeValue=선택값 이전 또는 마지막 enabled |
+| 알파벳 / 숫자 | (open 아님) native button 기본 무동작. Select 는 typeahead 를 열린 상태에서만 처리 |
+
+### 7.2 Content 가 열려 있을 때
+
+| 키 | 동작 |
+|---|---|
+| `ArrowDown` | activeValue = 다음 enabled item (끝이면 멈춤, wrap 없음 v1) |
+| `ArrowUp` | activeValue = 이전 enabled item |
+| `Home` | activeValue = 첫 enabled |
+| `End` | activeValue = 마지막 enabled |
+| `PageDown` | 10 step 앞으로 (끝 넘으면 마지막) |
+| `PageUp` | 10 step 뒤로 |
+| `Enter` / `Space` | activeValue 선택 + close |
+| `Escape` | close (값 변경 없음) |
+| `Tab` | close (값 변경 없음) + focus 가 다음 tabbable 로 자연스럽게 이동 |
+| `Shift+Tab` | close + focus 가 이전 tabbable 로 |
+| `a-z`, `0-9` | type-ahead |
+
+v1 은 wrap-around 없음. Radix 기본도 wrap 없음. wrap 을 원하면 v1.1 에서 `loop?: boolean` 옵션.
+
+### 7.3 구현
+
+```ts
+function onContentKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+  if (e.nativeEvent.isComposing) return;
+  const items = getItems().filter((i) => !i.disabled);
+  if (items.length === 0) {
+    if (e.key === "Escape" || e.key === "Tab") handleClose(e.key === "Escape" ? "escape" : "tab");
+    return;
+  }
+  const curIdx = activeValue
+    ? items.findIndex((i) => i.value === activeValue)
+    : -1;
+
+  switch (e.key) {
+    case "ArrowDown": {
+      e.preventDefault();
+      const next = items[Math.min(curIdx + 1, items.length - 1)];
+      if (next) setActiveValue(next.value);
+      break;
+    }
+    case "ArrowUp": {
+      e.preventDefault();
+      const prev = items[Math.max(curIdx - 1, 0)];
+      if (prev) setActiveValue(prev.value);
+      break;
+    }
+    case "Home": {
+      e.preventDefault();
+      if (items[0]) setActiveValue(items[0].value);
+      break;
+    }
+    case "End": {
+      e.preventDefault();
+      const last = items[items.length - 1];
+      if (last) setActiveValue(last.value);
+      break;
+    }
+    case "PageDown": {
+      e.preventDefault();
+      const target = items[Math.min(curIdx + 10, items.length - 1)];
+      if (target) setActiveValue(target.value);
+      break;
+    }
+    case "PageUp": {
+      e.preventDefault();
+      const target = items[Math.max(curIdx - 10, 0)];
+      if (target) setActiveValue(target.value);
+      break;
+    }
+    case "Enter":
+    case " ": {
+      e.preventDefault();
+      if (activeValue != null) {
+        setValue(activeValue);
+        handleClose("select");
+      }
+      break;
+    }
+    case "Escape": {
+      e.preventDefault();
+      handleClose("escape");
+      break;
+    }
+    case "Tab": {
+      handleClose("tab");
+      // preventDefault 하지 않음 → 자연스러운 tab 이동
+      break;
+    }
+    default:
+      if (e.key.length === 1) onTypeAhead(e.key);
+      break;
+  }
+}
+```
+
+---
+
+## 8. 상태 관리 (controlled/uncontrolled)
+
+### 8.1 value 듀얼 API
+
+```ts
+const [value, setValueInternal] = useControllable<SelectValue | undefined>(
+  props.value,
+  props.defaultValue,
+  props.onValueChange,
+);
+```
+
+`useControllable` 은 `T` 가 `undefined` 포함 가능해야 하므로 제네릭 `SelectValue | undefined` 로 호출. `defaultValue` 를 생략하면 내부 기본은 `undefined` (선택 없음).
+
+> `useControllable` 의 현재 시그니처 (`controlled: T | undefined, defaultValue: T`) 를 그대로 사용. defaultValue 가 `undefined` 인 경우도 허용 (T 가 `SelectValue | undefined`).
+
+### 8.2 open 듀얼 API
+
+동일 패턴:
+
+```ts
+const [open, setOpenInternal] = useControllable<boolean>(
+  props.open,
+  props.defaultOpen ?? false,
+  props.onOpenChange,
+);
+```
+
+### 8.3 setValue 에서 close 연동
+
+```ts
+const setValue = useCallback(
+  (v: SelectValue) => {
+    setValueInternal(v);
+    setOpenInternal(false);
+  },
+  [setValueInternal, setOpenInternal],
+);
+```
+
+단, onValueChange 가 먼저 불리고 onOpenChange 가 다음에 불린다. 사용자 앱이 양쪽을 독립 owner 로 관리해도 순서 안정.
+
+### 8.4 activeValue 는 항상 internal
+
+`activeValue` (키보드 가상 포커스) 는 외부 제어 대상이 아님. useState 로 내부 유지. open=false 시 null 로 리셋.
+
+---
+
+## 9. 고유 기능
+
+### 9.1 그룹 / 섹션
+
+```tsx
+<Select.Group label="프론트엔드">
+  <Select.Item value="ts">TypeScript</Select.Item>
+  <Select.Item value="js">JavaScript</Select.Item>
+</Select.Group>
+```
+
+- `Group` 은 `role="group"` + `aria-labelledby={labelId}` 를 렌더.
+- `label` prop 이 있으면 내부에 `<div role="presentation" id={labelId} className="sel-label">{label}</div>` 자동 렌더.
+- 사용자가 세밀 제어를 원하면 `<Select.Label>` 컴포넌트를 직접 사용 가능. 이 경우 `Select.Group` 에는 label prop 생략 + children 안에 `<Select.Label>` 배치.
+
+### 9.2 Separator
+
+```tsx
+<Select.Separator />
+```
+
+- `role="separator"` + `aria-orientation="horizontal"`.
+- 1 px 수평 라인. 그룹 간 시각 분리용.
+- 키보드 탐색에 영향 없음 (Item 만 탐색 대상).
+
+### 9.3 disabled item
+
+```tsx
+<Select.Item value="rs" disabled>Rust (준비 중)</Select.Item>
+```
+
+- `aria-disabled="true"`.
+- 마우스 클릭: 무반응.
+- 키보드: enabled items 배열에서 제외되어 skip.
+- 시각: opacity 0.5, cursor default.
+- type-ahead 매칭에서도 제외.
+
+### 9.4 custom render — Item children 자유
+
+```tsx
+<Select.Item value="ts" textValue="TypeScript">
+  <img src="/ts.svg" width={14} />
+  <span className="ml-2">TypeScript</span>
+  <span className="ml-auto text-xs text-gray-400">.ts</span>
+</Select.Item>
+```
+
+- `textValue` 가 지정되지 않으면 Root 는 mount 시 Item DOM 의 `textContent` 를 type-ahead 용으로 캐싱. 이미지/아이콘이 섞인 경우엔 `textValue` 를 명시하길 권장.
+
+### 9.5 ItemIndicator
+
+```tsx
+<Select.Item value="ts">
+  <Select.ItemIndicator />
+  <span>TypeScript</span>
+</Select.Item>
+```
+
+- 현재 선택된 value 와 Item 의 value 가 같을 때만 children 렌더.
+- children 미지정 시 ✓ svg 기본.
+- 사용자가 `<Select.ItemIndicator>✔</Select.ItemIndicator>` 처럼 커스텀 마크도 가능.
+
+### 9.6 SelectValue 의 displayText
+
+Root 는 현재 value 에 해당하는 Item 의 textValue/children 를 어떻게 표시할지 결정해야 한다. 두 전략:
+
+1. **레지스트리 기반 자동**: `items.find(i => i.value === value)` 의 `textValue` 를 표시. 단, Content 가 아직 한 번도 open 되지 않은 경우 레지스트리가 비어 있을 수 있음 → v1 은 `Trigger` 도 `<Select.Value>` 를 가지는 순간 Content 는 항상 마운트되되 open=false 시 숨겨진다... 로는 overhead. 대안:
+2. **value→label 매핑을 Root 가 observe**: Item 은 open 여부와 관계없이 Portal 밖에 숨겨진 `<template>` 으로 레지스트리 등록을 해야 함. 복잡.
+3. **사용자 제공 render**: `<Select.Value>{(v) => labelFromMap(v)}</Select.Value>`.
+
+→ **하이브리드**. v1 은 Item 이 항상 Content DOM tree 에 살아있어 open 여부와 관계없이 `registerItem` 하도록 한다. 단 Content 가 닫힌 상태에서는 전체 `<div role="listbox">` 가 `display:none` 또는 Portal 에 마운트되지 않는다. 이 경우 레지스트리는 비어 있다. 해결:
+
+**Root 자체가 `itemsMeta: Record<value, {textValue, disabled}>` 를 내부 state 로 유지한다. Item 컴포넌트는 Content 마운트 여부와 관계없이 매번 mount-once 하며 meta 를 등록**, 실제 DOM element 등록은 Content 마운트 시에만 한다.
+
+- 이를 위해 `Select.Root` 는 Content 의 children 을 "항상 한 번은 mount" 하지만 open=false 시엔 hidden. 또는 `Select.Item` 을 Root 자식으로도 허용하는 "preload" 패턴을 쓸 수도 있으나 DX 가 난잡.
+- **최종 결정**: `Select.Content` 는 open 여부와 관계없이 **항상 DOM 렌더**, 단 open=false 일 때 `style.display = "none"` + `aria-hidden=true`. Portal 은 open=true 인 프레임에만 활성. 이 방식은 "Item 레지스트리가 항상 준비" 를 보장하면서 Portal 비용은 open 시에만. Tradeoff: 닫힌 상태에서 popup DOM 메모리가 잔존 (Item 100 개 이내 전형 수준에서 무시 가능).
+
+더 나은 설계 대안: Content 컴포넌트 안에서 Item 들이 별도 "hidden registry" 에 meta 만 등록하도록 "dry mount" 를 구현. v1 에서는 단순함을 위해 **closed 상태에서도 DOM 유지 전략** 채택.
+
+```ts
+// SelectContent
+const visible = open || contentRef.current != null;
+return (
+  <Portal active={open}>
+    <div
+      role="listbox"
+      style={{
+        display: open ? "block" : "none",
+        ...(open ? floatingStyles : {}),
+      }}
+    >
+      {children}
+    </div>
+  </Portal>
+);
+```
+
+> `Portal active` 가 false 면 Portal 은 `document.body` 로 append 하지 않고 `null` 반환 — 즉 DOM 에서 완전히 제거. 이 전략을 선택하면 closed 상태 Item 레지스트리는 비어 있다. 그러면 Trigger 의 SelectValue 는 어떻게 선택값 라벨을 표시할까?
+
+**최종적으로 선택하는 구현 (명확히):**
+
+- Item 메타 (value→textValue 매핑) 는 Root 가 별도 `itemsMetaRef` 로 관리한다.
+- `Select.Item` 은 mount 시 `ctx.registerItemMeta(value, textValue, disabled)` 호출, unmount 시 해제.
+- Content 가 닫힌 상태에서도 Item 이 **mount 되어 있어야 meta 등록** 이 가능하다 → 해결: Content 는 open 여부와 관계없이 **항상 children 을 mount** 한다. 단 open=false 일 때는 `display:none` + Portal 비활성(`<Portal active={open}>`).
+- 이 방식으로 Item 은 항상 레지스트리에 있다. 실제 DOM element ref 는 open 이후에만 유효(Portal append 이후). 그러나 키보드 탐색은 open 상태에서만 일어나므로 문제 없음.
+
+즉 "Content 가 closed 일 때도 hidden 으로 DOM 유지" 전략. 메모리 비용은 미미.
+
+### 9.7 form 연동
+
+`name` prop 이 있으면 hidden input 을 Trigger 바로 옆에 렌더:
+
+```tsx
+{name && (
+  <input
+    type="hidden"
+    name={name}
+    value={value ?? ""}
+    required={required}
+  />
+)}
+```
+
+- `<form>` 안에서 Select 를 사용하면 form 제출 시 value 가 함께 제출된다.
+- `required` + value 가 없으면 브라우저 기본 validation 은 hidden input 엔 동작하지 않으므로, 더 정밀한 validation 은 JS 측에서 체크. v1 은 단순 pass-through.
+
+---
+
+## 10. 파일 구조
+
+```
+src/components/Select/
+├── Select.tsx                 # 배럴 namespace + SelectRoot 조립
+├── Select.types.ts            # 공개 타입
+├── SelectContext.ts           # Context 정의 + useSelectContext
+├── SelectRoot.tsx             # Root 컴포넌트 (controlled/uncontrolled, 레지스트리)
+├── SelectTrigger.tsx          # Trigger (button, combobox role, 키보드)
+├── SelectValue.tsx            # 선택값 표시 span
+├── SelectIcon.tsx             # ▾ 아이콘
+├── SelectContent.tsx          # Portal + floating + listbox
+├── SelectGroup.tsx            # 그룹 + label
+├── SelectLabel.tsx            # 그룹 헤더 라벨
+├── SelectItem.tsx             # Item (option role, 레지스트리 등록, click/hover)
+├── SelectItemIndicator.tsx    # ✓ 표시 슬롯
+├── SelectSeparator.tsx        # 구분선
+├── useSelectTypeahead.ts      # type-ahead 버퍼 훅
+├── colors.ts                  # palette
+└── index.ts                   # 배럴
+```
+
+각 파일 책임:
+
+- **SelectRoot.tsx** — `useControllable` 두 축, 레지스트리 관리, Context Provider, hidden input 렌더.
+- **SelectTrigger.tsx** — `<button type="button">` + aria, Enter/Space/Arrow 로 open, 포커스 visible 링.
+- **SelectContent.tsx** — Popover 의 `useFloating` + `useAnimationState` 재사용. Portal + listbox role. open 여부 상관없이 DOM 에 children 를 유지(위 §9.6 전략).
+- **SelectItem.tsx** — mount 시 registerItemMeta, open 상태일 때 실제 element ref 도 등록. 클릭 핸들러, hover 시 activeValue 갱신.
+- **SelectValue.tsx** — Context 의 value 를 읽어 레지스트리에서 textValue 찾아 표시.
+- **useSelectTypeahead.ts** — bufferRef + timer + `onTypeAhead(char)` 훅.
+- **colors.ts** — selectPalette light/dark.
+
+---
+
+## 11. 구현 단계
+
+각 단계 독립 커밋. 각 커밋이 `npm run typecheck` + `npx tsup` 통과.
+
+### Step 1 — 타입 + 배럴 + palette 스켈레톤
+1. `Select.types.ts` 전부 작성 (§2.1).
+2. `colors.ts` 작성 (palette light/dark).
+3. `index.ts` 배럴.
+4. `src/components/index.ts` 에 `export * from "./Select";`.
+5. `Select.tsx` placeholder: `export const Select = { Root: () => null, Trigger: () => null, /* ... */ };`.
+6. `npm run typecheck` 통과.
+7. 커밋: `feat(Select): 타입 + palette + 배럴`.
+
+### Step 2 — Context + SelectRoot 기본
+1. `SelectContext.ts`: `createContext<SelectContextValue | null>(null)` + `useSelectContext()`.
+2. `SelectRoot.tsx`:
+   - `useControllable<SelectValue | undefined>` (value)
+   - `useControllable<boolean>` (open)
+   - `itemsMetaRef: Map<value, {textValue, disabled}>` 레지스트리.
+   - `activeValue` state.
+   - Context Provider.
+3. `Select.tsx` 에서 Root 만 실체 연결.
+4. 커밋: `feat(Select): Root + Context`.
+
+### Step 3 — SelectTrigger + SelectValue + SelectIcon
+1. `SelectTrigger.tsx`: `<button type="button" role="combobox" aria-haspopup aria-expanded>`. click = toggle open.
+2. `SelectValue.tsx`: 현재 value 의 textValue 또는 placeholder 표시. render-prop children 지원.
+3. `SelectIcon.tsx`: 기본 ▾ svg. children 지정 시 교체.
+4. Trigger 키보드: Enter/Space/ArrowDown/ArrowUp 으로 open (ArrowDown/Up 은 open 후 active 계산 포함).
+5. 커밋: `feat(Select): Trigger + Value + Icon`.
+
+### Step 4 — SelectContent + Portal + positioning
+1. `SelectContent.tsx`: Popover 의 `useFloating` 재사용 (혹은 `useFloating` 을 `_shared/` 로 이미 뺀 상태면 그대로). side/align/sideOffset/alignOffset 지원.
+2. `Portal` 은 `_shared/Portal` 재사용. `active={open}` 로 mount 제어.
+3. open 여부와 별개로 children 은 항상 렌더하되 `display:none` 트릭으로 레지스트리 유지.
+4. `matchTriggerWidth` 로 Content width 결정.
+5. `maxHeight` + `overflowY:auto`.
+6. `useAnimationState` 로 opacity+translateY 전환.
+7. outside click + Escape → close. Trigger 자신은 outside 아님.
+8. 커밋: `feat(Select): Content + Portal + positioning`.
+
+### Step 5 — SelectItem 레지스트리 + 클릭/호버
+1. `SelectItem.tsx`:
+   - `useId()` 로 itemId.
+   - mount/unmount 시 `registerItemMeta`.
+   - content mount 상태일 때 DOM ref 도 `registerItemNode`.
+   - `role="option"`, `aria-selected`, `aria-disabled`, `data-active`.
+   - click → `setValue(value)` + close.
+   - mouseenter → `setActiveValue(value)` (단, disabled 면 무동작).
+2. `SelectItemIndicator.tsx`: value === itemValue 일 때만 children 렌더. 기본 ✓ 아이콘.
+3. 커밋: `feat(Select): Item + ItemIndicator + 레지스트리`.
+
+### Step 6 — 키보드 탐색 + aria-activedescendant
+1. `SelectContent` 에 `onKeyDown` 연결 (§7.3 전부).
+2. `SelectTrigger` 에 `onKeyDown` 으로 open trigger (Enter/Space/ArrowDown/ArrowUp).
+3. open 시 activeValue = 현재 value 또는 첫 enabled item.
+4. activeValue 바뀔 때마다 해당 node.scrollIntoView({ block: "nearest" }).
+5. listbox 가 focus 받아야 keydown 이 버블됨 — open 시 `contentRef.current?.focus()` 명시.
+6. `aria-activedescendant` 로 시각 포커스 노출.
+7. 커밋: `feat(Select): 키보드 + aria-activedescendant`.
+
+### Step 7 — Group / Label / Separator
+1. `SelectGroup.tsx`: `role="group"` + `aria-labelledby`. label prop 있으면 내부 Label 렌더.
+2. `SelectLabel.tsx`: `role="presentation"` + palette labelFg.
+3. `SelectSeparator.tsx`: `role="separator"` + 1 px 라인.
+4. 커밋: `feat(Select): Group + Label + Separator`.
+
+### Step 8 — Type-ahead
+1. `useSelectTypeahead.ts`: bufferRef + timer + `onTypeAhead(char)` 반환.
+2. `SelectContent` keydown 기본 case 에서 한 글자면 onTypeAhead 호출.
+3. enabled items 중 `textValue.toLowerCase().startsWith(buffer)` 매칭, 현재 위치 다음부터 순환 검색.
+4. 매칭되면 activeValue 갱신 + scrollIntoView.
+5. 커밋: `feat(Select): type-ahead`.
+
+### Step 9 — form 연동 + disabled + name
+1. Root 의 `name` 있으면 hidden input 렌더.
+2. Root `disabled` → Trigger disabled + keyboard 차단 + open 방지.
+3. 커밋: `feat(Select): form 연동 + disabled`.
+
+### Step 10 — Dark 테마
+1. palette dark 통합.
+2. Trigger/Content/Item/Label/Separator 색상 토큰화.
+3. 커밋: `feat(Select): dark 테마`.
+
+### Step 11 — 데모 페이지
+1. `demo/src/pages/SelectPage.tsx` (§12).
+2. `demo/src/App.tsx` NAV + `Page` 유니온 + 라우트 추가.
+3. 커밋: `feat(Select demo): 페이지 + 라우팅`.
+
+### Step 12 — 마감
+1. Props 표 + Usage 예제.
+2. §20 DoD 체크.
+3. 커밋: `feat(Select): Props 표 + Usage`.
+
+---
+
+## 12. 데모 페이지
+
+`demo/src/pages/SelectPage.tsx`. `CommandPalettePage.tsx` 의 Section/Card 헬퍼를 그대로 복제.
+
+### 12.1 NAV 추가 (App.tsx)
+
+`Page` 유니온에 `"select"` 추가:
+
+```ts
+type Page = "button" | "card" | /* ... */ | "select";
+```
+
+NAV 배열에 항목 추가:
+
+```ts
+{ id: "select", label: "Select", description: "단일 값 드롭다운", sections: [
+  { label: "Basic",          id: "basic" },
+  { label: "Grouped",        id: "grouped" },
+  { label: "Disabled items", id: "disabled" },
+  { label: "Controlled",     id: "controlled" },
+  { label: "With form",      id: "form" },
+  { label: "Custom render",  id: "custom-render" },
+  { label: "Long list",      id: "long-list" },
+  { label: "Dark theme",     id: "dark" },
+  { label: "Playground",     id: "playground" },
+  { label: "Props",          id: "props" },
+  { label: "Usage",          id: "usage" },
+]},
+```
+
+라우팅 switch 에 `{current === "select" && <SelectPage />}`.
+
+### 12.2 섹션 구성
+
+**Basic**
+```tsx
+const [lang, setLang] = useState<string | undefined>();
+return (
+  <Select.Root value={lang} onValueChange={setLang} placeholder="언어 선택…">
+    <Select.Trigger aria-label="언어">
+      <Select.Value />
+      <Select.Icon />
+    </Select.Trigger>
+    <Select.Content>
+      <Select.Item value="ts">TypeScript</Select.Item>
+      <Select.Item value="js">JavaScript</Select.Item>
+      <Select.Item value="py">Python</Select.Item>
+      <Select.Item value="go">Go</Select.Item>
+    </Select.Content>
+  </Select.Root>
+);
+```
+
+**Grouped**
+```tsx
+<Select.Root defaultValue="ts" placeholder="언어">
+  <Select.Trigger><Select.Value /><Select.Icon /></Select.Trigger>
+  <Select.Content>
+    <Select.Group label="프론트엔드">
+      <Select.Item value="ts">TypeScript</Select.Item>
+      <Select.Item value="js">JavaScript</Select.Item>
+    </Select.Group>
+    <Select.Separator />
+    <Select.Group label="백엔드">
+      <Select.Item value="py">Python</Select.Item>
+      <Select.Item value="go">Go</Select.Item>
+      <Select.Item value="rs">Rust</Select.Item>
+    </Select.Group>
+  </Select.Content>
+</Select.Root>
+```
+
+**Disabled items**
+```tsx
+<Select.Content>
+  <Select.Item value="ts">TypeScript</Select.Item>
+  <Select.Item value="js">JavaScript</Select.Item>
+  <Select.Item value="rs" disabled>Rust (준비 중)</Select.Item>
+  <Select.Item value="ko" disabled>Kotlin (준비 중)</Select.Item>
+</Select.Content>
+```
+키보드 ArrowDown 이 disabled 항목을 건너뜀을 확인.
+
+**Controlled**
+외부 `useState` + 3개 프리셋 버튼 ("TypeScript" / "Python" / "Go").
+
+```tsx
+const [value, setValue] = useState("ts");
+return (
+  <div className="flex items-center gap-2">
+    <Button onClick={() => setValue("ts")}>TS</Button>
+    <Button onClick={() => setValue("py")}>Python</Button>
+    <Button onClick={() => setValue("go")}>Go</Button>
+    <Select.Root value={value} onValueChange={setValue}>
+      <Select.Trigger><Select.Value /><Select.Icon /></Select.Trigger>
+      <Select.Content>
+        <Select.Item value="ts">TypeScript</Select.Item>
+        <Select.Item value="py">Python</Select.Item>
+        <Select.Item value="go">Go</Select.Item>
+      </Select.Content>
+    </Select.Root>
+    <span className="text-sm text-gray-500">현재: {value}</span>
+  </div>
+);
+```
+
+**With form**
+실제 `<form onSubmit>` 안에 Select + submit 버튼 → FormData 로 값 확인 출력.
+
+```tsx
+function FormDemo() {
+  const [submitted, setSubmitted] = useState<string>("");
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const data = new FormData(e.currentTarget);
+        setSubmitted(String(data.get("lang") ?? ""));
+      }}
+    >
+      <Select.Root name="lang" required defaultValue="ts">
+        <Select.Trigger><Select.Value /><Select.Icon /></Select.Trigger>
+        <Select.Content>
+          <Select.Item value="ts">TypeScript</Select.Item>
+          <Select.Item value="py">Python</Select.Item>
+        </Select.Content>
+      </Select.Root>
+      <Button type="submit">제출</Button>
+      {submitted && <div>제출됨: {submitted}</div>}
+    </form>
+  );
+}
+```
+
+**Custom render**
+아이콘 + 부제 + 키캡 배치.
+
+```tsx
+<Select.Item value="ts" textValue="TypeScript">
+  <span className="w-4 h-4 mr-2 inline-flex items-center justify-center bg-blue-500 text-white text-[10px] rounded-sm">TS</span>
+  <span className="flex-1">TypeScript</span>
+  <span className="ml-auto text-xs text-gray-400">.ts</span>
+</Select.Item>
+```
+
+**Long list (type-ahead 체감)**
+타임존 60 개 또는 국가코드 200 개 목록. 팝업 열고 "ko" 타이핑 시 Korea 로 점프.
+
+**Dark theme**
+배경 `#0f172a` 래퍼 + `theme="dark"`.
+
+**Playground**
+상단 컨트롤:
+- `placeholder` text input
+- `side` select (top/bottom/left/right)
+- `align` select (start/center/end)
+- `sideOffset` number
+- `maxHeight` number
+- `matchTriggerWidth` checkbox
+- `disabled` checkbox
+- `theme` radio (light/dark)
+
+하단에 `<Select.Root>` 를 args 로 렌더하고 selected value 를 label 로 노출.
+
+**Props 표**
+Root/Trigger/Content/Item/Group/ItemIndicator/Separator 각각. 기존 페이지 Props 섹션 포맷(테이블 + prop × 타입 × 기본값 × 설명) 그대로.
+
+**Usage (4개)**
+1. 기본 단순 Select.
+2. 그룹 + 구분선.
+3. Controlled + form 제출.
+4. Custom render (아이콘 + 부제).
+
+---
+
+## 13. 검증 계획
+
+### 13.1 자동화
+
+```bash
+cd /Users/neo/workspace/plastic
+npm run typecheck
+npx tsup
+```
+
+주의:
+- `exactOptionalPropertyTypes: true` — optional prop 은 `?:` 로 받고 디폴트 머지에서 `undefined` 분기.
+- `noUncheckedIndexedAccess: true` — `items[i]` 는 `RegisteredItem | undefined`. 키보드 핸들러의 `next`, `prev` 계산 시 가드 필요.
+- `verbatimModuleSyntax: true` — 타입은 `import type`.
+
+### 13.2 수동 (demo dev server)
+
+```bash
+cd demo && npm run dev
+```
+
+체크리스트:
+- [ ] Basic: Trigger 클릭 → 팝업 열림. 아이템 클릭 → Trigger label 업데이트, 팝업 닫힘.
+- [ ] 키보드: Trigger focus + Enter → 팝업 open + 현재 선택 active. ArrowDown/Up 이동. Enter 로 선택. Escape 로 취소.
+- [ ] Grouped: 그룹 헤더가 키보드 탐색 순서에 포함되지 않음. Separator 도 스킵.
+- [ ] Disabled item: mouse hover 는 스타일 변화만 없음(혹은 약함), 클릭 무반응, 키보드 스킵.
+- [ ] Controlled: 외부 버튼 클릭 시 Select 표시 즉시 변경. 사용자 Select 변경 시 onValueChange 로 외부 state 업데이트.
+- [ ] form: 제출 시 FormData 에 name=value 가 들어감. required + 빈 값이면 HTML5 유효성은 hidden input 특성상 우회되지만 dev 로그로 경고 (v1 scope).
+- [ ] Long list + type-ahead: 팝업 open 상태에서 "ko" 타이핑 → Korea 로 active 이동. 500 ms 대기 후 버퍼 리셋.
+- [ ] Dark theme: Trigger/Content/Item 전체 색상 전환.
+- [ ] Outside click: 팝업 외 영역 클릭 → 닫힘.
+- [ ] Tab: 팝업 open 중 Tab → 닫히고 다음 tabbable 로 이동.
+- [ ] Playground: 모든 컨트롤 조합 실시간 반영.
+- [ ] 다른 페이지 리그레션 없음.
+
+### 13.3 엣지 케이스
+
+- [ ] 옵션 0 개: 팝업은 열리지만 내부 빈 박스. 키보드 입력 시 안정적으로 ignore.
+- [ ] value 가 레지스트리에 없는 값: Trigger 는 placeholder 표시 + dev warn.
+- [ ] 동일 value 중복 Item: 첫 번째 기준 동작 + dev warn.
+- [ ] 팝업 열린 중 window 리사이즈: `useFloating` 의 resize 리스너로 재배치.
+- [ ] 팝업 열린 중 부모 scroll: 재배치.
+- [ ] IME 조합 중 keydown: `isComposing` 가드로 ignore.
+- [ ] `disabled` Root 에서 Space 눌러도 open 불가.
+- [ ] form 안에서 Trigger 가 submit 유발하지 않음 (type="button" 확인).
+- [ ] Portal 경계: `<div style="transform:scale(1)">` 안쪽에서도 팝업 위치 정확.
+- [ ] Dialog 안에 Select: z-index 충돌 없음 (Dialog 의 Portal z-index 보다 Select Portal 이 더 커야 함 — Popover 와 동일 전략 사용).
+- [ ] closed 상태에서도 Item 이 meta 를 등록 — SelectValue 가 mount 직후 올바른 텍스트를 보여줌.
+- [ ] 매우 긴 옵션 텍스트: Trigger 는 `overflow:hidden text-overflow:ellipsis`, Item 은 `white-space:nowrap overflow:hidden`.
+- [ ] Right-to-Left (dir="rtl"): Trigger 아이콘 위치 좌측으로 자동 flip (flex 로 구현되면 자연스럽게).
+
+---
+
+## 14. 성능
+
+### 14.1 목표
+- 팝업 open latency < 16 ms (60 fps 1 frame).
+- 100 옵션 렌더 시 초기 mount < 20 ms.
+- 키보드 반복 (Arrow 홀드) 시 60 fps 유지.
+
+### 14.2 병목 가설 + 완화
+
+1. **레지스트리 sort 비용**: activeValue 변경마다 items 배열 재정렬하면 O(n log n) × n. 완화: 레지스트리 등록/해제 시에만 `compareDocumentPosition` 기반 정렬, activeValue 변경은 단순 findIndex (O(n)).
+2. **Context value 매 렌더**: Root 의 Context 객체 새로 만들면 Trigger/Content/Item 모두 re-render. 완화: `useMemo` 로 value 안정화 + Item 은 `aria-selected`, `data-active` 를 DOM 속성으로만 바꾸는 방식으로 re-render 최소화. v1 은 단순함을 위해 context 1 개로 가되, Item 개수가 많아 체감 이슈 생기면 v1.1 에서 selector context 분리.
+3. **scrollIntoView 반복**: ArrowDown 홀드 시 매 frame scrollIntoView → 브라우저 smooth-scroll 경합. 완화: `behavior: "auto"` + `block: "nearest"` 기본. 이미 보이는 item 은 scroll 하지 않음.
+4. **long list 렌더 비용**: 500+ 옵션에서 초기 mount 지연. v1 은 virtualization 없음. 500+ 사용 사례는 v1.1 의 `virtualize` 로 위임.
+
+### 14.3 측정
+- DevTools Performance 로 팝업 open → keyboard ArrowDown 10 회 녹화, `Recalculate Style` 이 16 ms 안에 끝나는지 확인.
+
+---
+
+## 15. 접근성
+
+WAI-ARIA 1.2 의 "Combobox with Listbox Popup" 패턴 + "Listbox" 패턴을 혼합:
+
+### Trigger
+- `<button type="button">`.
+- `role="combobox"` (single-select collapsible).
+- `aria-haspopup="listbox"`.
+- `aria-expanded={open}`.
+- `aria-controls={listboxId}` (open 시).
+- `aria-labelledby` — 외부 `<label>` 가 있으면 해당 id. 없으면 내부 `aria-label` 사용자 prop 허용.
+- `aria-activedescendant={activeItemId}` — open + activeValue 가 있을 때. listbox 에 두기도 하지만 Trigger 가 `role=combobox` 인 경우 listbox 대신 combobox(=trigger) 에 두는 것이 ARIA 1.2 권장.
+- 실제 DOM focus: 팝업 open 이후에도 Trigger 에 유지. 이게 ARIA 1.2 의 "focus stays on combobox" 관례.
+
+### Content (listbox)
+- `role="listbox"`.
+- `aria-labelledby={triggerId}`.
+- `tabIndex={-1}` — focus 는 받지만 탭 순서에는 없음.
+- open 직후 focus 를 listbox 로 **이동하지 않는다**. Trigger 에 유지. (ARIA 1.2.)
+
+→ 그러면 keydown 이 listbox 로 들어오지 않는다. 해결: **keydown 리스너는 Trigger 에** 붙이고, open 일 때는 listbox 키처럼 처리. Radix 는 이 방식.
+
+**최종 구현**: Trigger 에 모든 keydown handler. open=true 일 때는 listbox 키(ArrowDown/Up/Home/End/Enter/Space/Escape/Tab/typeahead) 처리, open=false 일 때는 open trigger(Enter/Space/ArrowDown/Up) 처리.
+
+### Item
+- `role="option"`.
+- `aria-selected={value === itemValue}` — current value 와 일치.
+- `aria-disabled={disabled}`.
+- `id={itemId}` — `aria-activedescendant` 로 참조됨.
+- `data-active={isActive}` — CSS 하이라이트 용.
+
+### Group
+- `role="group"`.
+- `aria-labelledby={labelId}`.
+
+### Separator
+- `role="separator"`.
+- `aria-orientation="horizontal"`.
+
+### Screen reader 테스트
+VoiceOver / NVDA 에서:
+- Trigger focus → "언어, 선택 박스, 접힘, 버튼" 류로 읽힘.
+- Enter → "펼침, TypeScript 선택됨, 2/5" 같은 listbox 상태 안내.
+- ArrowDown → "JavaScript" 읽힘.
+- Enter → "축소됨, JavaScript" + Trigger focus 복귀.
+
+---
+
+## 16. 알려진 트레이드오프
+
+1. **value 는 string 만**. 객체/숫자를 직접 받으면 DX 는 좋지만 serialization / referential equality / form 제출 경계가 모호해진다. Radix/HeadlessUI 도 동일 결정. 사용자가 직접 `JSON.stringify` / `String(n)` 감싸서 사용.
+2. **Content 닫힌 상태에서도 DOM 유지**. (§9.6) Item 레지스트리를 "항상 mount" 로 유지해 `SelectValue` 가 즉시 label 을 표시하게 한다. 대안(hidden registry-only mount)은 구현 복잡. 비용: 닫힌 상태에서 Item JSX 가 메모리 상주. 100 항목 이하에서 무시 가능. 더 큰 사례 (1000+) 는 v1.1 virtualize 에서 dry-mount 전략으로 분리.
+3. **wrap-around 없는 키보드**. Radix 기본과 일치. VSCode 도 일치. 원하면 v1.1 에 `loop: boolean`.
+4. **type-ahead 는 startsWith 만**. fuzzy/contains 는 CommandPalette 의 책임으로 분리. Select 는 짧은 enumerable 값을 가정.
+5. **포커스 처리 — DOM focus 는 Trigger 에 유지, listbox 는 virtual focus**. ARIA 1.2 권장 + Radix 패턴 일치. 전통적 "listbox 가 실제 focus 를 가진다" 방식도 정답이지만, 그러면 팝업 open/close 마다 focus 를 명시 이동시켜야 하고 outside click 에서 복원 타이밍이 까다롭다. virtual focus 가 구현 단순 + ARIA 1.2 호환.
+6. **form 연동은 hidden input** — 간단하지만 `required` 의 브라우저 기본 validation UI 가 hidden input 에선 약함. 더 정밀한 validation 은 사용자 앱(JS)이 해야. 대안은 `<select hidden>` 이지만 이 역시 hidden 에선 required validation 이 브라우저별 다름.
+7. **no virtualization v1**. 1000+ 옵션에서 초기 mount 가 느려짐. v1.1 `virtualize` prop 으로 풀 예정. v1 은 설계 단순.
+8. **matchTriggerWidth 기본 true**. 드물게 Trigger 가 아주 좁고 Item 텍스트가 길면 truncation 발생. matchTriggerWidth=false 로 풀면 palette 와 box-shadow 가 시각적으로 "떠있는" 느낌이 되어 시각 밸런스가 깨질 수 있다. v1 은 기본 true 유지, false 는 escape hatch.
+9. **async options 없음**. 선언형 children 만 지원. 사용자가 async 로 options 배열을 만들고 map 으로 children 을 렌더하는 방식은 가능하지만 첫 render 에 options 없는 상태에서 value 가 세팅되면 placeholder 가 보인다 (위 §6 엣지 케이스).
+10. **Portal 필요**. SSR 환경에서 document 없으면 Portal fail. `_shared/Portal` 이 이미 `typeof window` 가드 포함한다는 전제. 확인 필요.
+
+---
+
+## 17. 후속 작업 (v1.1+)
+
+- **multi-select**: `mode="multiple"` + `value: string[]`. Trigger 에 chip 표시. MultiSelect 별도 컴포넌트로 풀 수도.
+- **virtualize**: `virtualize?: boolean | { itemHeight: number; overscan?: number }`. 내부적으로 react-window-like tiny 구현 또는 의존성 추가 여부 재검토.
+- **Combobox (autocomplete)**: Trigger 가 input 이고 type 할 때마다 필터링. Select 와 공통 Context 구조 재활용 가능.
+- **async options**: `loadOptions?: (query: string) => Promise<Item[]>` + loading 인디케이터.
+- **create new**: `onCreate?: (query: string) => void` + footer UI.
+- **nested submenu**: cascading select. Radix 의 SubMenu 패턴.
+- **nativeOnMobile**: `userAgent` 감지 후 iOS/Android 에서 `<select>` native UI 로 위임.
+- **custom filter for type-ahead**: `filterFunction?: (item, query) => boolean` 으로 contains/fuzzy 확장.
+- **loop (wrap-around)**: `loop?: boolean`.
+- **size variants**: `size="sm" | "md" | "lg"` — Button 과 일관.
+- **더 풍부한 screen reader 라이브 안내**: ARIA 1.2 이상 의 announcement 를 위한 aria-live region (ARIA best practice authoring guide).
+
+---
+
+## 18. 관련 파일 인벤토리 (구현 시 참조)
+
+| 용도 | 경로 |
+|---|---|
+| useControllable (dual API 표준) | `/Users/neo/workspace/plastic/src/components/_shared/useControllable.ts` |
+| Portal + floating + 애니메이션 패턴 | `/Users/neo/workspace/plastic/src/components/Popover/PopoverContent.tsx` |
+| Popover 디렉토리 전반 (`useFloating`, `useAnimationState`, `useFocusTrap`) | `/Users/neo/workspace/plastic/src/components/Popover/` |
+| combobox + activeIndex + aria-activedescendant 선행 예 | `/Users/neo/workspace/plastic/src/components/CommandPalette/CommandPaletteInput.tsx` |
+| CommandPalette 컴포넌트 구조 (compound + Context + fuzzyMatch) | `/Users/neo/workspace/plastic/src/components/CommandPalette/` |
+| 배럴 등록 위치 | `/Users/neo/workspace/plastic/src/components/index.ts` |
+| 데모 App 라우팅 / NAV | `/Users/neo/workspace/plastic/demo/src/App.tsx` |
+| 최신 데모 페이지 포맷 | `/Users/neo/workspace/plastic/demo/src/pages/CommandPalettePage.tsx` |
+| tsconfig 제약 (exactOptionalPropertyTypes / noUncheckedIndexedAccess / verbatimModuleSyntax) | `/Users/neo/workspace/plastic/tsconfig.json` |
+| 유사 plan 포맷 레퍼런스 | `/Users/neo/workspace/plastic/docs/plans/017-splitpane-component.md` |
+
+---
+
+## 19. 의존성 영향
+
+신규 런타임 의존 없음. React 18.3 (기존) + DOM API (`Portal` via `createPortal`, `requestAnimationFrame`, `scrollIntoView`, `getBoundingClientRect`) 만 사용.
+
+번들 영향:
+- Select 자체 예상 크기: ~4 KB (min), ~1.8 KB (min+gzip). Popover 의 useFloating 을 재사용한다면 중복 없음.
+- plastic 전체 dist 영향 minimal.
+
+브라우저 지원:
+- `Element.scrollIntoView({ block: "nearest" })`: Chrome 61+, Firefox 58+, Safari 14+. 모두 ES2020 타깃 OK.
+- `createPortal`: React 내장.
+- PointerEvents (click, mousedown): 모든 모던 브라우저.
+- `Element.compareDocumentPosition`: universal.
+
+접근성:
+- ARIA 1.2 combobox + listbox 패턴 준수.
+- VoiceOver / NVDA / JAWS 기본 동작 검증.
+
+---
+
+## 20. 구현 완료 정의 (Definition of Done)
+
+- [ ] `npm run typecheck` 통과.
+- [ ] `npx tsup` 통과 (타입 선언 포함).
+- [ ] demo 에 `/#/select` 라우트 동작.
+- [ ] §13.2 수동 체크리스트 항목 전부 눈으로 확인.
+- [ ] §13.3 엣지 케이스 항목 전부 눈으로 확인 또는 "v1 범위 밖" 이유 기재.
+- [ ] Button / Card / CodeView / CommandPalette / Dialog / Toast / Tooltip / Popover / PipelineGraph / DataTable 등 기존 페이지 리그레션 없음.
+- [ ] `src/components/index.ts` 배럴에 `export * from "./Select";` 추가됨.
+- [ ] `package.json` dependencies 변경 없음 (신규 의존 없음).
+- [ ] Props 문서 섹션이 Props 표로 채워져 있음 (Root/Trigger/Content/Item/Group/ItemIndicator/Separator 일곱 개).
+- [ ] Usage 섹션에 최소 4 개 스니펫 (기본 / 그룹 / controlled+form / custom render).
+- [ ] 데모 Playground 에서 모든 prop 토글 가능.
+- [ ] Light/Dark 테마 전환 시 시각 이상 없음.
+- [ ] 키보드 단독으로 (마우스 없이) 모든 동작이 가능 (open, 탐색, 선택, 취소, type-ahead).
+- [ ] 스크린리더(VoiceOver) 에서 Trigger 의 상태 변경과 선택 값 변경이 명확히 읽힘.
+- [ ] `Select.Root` 가 `<form>` 안에서 name prop 으로 값 제출되는 것을 확인.
+- [ ] `disabled` Root 에서 모든 상호작용이 차단됨.
+- [ ] Portal 렌더된 Content 가 `overflow:hidden` 부모 안에서도 올바르게 표시됨.
+
+---
+
+**끝.**

--- a/docs/plans/014-combobox-component.md
+++ b/docs/plans/014-combobox-component.md
@@ -1,0 +1,1544 @@
+# Combobox 컴포넌트 설계문서
+
+## Context
+
+plastic 라이브러리에 "텍스트 입력으로 옵션을 필터링/선택하는 자동완성 입력 프리미티브" `Combobox` 를 추가한다. 역할 비유: VSCode 의 "Go to Symbol" 입력(ctrl+shift+o), IntelliJ 의 "Search Everywhere" 박스, GitHub 의 repo/user autocomplete, Linear 의 assignee picker, Notion 의 `@`-mention, Algolia InstantSearch 의 검색 박스, Slack 의 채널 picker. 즉 "input 한 줄 + dropdown 리스트" 형태로 사용자가 타이핑하여 후보를 좁혀 나가는, 모든 설정/폼 UI 의 기본 블록이다.
+
+plastic 은 이미 `CommandPalette` (009) — 전역 단축키로 뜨는 **모달** 검색기 — 를 갖고 있다. 본 컴포넌트 `Combobox` 는 그와 프론트엔드 로직(필터·async·키보드·하이라이트 등) 상당 부분을 공유하지만, 결정적으로 다음이 다르다.
+
+- **인라인 배치**. 포털/오버레이 없이 폼 필드 자리에 그대로 놓인다 (드롭다운만 floating).
+- **값(value) 이 존재**. 선택 결과가 외부 상태에 저장되며 form 의 일부로 동작.
+- **freeform 허용**. 사용자가 목록에 없는 임의 텍스트를 그대로 값으로 확정할 수 있는 모드 제공.
+- **multi-select 변형**. 칩(chip/tag) 표시와 개별 삭제.
+- **strict 모드** 의 존재. 목록 외 값을 차단하는 전형적 "Select + 검색" 용도.
+
+따라서 `CommandPalette` 를 감싸 인라인으로 박는 어댑터가 아니라, 로직 공유(필터·fuzzy·debounce·keyboard)는 `_shared/` 로 승격하되 **독립 compound 컴포넌트**로 설계한다.
+
+참고 (prior art — UX/API 근거):
+- **Radix UI `Combobox`** (primitives.combobox) — compound (`Root/Trigger/Input/Portal/Content/Viewport/Item/Empty`), controlled-first, headless.
+- **Headless UI `Combobox`** (tailwindlabs) — `displayValue`, `by`, multiple, nullable, custom filter, `ComboboxOptions`.
+- **Ant Design `AutoComplete` / `Select showSearch`** — `options` prop, `filterOption`, `notFoundContent`, `loading`, grouped options.
+- **react-select** — 비동기 옵션 (`AsyncSelect`), `formatOptionLabel`, `createable`, multi with chips.
+- **Downshift** (pre-hooks 시대 표준) — `useCombobox` 훅 기반, WAI-ARIA 1.2 combobox pattern 충실.
+- **MUI `Autocomplete`** — `freeSolo`, `multiple`, `getOptionLabel`, `filterOptions(options, state)`.
+- **Chakra `AutoComplete` (choc-ui)** — tagged/chip multi, 강조 하이라이트.
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/_shared/useControllable.ts` — controlled/uncontrolled 이중 API 표준 훅. Combobox 는 `value`, `inputValue`, `open` 세 축을 각각 useControllable 로 관리한다.
+- `src/components/CommandPalette/` — 본 컴포넌트의 **최대 재사용 원천**. 특히 `fuzzyMatch.ts` (전체 이관/공유), `CommandPaletteRoot.tsx` 의 async debounce + searchSeqRef cancel 패턴, `CommandPaletteList.tsx` 의 activeIndex/scrollIntoView, `CommandPaletteItem.tsx` 의 match-highlight 렌더 로직.
+- `src/components/Popover/` — floating dropdown 위치 계산을 위한 `_shared/useFloating` 훅 의존처. Combobox 의 `Content` 는 Popover 와 동일한 floating 로직을 재사용 (단 role 은 `listbox`, modal 아님).
+- `src/components/PathInput/` — compound + input-중심 UX 참고 (Root/Input/Button/Status 배치, 이벤트 bubble 규칙).
+- `src/components/index.ts` — 배럴 등록 위치.
+- `demo/src/App.tsx` — NAV / Page 타입 / 라우팅 추가 위치.
+- `demo/src/pages/CommandPalettePage.tsx` — 데모 페이지 레이아웃·Props 표·Playground 패턴 참고 (가장 유사 컴포넌트).
+- `tsconfig.json` — `exactOptionalPropertyTypes: true`, `noUncheckedIndexedAccess: true`, `verbatimModuleSyntax: true` 제약.
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+// 기본: 동기 옵션 + 단일 선택 + strict
+<Combobox.Root
+  options={fruits}                       // { value: string; label: string }[]
+  value={value}
+  onValueChange={setValue}
+  placeholder="과일을 검색하세요"
+>
+  <Combobox.Input />
+  <Combobox.Trigger>▾</Combobox.Trigger>
+  <Combobox.Content>
+    <Combobox.Loading>불러오는 중…</Combobox.Loading>
+    <Combobox.Empty>결과 없음</Combobox.Empty>
+    {results.map((o) => (
+      <Combobox.Item key={o.value} value={o.value} label={o.label} />
+    ))}
+  </Combobox.Content>
+</Combobox.Root>
+```
+
+간단 사용 (`options` 만 전달하고 Item 렌더는 내부 기본):
+
+```tsx
+<Combobox.Root
+  options={fruits}
+  value={value}
+  onValueChange={setValue}
+/>
+```
+
+multi + async + freeform:
+
+```tsx
+<Combobox.Root
+  multiple
+  freeform                               // 목록 밖 텍스트 허용
+  value={tags}                           // string[]
+  onValueChange={setTags}
+  onSearch={async (q) => api.suggest(q)} // Promise<Option[]>
+  searchDebounce={200}
+  minChars={1}
+  theme="dark"
+>
+  <Combobox.Input placeholder="태그…" />
+  <Combobox.Content />
+</Combobox.Root>
+```
+
+렌더 결과 (개념):
+
+```
+┌──────────────────────────────────────┐  ← Combobox.Root (relative)
+│ [✕ React] [✕ TS]  type to search…  ▾ │  ← Input + chips + Trigger
+└──────────────────────────────────────┘
+ ┌──────────────────────────────────┐
+ │  ⎯ Fruits ⎯                       │   ← Group heading
+ │  Ap·p·le            ← highlight   │
+ │  Apri·cot                          │
+ │  ──────────────                    │
+ │  Banana                            │
+ │  (empty) 결과 없음                  │
+ └──────────────────────────────────┘
+```
+
+핵심 설계 원칙:
+- **compound 컴포넌트**. `Root` / `Input` / `Trigger` / `Content` / `Item` / `Group` / `Empty` / `Loading` 의 8 소계. Context 로 상태 공유.
+- **런타임 의존 zero**. React + DOM + 기존 `_shared/useFloating` 만. 새 런타임 라이브러리 없음.
+- **headless 지향**. 스타일은 최소 기본값(VSCode quality) 을 주되, 모두 `className`/`style`/`asChild`(trigger) 로 override 가능.
+- **3축 controlled API**. `value` (선택값) / `inputValue` (입력 텍스트) / `open` (드롭다운 열림) 모두 `useControllable` 로 개별 controlled.
+- **단일/다중 선택, strict/freeform, 동기/비동기** 4 × 2 × 2 매트릭스를 단일 컴포넌트로 커버.
+- **접근성 WAI-ARIA 1.2 Combobox** 패턴 준수: `role="combobox"`, `aria-expanded`, `aria-autocomplete="list"`, `aria-activedescendant`, Popup `role="listbox"`, Option `role="option"` + `aria-selected`.
+- **v1 에 virtualization 없음**. maxResults cap + filter 내 O(N) 로만 성능 확보. 1,000 개 수준까지 정상. 더 큰 데이터는 v1.1 (§17) 에서 `react-window` 통합.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. 텍스트 입력으로 옵션 리스트를 실시간 필터링.
+2. 단일 (`multiple=false`, 기본) 및 다중 (`multiple`) 선택.
+3. strict 모드 (기본) — 목록 내 값만 확정. freeform 모드 — 임의 텍스트 값 허용.
+4. 동기 옵션 (`options` prop) + 사용자 정의 필터 함수 (`filter`).
+5. 비동기 옵션 (`onSearch` → `Promise<Option[]>`), debounce 및 in-flight cancel.
+6. 하이라이트: 매치된 부분 문자열 시각 강조 (fuzzy 매치 인덱스 기반).
+7. 그룹핑: `Option.group` 필드 + `Combobox.Group heading=...` 자동/수동 둘 다.
+8. `Empty` / `Loading` 상태 슬롯.
+9. 키보드 완전 조작 — Arrow/Enter/Tab/Esc/Home/End/Backspace(multi chip).
+10. controlled/uncontrolled 이중 API — `value` / `inputValue` / `open` 세 축.
+11. Light/Dark 테마.
+12. `minChars`, `maxResults`, `searchDebounce` 제약 prop.
+13. 포털 없는 인라인 floating dropdown (Popover 의 `useFloating` 재사용).
+14. 기본 스타일 (VSCode palette 유사: subtle border + shadow + dark 지원).
+
+### Non-goals (v1 제외)
+- **Virtualization**: 대량(>1,000) 옵션의 `react-window` / `@tanstack/react-virtual` 통합. v1 은 `maxResults` (기본 50) 로 잘라 우회. v1.1 에서.
+- **Creatable(생성)**: "새 옵션 만들기" 전용 UX (`Create "foo"` 아이템). freeform 이 부분적으로 커버하나, 전용 render prop + `onCreate(label)` 콜백은 v1.1.
+- **async pagination / infinite scroll**: `onSearch` 는 단일 응답만 수신. 페이지네이션(cursor/loadMore)은 v1.2.
+- **태그 입력 (태그 전용 UX)**: multi + freeform 조합이 태그 필드를 근사하지만, "enter 로 임의 텍스트 추가" + "패턴 검증" 같은 태그-특화 동작은 별도 `TagInput` 컴포넌트(v1.2) 로 분리.
+- **서버사이드 렌더**: v1 은 `useId`/`useFloating` 등 CSR 가정. SSR 안전성은 `typeof document` 가드만 추가.
+- **옵션 자체의 비동기 lazy 트리**: CommandPalette 의 `children` 형 중첩 네비게이션은 여기 포함하지 않음. Combobox 는 평면 리스트 + 단일 레벨 그룹만.
+- **풍부한 렌더 (이미지/부제 2줄 등)**: `Item` 의 render slot 은 v1 에서 `label` 과 단일 child 만. 복합 레이아웃은 사용자가 `<Combobox.Item>` 에 custom children 을 넘기는 것으로 해결.
+- **form integration helpers**: react-hook-form / Formik adapter 는 배포하지 않는다. 컴포넌트가 controlled API 만 잘 지키면 사용자 측에서 연결.
+- **case-sensitive 옵션**: 기본 필터는 case-insensitive 고정. sensitive 요구는 `filter` 커스텀으로.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Combobox/Combobox.types.ts`
+
+```ts
+import type {
+  CSSProperties,
+  HTMLAttributes,
+  InputHTMLAttributes,
+  ButtonHTMLAttributes,
+  ReactNode,
+} from "react";
+
+export type ComboboxTheme = "light" | "dark";
+
+/**
+ * Combobox 의 단일 옵션.
+ * - `value` 는 내부 식별자 (고유해야 함). onValueChange 로 전달되는 값.
+ * - `label` 은 표시 텍스트. 필터·하이라이트 대상.
+ * - `group` 은 선택적 그룹 헤딩. 동일 group 값을 가진 옵션끼리 묶여 렌더.
+ * - `disabled` 는 선택 차단.
+ * - `keywords` 는 추가 검색어 (label 외). fuzzy 매치 대상.
+ * - `meta` 는 user-land 임의 데이터. onValueChange 에는 포함되지 않지만 커스텀 렌더에서 접근 가능.
+ */
+export interface ComboboxOption<Meta = unknown> {
+  value: string;
+  label: string;
+  group?: string | undefined;
+  disabled?: boolean | undefined;
+  keywords?: string[] | undefined;
+  meta?: Meta | undefined;
+}
+
+export interface ComboboxMatchResult {
+  option: ComboboxOption;
+  score: number;
+  labelMatches: number[];   // hit indices in label
+}
+
+export type ComboboxFilter = (
+  query: string,
+  options: ComboboxOption[],
+) => ComboboxOption[] | ComboboxMatchResult[];
+
+/**
+ * multiple=false 일 때 value 는 string | null,
+ * multiple=true  일 때 value 는 string[].
+ *
+ * 타입 유니온 대신 두 개의 separate props 로 오버로드하면 사용처가
+ * 더 단순하지만, 본 레포는 CommandPalette 와 같이 props 하나로
+ * 합쳐 런타임에 분기하는 방식을 택한다. typescript 의 conditional
+ * overload 는 RootProps 제네릭으로 제공.
+ */
+
+export interface ComboboxRootPropsSingle
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange" | "defaultValue"> {
+  multiple?: false | undefined;
+
+  value?: string | null | undefined;
+  defaultValue?: string | null | undefined;
+  onValueChange?: ((next: string | null) => void) | undefined;
+
+  options?: ComboboxOption[] | undefined;
+
+  inputValue?: string | undefined;
+  defaultInputValue?: string | undefined;
+  onInputValueChange?: ((next: string) => void) | undefined;
+
+  open?: boolean | undefined;
+  defaultOpen?: boolean | undefined;
+  onOpenChange?: ((open: boolean) => void) | undefined;
+
+  filter?: ComboboxFilter | undefined;
+  onSearch?: ((query: string) => Promise<ComboboxOption[]>) | undefined;
+  searchDebounce?: number | undefined;
+  minChars?: number | undefined;
+  maxResults?: number | undefined;
+
+  freeform?: boolean | undefined;
+  strict?: boolean | undefined;     // freeform 의 반대. 기본 true. 명시적 표현용.
+
+  disabled?: boolean | undefined;
+  readOnly?: boolean | undefined;
+  placeholder?: string | undefined;
+
+  theme?: ComboboxTheme | undefined;
+
+  /** 외부에서 label 매핑이 필요할 때 (freeform 값 등). 기본 identity. */
+  getOptionLabel?: ((value: string) => string) | undefined;
+
+  children?: ReactNode | undefined;
+}
+
+export interface ComboboxRootPropsMultiple
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange" | "defaultValue"> {
+  multiple: true;
+
+  value?: string[] | undefined;
+  defaultValue?: string[] | undefined;
+  onValueChange?: ((next: string[]) => void) | undefined;
+
+  options?: ComboboxOption[] | undefined;
+
+  inputValue?: string | undefined;
+  defaultInputValue?: string | undefined;
+  onInputValueChange?: ((next: string) => void) | undefined;
+
+  open?: boolean | undefined;
+  defaultOpen?: boolean | undefined;
+  onOpenChange?: ((open: boolean) => void) | undefined;
+
+  filter?: ComboboxFilter | undefined;
+  onSearch?: ((query: string) => Promise<ComboboxOption[]>) | undefined;
+  searchDebounce?: number | undefined;
+  minChars?: number | undefined;
+  maxResults?: number | undefined;
+
+  freeform?: boolean | undefined;
+  strict?: boolean | undefined;
+
+  disabled?: boolean | undefined;
+  readOnly?: boolean | undefined;
+  placeholder?: string | undefined;
+
+  theme?: ComboboxTheme | undefined;
+
+  getOptionLabel?: ((value: string) => string) | undefined;
+
+  children?: ReactNode | undefined;
+}
+
+export type ComboboxRootProps =
+  | ComboboxRootPropsSingle
+  | ComboboxRootPropsMultiple;
+
+export interface ComboboxInputProps
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    "value" | "onChange" | "type" | "disabled" | "readOnly"
+  > {
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface ComboboxTriggerProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick"> {
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  /** 기본 제공 쉐브론 아이콘 숨김. 사용자 children 만 렌더. */
+  plain?: boolean | undefined;
+}
+
+export interface ComboboxContentProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * 최대 높이. 넘치면 스크롤. 기본 "min(320px, 40vh)".
+   */
+  maxHeight?: number | string | undefined;
+  /** 드롭다운과 input 사이의 간격 (px). 기본 4. */
+  offset?: number | undefined;
+  /** 강제 placement. 기본 "bottom-start", 공간 부족하면 auto flip. */
+  placement?: "bottom-start" | "top-start" | "auto" | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  children?: ReactNode | undefined;
+}
+
+export interface ComboboxItemProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onSelect"> {
+  value: string;
+  /**
+   * 선택적. 명시되지 않으면 children(string 일 때) 또는 value 로 fallback.
+   * 하이라이트 매치는 label 기준.
+   */
+  label?: string | undefined;
+  /** 선택 차단. 기본 false. */
+  disabled?: boolean | undefined;
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface ComboboxGroupProps extends HTMLAttributes<HTMLDivElement> {
+  heading: string;
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface ComboboxEmptyProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface ComboboxLoadingProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+```
+
+### 2.2 배럴
+
+```ts
+// src/components/Combobox/index.ts
+export { Combobox } from "./Combobox";
+export type {
+  ComboboxRootProps,
+  ComboboxRootPropsSingle,
+  ComboboxRootPropsMultiple,
+  ComboboxInputProps,
+  ComboboxTriggerProps,
+  ComboboxContentProps,
+  ComboboxItemProps,
+  ComboboxGroupProps,
+  ComboboxEmptyProps,
+  ComboboxLoadingProps,
+  ComboboxOption,
+  ComboboxMatchResult,
+  ComboboxFilter,
+  ComboboxTheme,
+} from "./Combobox.types";
+```
+
+그리고 `src/components/index.ts` 에 `export * from "./Combobox";` 한 줄 추가.
+
+### 2.3 Compound namespace
+
+```ts
+// Combobox.tsx
+export const Combobox = {
+  Root: ComboboxRoot,
+  Input: ComboboxInput,
+  Trigger: ComboboxTrigger,
+  Content: ComboboxContent,
+  Item: ComboboxItem,
+  Group: ComboboxGroup,
+  Empty: ComboboxEmpty,
+  Loading: ComboboxLoading,
+};
+```
+
+displayName 은 각각 `"Combobox.Root"`, `"Combobox.Input"`, … 형태.
+
+---
+
+## 3. 도메인 모델
+
+### 3.1 `value` vs `label` 의 분리
+
+Combobox 는 본질적으로 **식별자 ↔ 표시 텍스트** 두 층이 분리된다.
+
+- `value: string` — 내부 식별자. 고유. 외부 상태(폼) 에 저장되는 것은 이 값.
+- `label: string` — 사람에게 보이는 텍스트. 필터·하이라이트 대상. 동일 value 라도 라벨은 다국어화될 수 있다 (사용자 책임).
+
+`inputValue` (사용자가 타이핑한 현재 텍스트) 는 `label` 과 같은 도메인에 있으며, "선택이 확정되면 inputValue ← 선택된 옵션.label" 의 동기화 규칙을 따른다 (§5.4).
+
+### 3.2 freeform vs strict
+
+- **strict (기본)**: 사용자가 확정한 값은 반드시 `options` 중 하나의 `value` 여야 한다. Enter/blur 시점에 현재 inputValue 가 어떤 옵션 label 과도 매칭되지 않으면 "선택되지 않은" 상태. blur 시 inputValue 는 마지막 유효 선택의 label 로 **되돌림** (revert).
+- **freeform**: Enter/blur 시점에 inputValue 자체가 값으로 확정된다. 즉 `onValueChange(inputValue)`. 이 경우 options 목록 밖 값도 허용.
+
+충돌 규칙: `freeform && strict` 동시 지정은 dev warn + freeform 우선. `freeform=false && strict=false` 조합은 dev warn + strict 로 해석.
+
+### 3.3 single vs multiple
+
+- **single** (`multiple=false`, 기본): value 는 `string | null`. 선택 즉시 드롭다운 닫고 inputValue 를 해당 옵션 label 로 동기화.
+- **multiple** (`multiple=true`): value 는 `string[]`. 선택 시 value 배열에 추가(중복은 무시), inputValue 는 **빈 문자열로 리셋**하고 드롭다운은 **열린 상태 유지** (연속 선택 UX).
+- chip 삭제: input 이 비었을 때 Backspace → 마지막 chip 삭제. 또는 chip 내부의 `✕` 클릭.
+
+### 3.4 filter contract
+
+기본 필터는 `CommandPalette/fuzzyMatch.ts` 의 `filterItems` 를 `ComboboxOption` 형으로 얇게 감싼 것. 사용자가 `filter` prop 을 지정하면 완전 대체.
+
+```ts
+filter: (query: string, options: ComboboxOption[]) => ComboboxOption[] | ComboboxMatchResult[]
+```
+
+반환 타입이 `ComboboxOption[]` 면 하이라이트 매치 인덱스를 잃는다 (단색 렌더). `ComboboxMatchResult[]` 를 돌려주면 Item 이 해당 index 로 `<mark>` 렌더. 이 이중 타입은 사용자 필터 구현 부담을 낮추기 위함 (가장 쉬운 구현 — String.includes 기반 — 은 `ComboboxOption[]` 만 돌려도 동작).
+
+### 3.5 Context 모양
+
+```ts
+interface ComboboxContextValue {
+  // ── 정체성
+  listId: string;
+  getItemId: (value: string) => string;
+  theme: ComboboxTheme;
+  disabled: boolean;
+  readOnly: boolean;
+
+  // ── 모드
+  multiple: boolean;
+  freeform: boolean;
+
+  // ── 상태 (3축)
+  value: string[] | string | null;   // multiple 여부에 따라
+  open: boolean;
+  setOpen: (next: boolean) => void;
+  inputValue: string;
+  setInputValue: (next: string) => void;
+
+  // ── 결과
+  results: ComboboxOption[];
+  matches: Map<string, ComboboxMatchResult>;
+  isLoading: boolean;
+  activeIndex: number;
+  setActiveIndex: (i: number) => void;
+
+  // ── 액션
+  selectOption: (opt: ComboboxOption) => void;
+  commitFreeform: (text: string) => void;
+  removeValue: (v: string) => void;            // multi 전용
+  clearAll: () => void;
+
+  // ── DOM refs
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  anchorRef: React.RefObject<HTMLDivElement | null>;
+  listRef: React.RefObject<HTMLDivElement | null>;
+  getOptionLabel: (value: string) => string;
+}
+```
+
+Context 는 null-able; `useComboboxContext()` 는 null 에서 throw.
+
+---
+
+## 4. 시각 / 구조 설계
+
+### 4.1 DOM 구조 (single 기준, 기본 스타일)
+
+```
+<div class="cb-root" data-theme="light" data-disabled="false">
+  <div class="cb-anchor" role="combobox"
+       aria-haspopup="listbox"
+       aria-expanded="{open}"
+       aria-controls="{listId}"
+       aria-owns="{listId}">
+    <input class="cb-input"
+           type="text"
+           role="combobox"            /* React 19 에선 나눠 씀. WAI 1.2 규격 */
+           aria-autocomplete="list"
+           aria-activedescendant="{getItemId(active)}"
+           aria-expanded="{open}"
+           aria-controls="{listId}"
+           placeholder="…" />
+    <button class="cb-trigger"
+            tabindex="-1"
+            aria-label="Toggle"
+            data-state="{open}">▾</button>
+  </div>
+  {open && (
+    <div class="cb-content"
+         id="{listId}"
+         role="listbox"
+         tabindex="-1"
+         style="position:absolute; top:…; left:…; width:…">
+      <div class="cb-group" role="group" aria-labelledby="{h1}">
+        <div id="{h1}" class="cb-group-heading">Fruits</div>
+        <div class="cb-item" role="option"
+             id="{getItemId('apple')}"
+             aria-selected="{activeIndex===i}"
+             data-disabled="false"
+             data-active="{activeIndex===i}">
+          <span class="cb-item-label">
+            Ap<mark>p</mark>le     /* label with highlight */
+          </span>
+        </div>
+      </div>
+      <div class="cb-empty" role="status">결과 없음</div>
+      <div class="cb-loading" role="status" aria-live="polite">…</div>
+    </div>
+  )}
+</div>
+```
+
+multi 인 경우 `cb-anchor` 내부에 input 앞쪽으로 `chip` 리스트가 추가된다:
+
+```
+<div class="cb-anchor …">
+  <div class="cb-chips">
+    <span class="cb-chip" data-disabled="false">
+      React<button class="cb-chip-remove" aria-label="Remove React">✕</button>
+    </span>
+    <span class="cb-chip">TS<button …>✕</button></span>
+  </div>
+  <input class="cb-input" … />
+  <button class="cb-trigger" …>▾</button>
+</div>
+```
+
+### 4.2 하이라이트 매치 렌더
+
+`ComboboxItem` 이 Context 의 `matches.get(option.value)` 로부터 `labelMatches: number[]` 를 꺼내 label 에 적용:
+
+```tsx
+function renderHighlighted(label: string, indices: number[]) {
+  if (indices.length === 0) return label;
+  const out: ReactNode[] = [];
+  let cursor = 0;
+  for (const idx of indices) {
+    if (idx > cursor) out.push(label.slice(cursor, idx));
+    out.push(<mark key={idx}>{label[idx]}</mark>);
+    cursor = idx + 1;
+  }
+  if (cursor < label.length) out.push(label.slice(cursor));
+  return out;
+}
+```
+
+`<mark>` 기본 스타일은 `background: transparent; color: inherit; font-weight: 600; text-decoration: underline; text-underline-offset: 2px;` — 즉 VSCode picker 의 언더라인 강조 스타일.
+
+### 4.3 floating dropdown 위치
+
+`Content` 는 Root 내부의 `position: absolute` 로 렌더되고, `useFloating` (기존 `_shared/useFloating`) 으로 anchor 하단 정렬. 뷰포트 하단 공간이 `min(maxHeight, 160px)` 보다 작으면 상단으로 flip (`placement="top-start"`). 너비는 anchor 와 동일(`width: anchorRect.width`). `offset` 기본 4 px.
+
+Popover 와 달리 포털을 쓰지 않는다 — 폼 필드 내부 DOM 경계 유지 + 포커스 그룹 기대. 단, anchor 의 조상 중 `overflow:hidden` 이 있으면 잘릴 수 있음 → v1 문서화, v1.1 에 portal 모드 추가 검토.
+
+### 4.4 palette 토큰
+
+```ts
+// Combobox/colors.ts
+export const comboboxPalette = {
+  light: {
+    anchorBg:          "#ffffff",
+    anchorBorder:      "rgba(0,0,0,0.12)",
+    anchorBorderHover: "rgba(0,0,0,0.24)",
+    anchorBorderFocus: "#2563eb",
+    anchorFg:          "#111827",
+    placeholderFg:     "#9ca3af",
+    triggerFg:         "#6b7280",
+
+    contentBg:         "#ffffff",
+    contentBorder:     "rgba(0,0,0,0.08)",
+    contentShadow:     "0 8px 24px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.06)",
+    itemBg:            "transparent",
+    itemBgActive:      "#eff6ff",
+    itemBgHover:       "#f3f4f6",
+    itemFg:            "#111827",
+    itemFgDisabled:    "#9ca3af",
+    itemMarkFg:        "#2563eb",
+
+    groupHeadingFg:    "#6b7280",
+
+    chipBg:            "#eff6ff",
+    chipBorder:        "#bfdbfe",
+    chipFg:            "#1e40af",
+    chipRemoveFg:      "#1e3a8a",
+
+    emptyFg:           "#6b7280",
+    loadingFg:         "#6b7280",
+    focusRing:         "#2563eb",
+  },
+  dark: {
+    anchorBg:          "#1f2937",
+    anchorBorder:      "rgba(255,255,255,0.10)",
+    anchorBorderHover: "rgba(255,255,255,0.20)",
+    anchorBorderFocus: "#60a5fa",
+    anchorFg:          "#e5e7eb",
+    placeholderFg:     "#6b7280",
+    triggerFg:         "#9ca3af",
+
+    contentBg:         "#1f2937",
+    contentBorder:     "rgba(255,255,255,0.08)",
+    contentShadow:     "0 8px 24px rgba(0,0,0,0.4), 0 2px 6px rgba(0,0,0,0.3)",
+    itemBg:            "transparent",
+    itemBgActive:      "rgba(59,130,246,0.18)",
+    itemBgHover:       "rgba(255,255,255,0.05)",
+    itemFg:            "#e5e7eb",
+    itemFgDisabled:    "#6b7280",
+    itemMarkFg:        "#93c5fd",
+
+    groupHeadingFg:    "#9ca3af",
+
+    chipBg:            "rgba(59,130,246,0.15)",
+    chipBorder:        "rgba(96,165,250,0.3)",
+    chipFg:            "#93c5fd",
+    chipRemoveFg:      "#60a5fa",
+
+    emptyFg:           "#9ca3af",
+    loadingFg:         "#9ca3af",
+    focusRing:         "#60a5fa",
+  },
+} as const;
+```
+
+### 4.5 크기·간격
+
+- anchor 높이: 36 px (default). `--cb-anchor-h` 로 override 가능 (CSS var).
+- anchor padding: 좌우 10 px. chip 이 들어가면 chip 간 gap 4 px.
+- content 최대 높이: `min(320px, 40vh)` 기본.
+- item 높이: 32 px. label font-size 14 px / line-height 20 px.
+- group heading: 11 px, uppercase, letter-spacing 0.04 em.
+
+---
+
+## 5. 핵심 동작
+
+### 5.1 open 트리거
+
+open 이 true 가 되는 상황:
+1. input 포커스 (open-on-focus, 기본 true). `openOnFocus={false}` 로 끌 수도 있지만 v1 엔 prop 미제공 — 기본만.
+2. input 타이핑 (change 이벤트).
+3. Trigger 버튼 클릭 (toggle).
+4. Down Arrow 키 (focus 상태에서).
+
+open 이 false 가 되는 상황:
+1. Escape (§7).
+2. outside click.
+3. single 모드에서 옵션 선택 성공.
+4. Tab 으로 blur.
+5. strict 모드에서 blur + 매치 실패 (revert 후 close).
+
+### 5.2 filter 실행 경로
+
+```
+inputValue 변경
+  │
+  ├── onSearch 지정됨?
+  │     ├── YES: debounce(searchDebounce ms) → onSearch(query)
+  │     │        → abort 이전 시퀀스 → setAsyncResults(res)
+  │     └── NO:  동기 경로 계속
+  │
+  ├── query.trim() === "" ?
+  │     ├── YES: results = options (no filtering, no highlight, maxResults cap)
+  │     └── NO : user filter 있으면 filter(query, options)
+  │              없으면 filterItems(query, options, maxResults) (fuzzyMatch 재사용)
+  │
+  └── matches Map 채움 → Context.results 로 전파
+```
+
+`filterItems` 는 CommandPalette 에서 이관 (§10). `ComboboxOption` 을 `CommandItem` 구조로 살짝 정규화해 호출 — 아니면 `fuzzyMatch.ts` 자체를 `_shared/` 로 승격하고 타입 파라미터화. §10 에서 후자를 택한다.
+
+### 5.3 async debounce + cancel
+
+`CommandPaletteRoot.tsx` 의 `searchSeqRef` 패턴 그대로 적용:
+
+```ts
+const searchSeqRef = useRef(0);
+
+useEffect(() => {
+  if (!onSearch) return;
+  const q = inputValue;
+  if (q.trim().length < minChars) {
+    setAsyncResults([]); setIsLoading(false);
+    searchSeqRef.current++;
+    return;
+  }
+  const seq = ++searchSeqRef.current;
+  setIsLoading(true);
+  const timer = setTimeout(() => {
+    void (async () => {
+      try {
+        const res = await onSearch(q);
+        if (seq !== searchSeqRef.current) return; // stale response
+        setAsyncResults(res);
+      } catch {
+        if (seq !== searchSeqRef.current) return;
+        setAsyncResults([]);
+      } finally {
+        if (seq === searchSeqRef.current) setIsLoading(false);
+      }
+    })();
+  }, searchDebounce);
+  return () => clearTimeout(timer);
+}, [inputValue, onSearch, searchDebounce, minChars]);
+```
+
+- `seq` 로 "이전 요청의 결과가 늦게 도착" 하는 race 를 차단.
+- `searchDebounce` 기본 200 ms.
+- `minChars` 미만이면 fetch 자체를 건너뛰고 빈 결과.
+- 외부 AbortController 연결은 v1.1 (사용자가 `onSearch` 내부에서 signal 을 구독하도록 하려면 prop 추가 필요).
+
+### 5.4 선택 확정 (selectOption)
+
+```ts
+function selectOption(opt: ComboboxOption) {
+  if (opt.disabled) return;
+  if (multiple) {
+    const cur = value as string[];
+    if (cur.includes(opt.value)) return;             // dedup
+    setValue([...cur, opt.value]);
+    setInputValue("");                                // clear input for next
+    setActiveIndex(0);
+    // open 유지
+    requestAnimationFrame(() => inputRef.current?.focus());
+  } else {
+    setValue(opt.value);
+    setInputValue(opt.label);
+    setOpen(false);
+  }
+}
+```
+
+### 5.5 freeform 확정 (commitFreeform)
+
+```ts
+function commitFreeform(text: string) {
+  const t = text.trim();
+  if (!t) return;
+  if (multiple) {
+    const cur = value as string[];
+    if (cur.includes(t)) return;
+    setValue([...cur, t]);
+    setInputValue("");
+  } else {
+    setValue(t);
+    setInputValue(t);
+    setOpen(false);
+  }
+}
+```
+
+freeform 이 false (=strict) 이면 이 경로는 호출되지 않고, 대신 blur 시점에 `setInputValue(labelOfCurrentValue ?? "")` 로 revert.
+
+### 5.6 하이라이트 업데이트 타이밍
+
+`results` 가 바뀔 때마다 `activeIndex` 는 0 으로 리셋. 사용자가 Arrow 로 이동한 index 가 다음 query 의 results 범위를 벗어나면 clamp.
+
+---
+
+## 6. 제약 (minChars / maxResults / searchDebounce)
+
+### 6.1 minChars
+
+- 기본 0. `onSearch` 사용 시 권장 1 이상.
+- query 의 trimmed length 가 minChars 미만이면:
+  - `onSearch` 모드: fetch 건너뛰고 results = [] + isLoading = false.
+  - 동기 모드: results = options (전체 표시). 사용자가 기대하는 "빈 입력 = 전체" UX.
+- minChars 미도달 상태에서 `Empty` 슬롯이 아니라 "검색어를 N자 이상" 힌트 등을 보여주고 싶다면, 사용자가 `Empty` children 내부에 조건부 렌더링 (Context 로 minChars 와 현재 길이 노출 필요 없음 — inputValue 는 이미 사용자 측 상태).
+
+### 6.2 maxResults
+
+- 기본 50.
+- 동기 필터의 결과 배열 길이 cap.
+- async 모드에서는 사용자가 돌려준 배열을 그대로 사용 (cap 미적용). 서버가 pagination 을 책임지는 것이 자연스러워서.
+- v1 엔 "더 보기" 링크는 없음. v1.1 에서.
+
+### 6.3 searchDebounce
+
+- 기본 200 ms (async), 0 ms (sync — 즉시 반영).
+- 동기 필터도 대량 옵션에서 debounce 가 도움될 수 있지만 v1 에는 async 모드에서만 적용.
+
+### 6.4 기타 제약
+- `disabled` — 전체 입력/트리거/선택 차단. `aria-disabled="true"`.
+- `readOnly` — 입력 readonly, 트리거는 클릭 가능하지만 드롭다운은 "선택만 가능, 타이핑 불가". 현재 value 의 label 만 표시. 실용적 시나리오: 사전에 선택된 값을 보여주되 편집 금지.
+
+---
+
+## 7. 키보드
+
+input 포커스 또는 content 포커스 기준. content 는 `tabindex=-1` (프로그래매틱 focus 용).
+
+| 키 | 조건 | 동작 |
+|---|---|---|
+| `ArrowDown` | input focused, open=false | open=true + activeIndex=0 |
+| `ArrowDown` | open=true | activeIndex = (activeIndex+1) mod results.length |
+| `ArrowUp` | open=false | (미작동) |
+| `ArrowUp` | open=true | activeIndex = (activeIndex-1+N) mod N |
+| `Home` | open=true | activeIndex = 0 |
+| `End` | open=true | activeIndex = N-1 |
+| `PageDown` | open=true | activeIndex += 10 (clamp) |
+| `PageUp` | open=true | activeIndex -= 10 (clamp) |
+| `Enter` | open=true, activeIndex 유효 | selectOption(results[activeIndex]) |
+| `Enter` | open=true, results 비었음, freeform | commitFreeform(inputValue) |
+| `Enter` | open=false, freeform | commitFreeform(inputValue) |
+| `Tab` | open=true, activeIndex 유효 | **autocomplete**: inputValue ← results[activeIndex].label. open 유지, selection 은 미확정. 다음 Tab 또는 Enter 에서 확정. |
+| `Escape` | open=true | open=false. inputValue 는 그대로 둠. |
+| `Escape` | open=false, multi, inputValue 있음 | inputValue="" |
+| `Escape` | open=false, single, strict | inputValue ← label of current value (revert) |
+| `Backspace` | input 이 빈 상태, multi | 마지막 chip 삭제 |
+| `Alt+ArrowDown` | any | open=true |
+| `Alt+ArrowUp` | open=true | open=false |
+
+### 7.1 Tab autocomplete 세부
+
+"Tab 으로 선택 확정" 과 "Tab 으로 블러" 를 분리한다:
+- results 중 activeIndex 가 유효 + prefix 매치 (`results[active].label.startsWith(inputValue)`) 인 경우: Tab 은 **inputValue 를 label 로 채움** 만. 포커스 유지. 다음 Tab 에 진짜 blur.
+- 그 외: Tab 은 기본 동작 (blur + 다음 focusable 로 이동). strict 모드면 revert 로직 트리거.
+
+### 7.2 RTL
+
+화살표 키는 orientation 상 의미가 바뀌지 않음 (vertical list). 단 Home/End 와 chip 삭제의 "마지막" 의미는 writing direction 과 무관하게 배열의 실제 끝을 가리킨다.
+
+### 7.3 IME 처리
+
+CJK IME 조합 중(`compositionstart` ~ `compositionend`) 에는 Enter 키를 **무시** (브라우저의 IME confirm 과 혼동 방지). `isComposingRef` 로 추적.
+
+```ts
+<input
+  onCompositionStart={() => (composingRef.current = true)}
+  onCompositionEnd={() => (composingRef.current = false)}
+  onKeyDown={(e) => {
+    if (composingRef.current) return;
+    ...
+  }}
+/>
+```
+
+---
+
+## 8. 상태 관리 (controlled / uncontrolled — 3 축)
+
+### 8.1 3 축 요약
+
+Combobox 는 **독립적으로 controlled 될 수 있는 세 상태**를 가진다:
+
+1. **value** — 선택된 값 (single: `string | null`, multi: `string[]`).
+2. **inputValue** — 현재 input 에 있는 텍스트.
+3. **open** — 드롭다운 열림 여부.
+
+각각 `useControllable` 로 이중 API. 사용자는 셋 중 일부만 controlled 해도 됨.
+
+```ts
+const [value, setValue] = useControllable(
+  props.value, props.defaultValue ?? (multiple ? [] : null), props.onValueChange,
+);
+const [inputValue, setInputValue] = useControllable(
+  props.inputValue, props.defaultInputValue ?? "", props.onInputValueChange,
+);
+const [open, setOpen] = useControllable(
+  props.open, props.defaultOpen ?? false, props.onOpenChange,
+);
+```
+
+### 8.2 inputValue ↔ value 동기화
+
+세 축이 독립이지만, "선택 확정 시 inputValue ← 해당 label" 규칙은 내부적으로 보장. controlled 와 충돌 가능성:
+
+- 사용자가 `inputValue` 를 controlled 로 주면서 `value` 도 controlled 로 주는 경우: 선택 후 `onInputValueChange("사과")` 콜백이 먼저, 그 다음 `onValueChange("apple")` 콜백이 호출된다. 사용자는 둘 다 반영해야 한다.
+- 사용자가 `inputValue` 는 controlled, `value` 는 uncontrolled: 내부 value 가 바뀌고 `onInputValueChange` 로 라벨 통지. 사용자가 이 라벨을 useState 에 저장하지 않으면 무시될 수 있음 — dev warn 대상은 아니지만 docs 에 명시.
+
+### 8.3 open ↔ 포커스 동기화
+
+- input focus → open=true (기본). 단 open 이 controlled 이면 사용자의 setter 호출만 하고 결과를 반영.
+- outside click → open=false.
+- Escape → open=false.
+
+controlled 인 경우 `onOpenChange` 가 호출되고 사용자가 state 를 업데이트해야 open 이 실제로 변한다. 이게 불편하면 uncontrolled 로 두면 됨.
+
+### 8.4 single vs multiple 전환
+
+`multiple` prop 을 런타임에 토글하지 말 것. value 형이 바뀌므로 TypeScript 레벨에선 에러이지만, 혹시 toggling 하면 dev warn + 내부 value 재초기화.
+
+### 8.5 Provider
+
+`ComboboxRoot` 에서 `ComboboxContext.Provider` 로 Context value 를 제공. Context 값은 `useMemo` 로 감싸 re-render 최소화.
+
+---
+
+## 9. Async & 필터
+
+### 9.1 fetch 인터페이스
+
+```ts
+onSearch?: (query: string) => Promise<ComboboxOption[]>;
+```
+
+- `query` 는 현재 inputValue (trim 전).
+- 반환은 `Promise<ComboboxOption[]>`. 예외 시 `[]` 로 처리(+ isLoading=false).
+- AbortSignal 은 v1 미지원 (§5.3).
+
+### 9.2 debounce + cancel — CommandPalette 패턴 재사용
+
+§5.3 참조. `searchSeqRef` 증가로 stale 응답 폐기.
+
+### 9.3 에러 처리
+
+v1 은 단순 폐기 (`catch { setAsyncResults([]); }`). 에러 UI 는 사용자가 `onSearch` 내부에서 `onError` 같은 외부 콜백을 호출하도록 유도. v1.1 에서 공식 `onSearchError` prop 추가 검토.
+
+### 9.4 초기 옵션 + async 혼합
+
+`options` 와 `onSearch` 를 동시에 주는 경우:
+- 빈 input: `options` 표시.
+- input 비어있지 않음: `onSearch` 결과만 표시 (debounce 중엔 이전 결과 유지).
+
+이 규칙은 "로컬 캐시 → 서버 검색" 패턴에 유용. dev warn 없음.
+
+### 9.5 filter prop 과의 공존
+
+- `filter` 가 있으면 동기 경로에서 기본 `filterItems` 대신 사용자 `filter(query, options)` 결과 사용.
+- `onSearch` 가 있으면 `filter` 는 **무시**되고 async 결과만 사용 (dev warn: "filter and onSearch both provided; onSearch wins").
+- `filter` 가 `ComboboxMatchResult[]` 를 반환하면 하이라이트가 살아남고, `ComboboxOption[]` 만 반환하면 하이라이트 없이 렌더.
+
+### 9.6 캐싱
+
+v1 은 내장 캐시 없음. 사용자가 필요시 `onSearch` 를 자체 memoize (예: `useMemo` + LRU). v1.2 에서 `cache?: "lru" | false` 검토.
+
+---
+
+## 10. 파일 구조
+
+```
+src/components/Combobox/
+├── Combobox.tsx                # namespace (Root/Input/Trigger/Content/Item/Group/Empty/Loading)
+├── ComboboxRoot.tsx            # Root + Context provider + 상태 오케스트레이션
+├── ComboboxInput.tsx           # text input + chips (multi) + trigger btn 컨테이너 조합
+├── ComboboxTrigger.tsx         # 쉐브론 버튼
+├── ComboboxContent.tsx         # floating listbox + scroll + empty/loading 슬롯 병합
+├── ComboboxItem.tsx            # option renderer (하이라이트 포함)
+├── ComboboxGroup.tsx           # group heading + children
+├── ComboboxEmpty.tsx           # 결과 없음 슬롯
+├── ComboboxLoading.tsx         # 로딩 슬롯
+├── ComboboxContext.ts          # Context 정의 + useComboboxContext 훅
+├── Combobox.types.ts           # 공개 타입
+├── colors.ts                   # comboboxPalette
+└── index.ts                    # 배럴
+```
+
+그리고 `src/components/_shared/` 에 fuzzy 매칭 로직을 **승격**:
+- `src/components/_shared/fuzzyMatch.ts` — 기존 `CommandPalette/fuzzyMatch.ts` 의 제네릭 버전.
+  - `fuzzyMatchOptimized(query, target): [score, number[]] | null` 는 target 이 string 인 순수 함수이므로 그대로 이동.
+  - `scoreItem`, `filterItems` 는 `CommandItem` 에 특화되어 있으므로 CommandPalette 내에 유지하고, Combobox 쪽은 `ComboboxOption` 전용 `scoreOption` / `filterOptions` 을 새로 작성 (fuzzyMatchOptimized 만 공유). 이 편이 변경 파급이 작고 리스크가 낮다.
+- 또는 대안: `CommandPalette/fuzzyMatch.ts` 를 그대로 두고 `Combobox/filter.ts` 에서 `fuzzyMatchOptimized` 를 relative import. Step 1 은 후자로 채택 (§11).
+
+각 파일 책임:
+
+- **ComboboxRoot.tsx**
+  - props 파싱 + 기본값 적용 (multiple, freeform, theme, debounce, maxResults, minChars).
+  - `useControllable` × 3 (value, inputValue, open).
+  - async debounce (searchSeqRef).
+  - 필터 실행 → results / matches / isLoading 상태.
+  - keyboard handler 설치 (input 이 아닌 Root 에 `onKeyDown`).
+  - outside click 감지 (document pointerdown + ref contains 체크).
+  - Context.Provider 로 children 감싸 렌더. 자체 wrapper `<div class="cb-root">` + `anchor`.
+
+- **ComboboxInput.tsx**
+  - `<input>` 렌더 + chip row (multi).
+  - Context 구독해 controlled 바인딩.
+  - IME compositionstart/end 추적.
+  - `aria-autocomplete`, `aria-activedescendant`, `role="combobox"`, `aria-expanded`, `aria-controls` 설정.
+
+- **ComboboxTrigger.tsx**
+  - `<button type="button" tabindex="-1">` + 기본 쉐브론 svg.
+  - 클릭 → Context.setOpen(!open) + input focus.
+  - `plain` 이면 기본 쉐브론 숨김, children 만 렌더.
+
+- **ComboboxContent.tsx**
+  - `<div role="listbox" id={listId}>` 렌더.
+  - `useFloating(anchorRef, { placement: "bottom-start", offset })` 로 좌표 계산.
+  - open 상태가 false 면 unmount (mount/unmount 이펙트는 v1 단순화).
+  - children 은 사용자 지정 (Item, Group, Empty, Loading 섞어 배치). children 이 비었으면 내부 default 렌더: results.map → Item.
+  - Empty / Loading 슬롯은 Context.results.length 와 isLoading 에 따라 조건부.
+
+- **ComboboxItem.tsx**
+  - Context 구독해 `matches.get(value)` 로부터 하이라이트 인덱스 받음.
+  - 렌더: `role="option"`, `aria-selected={activeIndex}`, `id={getItemId(value)}`.
+  - 클릭 → `selectOption`.
+  - mousemove 시 activeIndex 갱신 (키보드 탐색과 마우스가 섞일 때 "hover 가 active 를 빼앗는" UX).
+  - `scrollIntoView({ block: "nearest" })` 를 activeIndex 가 자신을 가리킬 때만 호출.
+
+- **ComboboxGroup.tsx**
+  - `role="group"` + `aria-labelledby` + `<div class="cb-group-heading">`.
+  - children 에 중첩된 Item 들을 그대로 렌더.
+
+- **ComboboxEmpty.tsx / ComboboxLoading.tsx**
+  - Context.isLoading / results.length 로 자동 가시성 판단.
+  - 명시적으로 Content children 에 배치하지 않으면 Content 기본 렌더에서 자동 삽입.
+
+- **ComboboxContext.ts**
+  - `createContext<ComboboxContextValue | null>(null)` + `useComboboxContext()` throw-on-null.
+
+- **colors.ts**
+  - `comboboxPalette` (§4.4).
+
+- **index.ts**
+  - 배럴.
+
+---
+
+## 11. 구현 단계 (후속 agent 가 순차 실행)
+
+각 단계는 독립 커밋 권장. 각 커밋이 `npm run typecheck` + `npx tsup` 통과 상태 유지.
+
+### Step 1 — 타입 + 배럴 + 팔레트 스켈레톤
+1. `Combobox.types.ts` 작성 (§2.1 전부).
+2. `colors.ts` 작성 (`comboboxPalette`).
+3. `ComboboxContext.ts` 작성 (Context 정의 + 훅).
+4. `Combobox.tsx` placeholder: `export const Combobox = { Root: () => null, Input: () => null, Trigger: () => null, Content: () => null, Item: () => null, Group: () => null, Empty: () => null, Loading: () => null };`.
+5. `index.ts` 배럴.
+6. `src/components/index.ts` 에 `export * from "./Combobox";`.
+7. `npm run typecheck` 통과 확인.
+8. 커밋: `feat(Combobox): 타입 + 배럴 + Context 스켈레톤`.
+
+### Step 2 — Root + controlled 3축 + 동기 필터
+1. `ComboboxRoot.tsx` 본체. useControllable × 3.
+2. 동기 경로 `filterOptions(query, options)`:
+   - `src/components/CommandPalette/fuzzyMatch.ts` 의 `fuzzyMatchOptimized` 를 `import` 해서 활용.
+   - Combobox 전용 `scoreOption` + `filterOptions` 를 `Combobox/filter.ts` 에 작성.
+3. results / matches Map 계산 (useMemo).
+4. activeIndex 관리 (results 변경 시 clamp; inputValue 변경 시 0 리셋).
+5. Context.Provider 에 value 주입.
+6. children 을 그대로 렌더 (아직 기본 UI 없음 — 사용자 compound 가정).
+7. 커밋: `feat(Combobox): Root 상태 오케스트레이션 + 동기 필터`.
+
+### Step 3 — Input + Trigger + 기본 anchor 스타일
+1. `ComboboxInput.tsx`. text input + chip row (multi). Context 바인딩.
+2. `ComboboxTrigger.tsx`. 쉐브론 토글 버튼.
+3. anchor wrapper 는 ComboboxInput 가 렌더 (`<div class="cb-anchor">` 내부).
+4. light 테마 스타일 적용 (colors.ts).
+5. Multi chip 렌더 + 제거 버튼.
+6. 커밋: `feat(Combobox): Input + Trigger + chip 렌더`.
+
+### Step 4 — Content + floating + Item + 하이라이트
+1. `ComboboxContent.tsx`. `useFloating` 으로 anchor 아래 위치.
+2. open 일 때만 렌더. 너비 = anchorRect.width.
+3. `ComboboxItem.tsx` — role="option", activeIndex 바인딩, 하이라이트 <mark>.
+4. `ComboboxGroup.tsx` — heading + children.
+5. Content 의 "children 비었으면 자동 렌더" 폴백: `results.map((o) => <Item value={o.value} label={o.label} />)`.
+6. 커밋: `feat(Combobox): Content + Item + 하이라이트`.
+
+### Step 5 — 키보드 + IME
+1. Root 수준 `onKeyDown`: ArrowUp/Down/Home/End/PageUp/PageDown/Enter/Escape/Tab(autocomplete)/Alt+Arrow/Backspace(multi chip 삭제).
+2. IME compositionstart/end 으로 Enter 무시.
+3. `scrollIntoView` 훅 (item 이 active 바뀔 때).
+4. 커밋: `feat(Combobox): 키보드 내비게이션 + IME`.
+
+### Step 6 — Empty + Loading 슬롯 + outside click
+1. `ComboboxEmpty.tsx` / `ComboboxLoading.tsx`.
+2. Content 기본 렌더 경로에서 `results.length === 0 && !isLoading` → Empty, `isLoading` → Loading.
+3. outside pointerdown → setOpen(false). input 또는 content 내부면 무시.
+4. 커밋: `feat(Combobox): Empty/Loading + outside click`.
+
+### Step 7 — Async (onSearch + debounce + cancel)
+1. `searchSeqRef` 패턴 (§5.3).
+2. `minChars`, `searchDebounce` 반영.
+3. `onSearch` 와 `options` 동시 지정 시 async 우선.
+4. `filter` 와 `onSearch` 동시 지정 시 dev warn.
+5. 커밋: `feat(Combobox): async onSearch + debounce`.
+
+### Step 8 — freeform / strict 확정 로직
+1. Enter / Tab / blur 시점의 확정 분기.
+2. strict + blur + 매치 실패 → revert.
+3. freeform + Enter/blur → commitFreeform.
+4. multi + Enter + 빈 results + freeform → 태그 추가.
+5. 커밋: `feat(Combobox): freeform / strict 확정`.
+
+### Step 9 — Dark 테마 + a11y 최종 점검
+1. `theme="dark"` palette 적용.
+2. aria-combobox / aria-expanded / aria-activedescendant / role=listbox / role=option 완전성 점검 (§15 체크리스트).
+3. 커밋: `feat(Combobox): dark 테마 + a11y`.
+
+### Step 10 — 데모 페이지
+1. `demo/src/pages/ComboboxPage.tsx` (§12).
+2. `demo/src/App.tsx` NAV / Page 타입 / 라우팅 추가.
+3. 커밋: `feat(Combobox): 데모 페이지`.
+
+### Step 11 — Props 표 + Usage
+1. Props 표 Root/Input/Trigger/Content/Item/Group/Empty/Loading 개별.
+2. Usage 섹션 4 개 (§12.3).
+3. 커밋: `feat(Combobox): 데모 props 표 + usage`.
+
+### Step 12 — 마감
+1. §20 Definition of Done 전부 체크.
+2. README/changelog (있다면) 한 줄 추가.
+3. 최종 커밋.
+
+---
+
+## 12. 데모 페이지
+
+`demo/src/pages/ComboboxPage.tsx`. 기존 CommandPalettePage 구조 복제. 섹션별 `<section id="...">` + 우측 사이드바 연동.
+
+### 12.1 NAV 추가 (App.tsx)
+
+```ts
+{ id: "combobox", label: "Combobox", description: "자동완성 입력", sections: [
+  { label: "Basic",                id: "basic" },
+  { label: "Async",                id: "async" },
+  { label: "Grouped",              id: "grouped" },
+  { label: "Multi-select",         id: "multi" },
+  { label: "Freeform",             id: "freeform" },
+  { label: "Controlled",           id: "controlled" },
+  { label: "Custom filter",        id: "custom-filter" },
+  { label: "Empty / Loading",      id: "empty-loading" },
+  { label: "Dark",                 id: "dark" },
+  { label: "Disabled / ReadOnly",  id: "disabled" },
+  { label: "Playground",           id: "playground" },
+  { label: "Props",                id: "props" },
+  { label: "Usage",                id: "usage" },
+]},
+```
+
+그리고 `Page` 타입에 `"combobox"` 추가 + 하단 `{current === "combobox" && <ComboboxPage />}`.
+
+### 12.2 섹션 구성
+
+**Basic (동기 옵션, 단일, strict)**
+```tsx
+const fruits: ComboboxOption[] = [
+  { value: "apple", label: "Apple" },
+  { value: "apricot", label: "Apricot" },
+  { value: "banana", label: "Banana" },
+  { value: "blackberry", label: "Blackberry" },
+  { value: "cherry", label: "Cherry" },
+];
+
+function BasicDemo() {
+  const [v, setV] = useState<string | null>(null);
+  return (
+    <div style={{ width: 320 }}>
+      <Combobox.Root options={fruits} value={v} onValueChange={setV} placeholder="과일…" />
+      <div className="mt-2 text-xs text-gray-500">value: {v ?? "(none)"}</div>
+    </div>
+  );
+}
+```
+
+**Async**
+```tsx
+async function fakeAPI(q: string): Promise<ComboboxOption[]> {
+  await new Promise((r) => setTimeout(r, 300));
+  return fruits.filter((f) => f.label.toLowerCase().includes(q.toLowerCase()));
+}
+<Combobox.Root
+  onSearch={fakeAPI}
+  searchDebounce={200}
+  minChars={1}
+  value={v}
+  onValueChange={setV}
+/>
+```
+
+**Grouped (Option.group 자동)**
+```tsx
+const bigList: ComboboxOption[] = [
+  { value: "apple", label: "Apple", group: "Fruits" },
+  { value: "banana", label: "Banana", group: "Fruits" },
+  { value: "carrot", label: "Carrot", group: "Vegetables" },
+  { value: "celery", label: "Celery", group: "Vegetables" },
+];
+<Combobox.Root options={bigList} /* 내부에서 group 별로 자동 묶음 */ />
+```
+
+**Multi-select (chip)**
+```tsx
+const [tags, setTags] = useState<string[]>([]);
+<Combobox.Root multiple options={fruits} value={tags} onValueChange={setTags} placeholder="과일들…" />
+```
+
+**Freeform (태그 입력 근사)**
+```tsx
+const [tags, setTags] = useState<string[]>([]);
+<Combobox.Root multiple freeform options={suggestedTags} value={tags} onValueChange={setTags} />
+```
+
+**Controlled (inputValue + value 같이)**
+```tsx
+const [v, setV] = useState<string | null>(null);
+const [q, setQ] = useState("");
+<Combobox.Root
+  options={fruits}
+  value={v}
+  onValueChange={setV}
+  inputValue={q}
+  onInputValueChange={setQ}
+  open={open}
+  onOpenChange={setOpen}
+/>
+```
+
+**Custom filter**
+```tsx
+<Combobox.Root
+  options={fruits}
+  filter={(q, opts) => opts.filter((o) => o.label.toLowerCase().startsWith(q.toLowerCase()))}
+/>
+```
+
+**Empty / Loading (사용자 슬롯)**
+```tsx
+<Combobox.Root onSearch={fakeAPI} value={v} onValueChange={setV}>
+  <Combobox.Input placeholder="검색…" />
+  <Combobox.Content>
+    <Combobox.Loading>⏳ 검색 중…</Combobox.Loading>
+    <Combobox.Empty>
+      <div style={{ padding: 12 }}>결과가 없습니다. 다른 키워드를 입력해 주세요.</div>
+    </Combobox.Empty>
+  </Combobox.Content>
+</Combobox.Root>
+```
+
+**Dark**
+`<Combobox.Root theme="dark" options={fruits} />` + 배경 `#0f172a` 래퍼.
+
+**Disabled / ReadOnly**
+```tsx
+<Combobox.Root options={fruits} value="apple" disabled />
+<Combobox.Root options={fruits} value="apple" readOnly />
+```
+
+**Playground**
+상단 컨트롤 바 (모든 prop 토글):
+- `multiple` 체크박스
+- `freeform` 체크박스
+- `theme` 라디오 (light/dark)
+- `placeholder` input
+- `searchDebounce` number
+- `minChars` number
+- `maxResults` number
+- `options 소스` 라디오 (동기 / async-slow / async-fail)
+- `filter` 라디오 (default / startsWith / includes)
+- `disabled` / `readOnly` 체크박스
+- `open` 토글 (null / true / false) — controlled open 테스트
+
+하단에 `<Combobox.Root {...args}>` + value / inputValue / open 실시간 표시 패널.
+
+### 12.3 Props 표
+
+기존 페이지 패턴 그대로. `Combobox.Root`, `.Input`, `.Trigger`, `.Content`, `.Item`, `.Group`, `.Empty`, `.Loading` 8 개 각각 prop × type × default × 설명.
+
+### 12.4 Usage (4개)
+
+1. **기본 단일 선택 (동기)** — country picker 처럼.
+2. **비동기 서버 검색** — GitHub repo / user 검색 모사.
+3. **multi + freeform 태그 입력** — tag cloud.
+4. **controlled 3축** — 외부 state 로 모든 축 제어 (폼 라이브러리 통합 샘플).
+
+**GitHub-like 샘플**:
+```tsx
+function RepoPicker() {
+  const [v, setV] = useState<string | null>(null);
+  return (
+    <Combobox.Root
+      value={v}
+      onValueChange={setV}
+      onSearch={async (q) => {
+        const r = await fetch(`https://api.github.com/search/repositories?q=${q}`);
+        const json = await r.json();
+        return json.items.slice(0, 10).map((it: any) => ({
+          value: it.full_name,
+          label: it.full_name,
+          keywords: [it.description ?? ""],
+        }));
+      }}
+      searchDebounce={250}
+      minChars={2}
+      placeholder="owner/repo…"
+    />
+  );
+}
+```
+
+---
+
+## 13. 검증 계획
+
+### 13.1 자동화
+```bash
+cd /Users/neo/workspace/plastic
+npm run typecheck
+npx tsup
+```
+
+주의 (§tsconfig):
+- `exactOptionalPropertyTypes: true` — optional prop 은 `?:` 로 받고 디폴트 머지에서 `undefined` 명시. ComboboxOption 의 optional 필드도 `| undefined` 유니온 필수.
+- `noUncheckedIndexedAccess: true` — `results[activeIndex]` 는 `ComboboxOption | undefined`. guard 필수.
+- `verbatimModuleSyntax: true` — 타입은 `import type`.
+
+### 13.2 수동 (demo dev server)
+```bash
+cd demo && npm run dev
+```
+
+체크리스트:
+- [ ] Basic: 타이핑 → 드롭다운 필터, 선택 → input 채워짐 + 드롭다운 닫힘.
+- [ ] 하이라이트: 매치된 글자에 underline/weight 표시.
+- [ ] ArrowDown/Up 으로 active 이동, 스크롤 따라옴.
+- [ ] Enter 로 선택 확정.
+- [ ] Escape 로 닫기 (값은 유지).
+- [ ] Tab: prefix 매치 → inputValue 자동완성, 다시 Tab → blur.
+- [ ] Async: 타이핑 → 200 ms 후 fetch → loading 표시 → 결과.
+- [ ] 빠른 연속 타이핑 시 stale 응답이 최종 입력을 덮지 않음.
+- [ ] minChars: 1 자 미만이면 fetch 안 함.
+- [ ] Grouped: heading 이 Fruits/Vegetables 로 묶여 렌더.
+- [ ] Multi: 선택 시 chip 추가, input 초기화, 드롭다운 유지.
+- [ ] Multi Backspace (빈 input): 마지막 chip 삭제.
+- [ ] Multi chip ✕ 클릭: 개별 삭제.
+- [ ] Freeform + Enter: inputValue 가 value 로 확정.
+- [ ] Strict + blur + 매치 실패: inputValue 가 이전 value 의 label 로 revert.
+- [ ] Custom filter: prefix 매치만 남음.
+- [ ] Empty: 결과 0 + !isLoading 에서 Empty 슬롯 렌더.
+- [ ] Loading: async 진행 중 Loading 슬롯.
+- [ ] Controlled 3축: 외부 setter 만으로 전체 동작.
+- [ ] Dark 테마: 모든 색 전환.
+- [ ] Disabled: input/trigger 클릭/타이핑 불가.
+- [ ] ReadOnly: 타이핑 불가, trigger 는 열 수 있음.
+- [ ] IME(한글): 조합 중 Enter 로 확정되지 않음 (조합 확정 후에만).
+- [ ] 다른 페이지 리그레션 없음 (CommandPalette 포함).
+
+### 13.3 엣지 케이스
+- [ ] `options` 중복 value: dev warn.
+- [ ] `multiple` 인데 `value` 가 string 인 경우: dev warn + 내부에서 `[]` 로 보정.
+- [ ] `filter` 가 ComboboxMatchResult[] 아니고 ComboboxOption[] 를 돌려준 경우: 하이라이트 없이 렌더 (정상).
+- [ ] `onSearch` 가 reject: 결과 [], isLoading=false.
+- [ ] Content 부모에 `overflow:hidden` → 드롭다운 잘림. 문서화 + v1.1 portal 옵션 후속.
+- [ ] 매우 긴 label: item 이 ellipsis 로 잘리고 title tooltip 으로 전체 표시.
+- [ ] `inputValue=""` 빈 상태 + open=true: results 에 전체 options (maxResults cap) 표시.
+- [ ] 선택된 value 가 options 에 없음 (예: async 로 받은 값인데 현재 options 로컬 캐시엔 없음): `getOptionLabel(value)` 로 라벨 확보. 미지정 시 fallback 으로 value 자체를 label 로 표시.
+- [ ] strict + value="apple" 설정 + apple 옵션이 disabled → 표시는 그대로 하되 "apple" 을 새로 선택 못 함.
+- [ ] multi + options 에 disabled 옵션 포함 → 클릭/Enter 로 추가 불가.
+- [ ] 키보드로 drop 열림 → 즉시 첫 옵션이 active (index=0).
+- [ ] 포커스 안 상태에서 Trigger 클릭만으로 open → input 에 자동 focus.
+- [ ] 매우 작은 viewport (모바일 가정): content 가 화면 바닥 초과 → 위쪽으로 flip.
+- [ ] width: anchor 가 `width: 100%` 인 경우 content 도 100% 따름.
+- [ ] form 내부에서 Enter 가 form submit 으로 bubble 되지 않도록 preventDefault.
+
+---
+
+## 14. 성능
+
+### 14.1 목표
+- 1,000 개 동기 options 에서 타이핑 응답 < 16 ms (60 fps).
+- async 첫 응답 도착 후 렌더링 < 16 ms.
+- re-render 횟수: 타이핑 1 회당 Root 1 회 + Content 1 회 + 변경된 Item 만.
+
+### 14.2 filter cost
+
+- `fuzzyMatchOptimized` 는 O(n·m) (target·query 길이). 대부분 label 은 짧아 무시 가능. options 배열 전체 스캔은 O(N) — N=1000 에서 1~3 ms 수준 (기존 CommandPalette 에서 측정된 수치).
+- `maxResults` cap 으로 정렬 후 slice. 정렬은 O(K log K), K=매치 개수.
+- 최적화 여지: `filterItems` 가 이미 CommandPalette 에서 쓰이며 충분히 빠르다. v1 추가 최적화 없음.
+
+### 14.3 re-render 최소화
+
+- Context value 를 `useMemo` 로 stable.
+- Item 은 `React.memo` (label / value / active / matches 변경 시에만). 단 `matches` Map 은 reference identity 가 바뀌므로 Item 내부에서 `matches.get(value)` 의 반환 참조를 memo 해야 효과가 있음 — v1 은 단순하게 Item memo 없이 구현하고, 1k option 에서 병목 없으면 그대로. 병목이 발견되면 Step 12 이후 추가 최적화.
+- Content 의 chip/Loading/Empty 조건부는 React 가 알아서 diff.
+
+### 14.4 virtualization — v1 제외
+
+- 3k+ options + dense scroll UI 는 virtualization 없이 frame drop. 대신 `maxResults=50` default 로 시각 표시를 제한 — 사용자는 먼저 타이핑해서 좁혀야 함. 이는 CommandPalette 와 동일 정책.
+- v1.1 에서 `virtualize: boolean | { itemSize: number }` prop 을 추가 예정 (§17).
+
+### 14.5 측정 방법
+- React DevTools Profiler 로 "타이핑 1 글자 → commit 시간" 측정.
+- 1k options 데이터 셋을 Playground 에서 전환할 수 있게 제공.
+
+---
+
+## 15. 접근성 (WAI-ARIA 1.2 Combobox pattern)
+
+### 15.1 ARIA 속성
+
+- 컨테이너(anchor 래퍼): `role="combobox"`. 단 WAI 1.2 에선 input 에 role 을 직접 부여하는 것도 허용됨 — v1 은 input 에 `role="combobox"` 를 부여 (HTML5 `<input>` 은 기본 role 이 없으므로 안전). anchor 자체는 role 없음.
+- input:
+  - `role="combobox"`
+  - `aria-autocomplete="list"` (inline autocomplete 보조 — Tab 자동완성 지원 측면에서 사실상 "both" 에 가깝지만, ARIA 1.2 권고대로 list 로).
+  - `aria-expanded="{open}"`
+  - `aria-controls="{listId}"`
+  - `aria-activedescendant="{getItemId(activeValue)}"` (open + activeIndex 유효 시에만).
+  - `aria-disabled="{disabled}"` / `aria-readonly="{readOnly}"`.
+- Trigger: `<button type="button" tabindex="-1" aria-label="Toggle options">`. tabindex=-1 로 Tab 순회에서 빠짐 (focus 는 input 에 집중).
+- Content (listbox):
+  - `role="listbox"`
+  - `id="{listId}"`
+  - `aria-label`/`aria-labelledby` — 외부 label 이 있으면 그것 사용, 없으면 placeholder 에서 유추.
+  - multi 이면 `aria-multiselectable="true"`.
+- Group: `role="group"` + `aria-labelledby` (heading id).
+- Item:
+  - `role="option"`
+  - `id="{getItemId(value)}"`
+  - `aria-selected="{isSelected}"` — single 은 value 와 일치할 때 true. multi 는 value 배열에 포함될 때 true. "active"(키보드 활성) 와 "selected" 는 다른 개념 — active 는 aria-activedescendant 로 표시, selected 는 aria-selected.
+  - `aria-disabled="{disabled}"`.
+- Empty: `role="status"`.
+- Loading: `role="status" aria-live="polite"`.
+- chip remove 버튼: `aria-label="Remove {label}"`.
+
+### 15.2 Focus 순서
+
+- Tab 이 들어오면 input 에 focus (Trigger 는 tabindex=-1).
+- Item 은 focus 받지 않음. active 는 DOM focus 가 아닌 aria-activedescendant 로 표현.
+- Escape 후에도 focus 는 input 에 유지.
+
+### 15.3 스크린리더 동작 기대
+
+- "Combobox, 과일을 검색하세요, expanded" (열린 상태).
+- 타이핑: aria-live 로 "3 options available" 같은 공지가 바람직하지만 v1 은 생략 (aria-live 과다 사용 시 피로). v1.1 후보.
+- Arrow 이동: "Apple, option, 1 of 5" 식으로 읽힘 (대부분 스크린리더는 aria-activedescendant 변경에 반응).
+
+### 15.4 고대비 / 축소 모션
+
+- `prefers-reduced-motion`: content open/close 에 작은 transition 을 쓰는 경우 (opacity 80 ms) 에는 reduce motion 시 transition 을 disable. v1 은 transition 자체가 거의 없어 크게 중요하지 않지만 코드에 media query 가드 포함.
+- focus ring: `outline: 2px solid focusRing; outline-offset: 2px;` — 고대비 모드에서도 보이도록 background color 와 대비.
+
+### 15.5 a11y 체크리스트
+
+- [ ] axe devtools 에서 violation 0.
+- [ ] VoiceOver (mac) Safari: 열림 상태 인식, 옵션 선택 announce.
+- [ ] NVDA (Windows) + Firefox: 동일.
+- [ ] 키보드 단독으로 모든 기능 사용 가능.
+
+---
+
+## 16. 알려진 트레이드오프 · 결정
+
+1. **Select (013) vs Combobox**: plastic 의 별도 plan `013-select-component.md` 에서 `Select` 는 "타이핑 없음, 드롭다운 선택만" 을 맡는다. Combobox 는 "타이핑으로 필터링" 이 핵심. UX 결정 기준:
+   - 옵션이 20 개 미만 + 고정 → Select.
+   - 20+ 또는 가변/async → Combobox.
+   - Combobox 는 Select 의 상위 호환이 **아님**. 예) form 필드로 "성별" 을 Combobox 로 만드는 것은 과함.
+2. **freeform 정책**: 기본 strict. 이유: "form 필드로 쓸 때" 가 주 사용처. 임의 문자열 허용은 옵트인.
+3. **multi UX — 칩 vs 체크박스**: v1 은 칩(chip) 전용. 이유: 사용자가 "지금 선택된 것" 을 한눈에 보고 삭제할 수 있음. 드롭다운 내부에 체크박스 UI 를 넣는 변형은 v1.1 (`multipleStyle: "chip" | "checkbox"`).
+4. **inline floating vs portal**: v1 은 inline. 이유: 폼 필드 경계 유지, SSR 단순, 일반 사용처에서 overflow 문제 없음. portal 모드는 overflow 컨테이너에 박혀 잘리는 경우를 위해 v1.1 에서 추가.
+5. **CommandPalette fuzzy 와 공유**: `fuzzyMatchOptimized` 순수 함수 하나만 재사용. `filterItems` 전체 이관은 overhead — Combobox 의 option 에는 `description` 이 없고 `keywords` 와 `group` 만 있어 스코어링 규칙이 살짝 다르다. 따라서 Combobox 용 `filterOptions` 를 별도 작성.
+6. **3 축 controlled**: Headless UI 는 value / query(inputValue) 2 축, Radix 는 3 축. Radix 방식 채택. 더 명시적이고 form 통합 시 유리 (예: 검색어 유지하면서 value 는 초기화).
+7. **Enter 가 form submit 을 막는 정책**: 드롭다운 open 시에는 Enter → 선택. open=false + freeform → commitFreeform. open=false + strict + 빈 input + 활성 요소가 form 안: form 기본 submit 허용 (preventDefault 안 함). 이는 사용자가 combobox 에서 선택 후 Enter 로 제출하는 UX 를 보장.
+8. **results 가 비었고 isLoading=false 인 경우 Content 가 열려있어야 하는가?**: open 유지하고 Empty 슬롯 표시. 일부 라이브러리는 자동 close 를 선택하지만 UX 혼란(왜 닫혔지?) 때문에 open 유지가 낫다.
+9. **maxResults cap 을 async 에 미적용**: 서버가 페이지네이션을 책임지기 때문. 사용자가 1000 개를 넘기면 비난하는 것은 라이브러리의 월권.
+10. **keyboard 경로를 Root 에 걸기**: input 에만 걸면 content 포커스 시(e.g., scroll/drag) 키가 안 먹음. Root `onKeyDown` + capture 로 통합. 단, IME 처리 주의.
+11. **`mark` 요소 선택**: 하이라이트는 `<mark>` 가 의미론적으로 적합 (HTML spec: "highlighted text"). `<b>` 나 `<span>` 대비 스크린리더의 인식이 낫고 user stylesheet 호환.
+12. **chip 스타일을 외부 Button 과 무관하게 내장**: plastic 의 `Button` 컴포넌트에 의존시키면 순환/버전 관리 문제. chip 전용 경량 스타일을 Combobox 내부에 둔다.
+13. **React 19 aria-owns vs aria-controls**: 스펙 혼선이 있으나 ARIA 1.2 권고에 따라 `aria-controls` 를 사용. Safari VO 호환성 중요.
+14. **option.value 의 string 제약**: number/symbol 을 받으려면 ts 가 복잡해진다 — v1 은 string 고정. 사용자는 number 를 String() 으로 감싸 넘기면 됨.
+15. **onValueChange 가 label 을 같이 넘기지 않음**: value 만 넘긴다. 사용자가 label 이 필요하면 options 에서 lookup. 이유: CommandPalette 과의 API 일관성, 그리고 async 에서 local options 에 없는 값(historical) 도 처리 가능하도록 함.
+
+---
+
+## 17. 후속 작업 (v1.1+)
+
+- **Virtualization**: `virtualize: boolean | { itemSize: number }` 로 `@tanstack/react-virtual` 통합. 1k+ options 시 자동 활성 옵션.
+- **Portal 모드**: `portal?: boolean | HTMLElement` — Content 를 `document.body` 로 렌더 (overflow 컨테이너 회피).
+- **Async pagination**: `onSearch(query, { cursor })` + `hasMore` 반환 + "Load more" 아이템 + infinite scroll 옵션.
+- **Creatable**: `creatable: boolean | { format?: (q: string) => string }` — 매치 0 일 때 "Create '{q}'" 아이템 + `onCreate(label) => Option` 콜백.
+- **Tag mode**: `TagInput` 분리 컴포넌트 — Combobox 위에 얇은 래퍼, enter=add, paste-split(comma/tab/newline), pattern validation.
+- **Group heading 커스터마이징 slot**: `Combobox.Group` 에 render prop 으로 custom heading.
+- **옵션 아이콘**: `Option.icon` 필드 + Item 기본 렌더가 앞쪽에 표시.
+- **최근 사용(recent) / 핀(pinned)**: CommandPalette 와 동일 개념 — query=="" 일 때 recent/pinned 섹션 자동 삽입.
+- **AbortController**: `onSearch(query, { signal })` 로 공식 cancel.
+- **onCreateError / onSearchError**: 비동기 에러 피드백 hook.
+- **form integration helpers**: `react-hook-form` adapter 예제 + `@hookform/resolvers` style 문서.
+- **CommandPalette 와 fuzzy 로직 공유 일원화**: `src/components/_shared/fuzzyMatch.ts` 로 최종 승격 후 CommandPalette 도 거기서 import. v1 엔 호환성 이유로 CommandPalette 는 기존 경로 유지.
+
+---
+
+## 18. 관련 파일 인벤토리 (구현 시 참조)
+
+| 용도 | 경로 |
+|---|---|
+| useControllable (dual API) | `/Users/neo/workspace/plastic/src/components/_shared/useControllable.ts` |
+| fuzzy 매치 알고리즘 (재사용 대상) | `/Users/neo/workspace/plastic/src/components/CommandPalette/fuzzyMatch.ts` |
+| async debounce + cancel 패턴 (참고) | `/Users/neo/workspace/plastic/src/components/CommandPalette/CommandPaletteRoot.tsx` (line 191~223) |
+| activeIndex / scrollIntoView 패턴 | `/Users/neo/workspace/plastic/src/components/CommandPalette/CommandPaletteList.tsx` |
+| 하이라이트 매치 렌더 패턴 | `/Users/neo/workspace/plastic/src/components/CommandPalette/CommandPaletteItem.tsx` |
+| floating 위치 계산 (Content 재사용) | `/Users/neo/workspace/plastic/src/components/Popover/` + `src/components/_shared/useFloating.ts` |
+| compound + input-중심 UX 참고 | `/Users/neo/workspace/plastic/src/components/PathInput/` |
+| 데모 페이지 레이아웃 패턴 (가장 유사) | `/Users/neo/workspace/plastic/demo/src/pages/CommandPalettePage.tsx` |
+| 데모 App 라우팅 / NAV | `/Users/neo/workspace/plastic/demo/src/App.tsx` |
+| 배럴 등록 | `/Users/neo/workspace/plastic/src/components/index.ts` |
+| tsconfig 제약 | `/Users/neo/workspace/plastic/tsconfig.json` |
+| 이전 plan 포맷 참고 (템플릿) | `/Users/neo/workspace/plastic/docs/plans/017-splitpane-component.md` |
+
+---
+
+## 19. 의존성 영향
+
+신규 런타임 의존 없음. React 18.3 (기존) + DOM API (`IntersectionObserver` 불필요, `scrollIntoView`, `getBoundingClientRect`, `addEventListener`) 만 사용.
+
+번들 영향:
+- Combobox 자체 예상 크기: ~5.5 KB (min), ~2.2 KB (min+gzip).
+  - fuzzyMatchOptimized 를 CommandPalette 와 공유하므로 중복 없음.
+  - useFloating 도 공유.
+- plastic 전체 dist 증가는 주로 Combobox 본체 + types 선언.
+
+Browser 지원:
+- `PointerEvent`, `requestAnimationFrame`, `scrollIntoView({ block: "nearest" })`: 모던 브라우저 전체.
+- `ResizeObserver` (Content width 동기화): Chrome 64+, Firefox 69+, Safari 13.1+.
+- `Element.isConnected` / `contains` (outside click): 모든 브라우저.
+
+SSR:
+- `typeof document` 가드로 outside click effect 건너뜀.
+- `useFloating` 은 CSR 가정 — SSR 초기 렌더에서 Content 는 hidden (open=false) 상태라 무관.
+
+---
+
+## 20. 구현 완료 정의 (Definition of Done)
+
+- [ ] `npm run typecheck` 통과 (`exactOptionalPropertyTypes` 포함).
+- [ ] `npx tsup` 통과 (타입 선언 포함).
+- [ ] demo 에 `/#/combobox` 라우트 동작.
+- [ ] §13.2 수동 체크리스트 항목 전부 눈으로 확인.
+- [ ] §13.3 엣지 케이스 항목 전부 눈으로 확인 또는 "v1 범위 밖" 이유 기재.
+- [ ] CommandPalette / PathInput / Popover / 기타 페이지 리그레션 없음.
+- [ ] `src/components/index.ts` 배럴에 `export * from "./Combobox";` 추가됨.
+- [ ] `package.json` dependencies 변경 없음 (신규 런타임 의존 없음).
+- [ ] Props 문서 섹션이 Props 표로 채워져 있음 (Root/Input/Trigger/Content/Item/Group/Empty/Loading 8 개).
+- [ ] Usage 섹션에 최소 4 개 스니펫 (기본 / async / multi+freeform / controlled 3축).
+- [ ] 데모 Playground 에서 모든 prop 토글 가능.
+- [ ] Light / Dark 테마 전환 시 시각 이상 없음.
+- [ ] 키보드 단독으로 (마우스 없이) 선택 · 자동완성 · 칩 삭제 · 닫기 가능.
+- [ ] 스크린리더 (VoiceOver) 에서 열림/옵션/선택 announce 가 정상.
+- [ ] IME (한글) 조합 중 Enter 가 선택을 트리거하지 않음.
+- [ ] 1k option 데이터셋에서 타이핑 랙 체감 없음.
+- [ ] strict 모드 blur revert / freeform 모드 commit 동작 검증.
+- [ ] multi 모드 chip 추가 · Backspace 삭제 · ✕ 클릭 삭제 동작 검증.
+- [ ] async 모드에서 빠른 연속 타이핑 시 stale 응답 폐기 동작 검증.
+
+---
+
+**끝.**

--- a/docs/plans/015-datepicker-component.md
+++ b/docs/plans/015-datepicker-component.md
@@ -1,0 +1,1541 @@
+# DatePicker 컴포넌트 설계문서
+
+## Context
+
+plastic 라이브러리에 "날짜 입력 + 팝업 캘린더" 프리미티브 `DatePicker` 를 추가한다. 역할 비유: macOS 시스템 환경설정의 date selector, VSCode 의 확장 설정에서 쓰이는 inline calendar, Linear 이슈의 due-date picker. 본 컴포넌트는 "텍스트 인풋 + 클릭 시 월 그리드 팝업 + 키보드로 셀 탐색 + 선택/범위/제약"의 조합이며, plastic 이 지향하는 IDE-급 경험과 "zero runtime dependency" 원칙을 동시에 증명하는 대표 사례다.
+
+참고 (prior art — UX / API 근거):
+- **Radix `DatePicker` / `Calendar`** (`@radix-ui/react-date-picker`, react-aria-date-picker) — compound API, unstyled, aria-selected/activedescendant 표준.
+- **Ant Design `DatePicker`** — input + dropdown 캘린더, `picker="date" | "week" | "month" | "year"`, 범위(`RangePicker`), locale/presets.
+- **MUI `DatePicker` / `DateRangePicker`** — input parsing + mask, `shouldDisableDate`, 2 달 뷰.
+- **react-day-picker** (헤드리스) — 순수 JS 달력 계산(외부 라이브러리 없음). 본 컴포넌트가 가장 근접하게 참고하는 구현 레퍼런스.
+- **cally** (web component) / **Pikaday** (구세대) — UX 근거.
+- **shadcn/ui `<Calendar>` + `<Popover>` 조합** — plastic 이 이미 가진 `Popover` 와 `PathInput` 을 조합한다는 점에서 구조적 유사.
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/_shared/useControllable.ts` — controlled/uncontrolled 이중 API 표준 훅. `value`, `open`, `currentMonth` 세 축 모두 동일 패턴으로 이중화.
+- `src/components/Popover/` — floating 위치/외부 클릭 닫힘/Escape 처리의 기성 구현. DatePicker 팝업은 Popover 위에 얹는다.
+- `src/components/PathInput/` — 텍스트 입력 + 제안 팝업 + 키보드 탐색 + light/dark 패턴. input 부분의 스타일·동작 근거.
+- `src/components/index.ts` — 배럴 등록 위치.
+- `demo/src/App.tsx` — NAV/라우팅/사이드바 섹션 패턴.
+- `demo/src/pages/CommandPalettePage.tsx` — 데모 페이지 구조(Props/Usage/Playground 섹션 포함)의 가장 최신 레퍼런스.
+- `tsconfig.json` — `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax` 제약 하에 타입 설계.
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+// 단일 날짜
+<DatePicker.Root
+  value={date}
+  onValueChange={setDate}
+  minDate={new Date(2024, 0, 1)}
+  maxDate={new Date(2026, 11, 31)}
+  locale="ko-KR"
+  weekStartsOn={0}       // 0=일, 1=월
+  theme="light"
+  format="yyyy-MM-dd"    // Intl 기반 포매터 + 파서
+>
+  <DatePicker.Input placeholder="YYYY-MM-DD" />
+  <DatePicker.Trigger aria-label="Open calendar" />
+  <DatePicker.Calendar>
+    <DatePicker.Header>
+      <DatePicker.Nav direction="prev-year" />
+      <DatePicker.Nav direction="prev-month" />
+      <DatePicker.MonthLabel />
+      <DatePicker.Nav direction="next-month" />
+      <DatePicker.Nav direction="next-year" />
+    </DatePicker.Header>
+    <DatePicker.Grid>
+      {(day) => <DatePicker.Day day={day} />}
+    </DatePicker.Grid>
+  </DatePicker.Calendar>
+</DatePicker.Root>
+
+// 범위
+<DatePicker.Root
+  mode="range"
+  value={{ start, end }}
+  onValueChange={(r) => setRange(r)}
+>
+  <DatePicker.Input />
+  <DatePicker.Trigger />
+  <DatePicker.Calendar />   {/* 내부 기본 조립 사용 */}
+</DatePicker.Root>
+```
+
+렌더 결과 (개념):
+```
+┌──────────────────────────┐  ┌──────────────────────────────┐
+│ 2026-04-23           ⌄  │  │ «  ‹    2026년 4월    ›  »  │
+└──────────────────────────┘  │ 일 월 화 수 목 금 토         │
+  ↑ Input (parse)             │ 29 30 31  1  2  3  4        │
+  ↑ Trigger  →  Popover       │  5  6  7  8  9 10 11        │
+                              │ 12 13 14 15 16 17 18        │
+                              │ 19 20 21 22 [23] 24 25      │  ← selected
+                              │ 26 27 28 29 30  1  2        │
+                              │  Today   Clear              │
+                              └──────────────────────────────┘
+                                Popover anchored to Input
+```
+
+핵심 설계 원칙:
+- **compound 컴포넌트**. `Root` / `Input` / `Trigger` / `Calendar` / `Header` / `Nav` / `MonthLabel` / `Grid` / `Day` 의 소계로 Context 를 통해 상태 공유. 사용자는 최소 `Root + Input + Trigger + Calendar` 만 두고 내부 기본 조립에 맡기거나, 원자 단위로 재조립 가능.
+- **mode="single" | "range"**. 동일 Root 에서 두 가지 의미의 `value` 를 지원. 타입은 discriminated union 으로 안전화.
+- **런타임 의존 zero**. `date-fns` / `dayjs` / `luxon` 같은 라이브러리 일체 사용하지 않는다. 포매팅은 `Intl.DateTimeFormat` (내장), 파싱은 `Intl.DateTimeFormat.prototype.formatToParts` 기반 가벼운 tokenizer 로 직접 구현, 날짜 산술(월 ±1, 주 시작 weekday 등)은 `new Date(year, month, day)` 생성자와 Date 메서드로 충분. 이 원칙은 라이브러리 슬로건(“zero runtime dependency”)의 근간이므로 협상 불가.
+- **controlled / uncontrolled 이중 API**. `value`/`defaultValue`, `open`/`defaultOpen`, `month`/`defaultMonth`. `useControllable` 기존 훅 활용.
+- **접근성 우선**. `role="grid"`, 각 주는 `role="row"`, 각 날은 `role="gridcell"` + `aria-selected`. 월/년 헤더 변경은 `aria-live="polite"` 로 알림.
+- **Local time zone 기준**. 내부 도메인 모델은 **브라우저 로컬 타임존**. UTC/ISO 변환은 boundary(포맷 input/output)에서만. `value` 는 `Date` 또는 `{ year, month, day }` 두 형태를 동시에 허용 (후자가 권장).
+- **키보드**. Arrow=±1 일, Home/End=주 시작/끝, PageUp/Down=월 이동, Shift+PageUp/Down=년 이동, Enter=선택, Escape=팝업 닫기.
+- **Locale**. 기본 `en-US`(sun-start). `ko-KR` 을 일급 케이스로 테스트. `weekStartsOn` 수동 지정 가능.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. **single / range 두 모드** (`mode: "single" | "range"`). 두 모드는 같은 Root 가 제어, value 타입만 달라진다.
+2. **Input + Popup 캘린더 조합**. Input 에 직접 타이핑(파싱) + Trigger/Input 포커스로 팝업 open + 팝업에서 클릭/키보드 선택.
+3. **제약**: `minDate`, `maxDate`, `isDisabled(day) => boolean` (사용자 정의 비활성화, 예: 주말 비활성화).
+4. **Locale & formatting**: `Intl.DateTimeFormat` 기반. `locale` prop 기본 `"en-US"`, 한국어(`"ko-KR"`) 를 공식 지원하여 검증. `format` prop 으로 input 표시 포맷을 제어(기본 "yyyy-MM-dd").
+5. **weekStartsOn**: `0` (Sun) ~ `6` (Sat). 기본값은 locale 에서 유추(`Intl.Locale.prototype.getWeekInfo` 지원 브라우저) → 폴백 `0`.
+6. **Today highlight / Selected highlight / 오늘 버튼**.
+7. **키보드 탐색**: Arrow(일) / Home-End(주 시작·끝) / PageUp-Down(월) / Shift+PageUp-Down(년) / Enter / Escape / Tab.
+8. **Input parsing**: 관대(lenient) 파싱(숫자 구분자 자동 해석) + strict 모드 옵션. 실패 시 `onParseError` + 자체 red border.
+9. **controlled / uncontrolled 이중 API** — `value/defaultValue`, `open/defaultOpen`, `month/defaultMonth`.
+10. **Light / Dark** 두 테마.
+11. **범위 모드 hover preview**: start 선택 후 마우스 hover 시 "임시 end" 를 하이라이트하여 범위 예측.
+12. **접근성**: `role="grid"` + aria-label + live region + focus ring.
+
+### Non-goals (v1 제외)
+- **Time-of-day (시/분/초 선택)**: `<DatePicker>` 은 "day precision" 까지만. time 은 v1.1 `<DateTimePicker>` 로 분리.
+- **2 개월 동시 뷰** (MUI DateRangePicker 스타일): range 모드에서도 v1 은 1 개월만. v1.1 에서 `numberOfMonths={2}` prop 추가.
+- **Quick preset 목록** ("Last 7 days", "This month" 등 버튼 리스트): v1.1.
+- **Week picker / Month picker / Year picker**: v1.1 이후(`picker="week" | "month" | "year"`).
+- **회계연도(fiscal year)** / 일본식 원호(Reiwa) / 음력(lunar) / 이슬람력: v1 은 그레고리력만. `Intl.DateTimeFormat` 의 `calendar` 옵션 확장은 v2 범위.
+- **Cross-timezone 지정**: `<DatePicker tz="America/Los_Angeles">` 같은 명시 TZ 지정 불가. v1 은 "브라우저 로컬 TZ" 로 고정. TZ 를 다루는 앱은 값 boundary 에서 자체 변환.
+- **Masked input**: input 에 `01/__/____` 같은 마스크 적용은 v1.1.
+- **Footer presets 슬롯**: v1 은 `Today` / `Clear` 버튼만 내장. 임의 presets 는 children 으로 `<DatePicker.Footer>` 에 꽂을 수 있게 API 만 열어두고, built-in preset 집합은 v1.1.
+- **Animation**: open/close fade 는 기존 `Popover` 기본 transition 재사용. 달력 좌/우 슬라이드(월 이동) 애니메이션은 v1.1.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/DatePicker/DatePicker.types.ts`
+
+```ts
+export type DatePickerTheme = "light" | "dark";
+export type DatePickerMode = "single" | "range";
+
+/** 사용자에게 노출되는 "달력 좌표". 타임존·시·분 등 파생값을 숨긴다. */
+export interface CalendarDate {
+  /** 4자리 서기 연도 (예: 2026). */
+  year: number;
+  /** 1~12 (사람 기준). 내부 Date.month 은 0~11 이므로 변환 주의. */
+  month: number;
+  /** 1~31. */
+  day: number;
+}
+
+/** single 모드 value. */
+export type SingleValue = CalendarDate | null;
+
+/** range 모드 value. start <= end 보장. 한쪽만 선택된 중간 상태 허용. */
+export interface RangeValue {
+  start: CalendarDate | null;
+  end: CalendarDate | null;
+}
+
+/** 공용 base. */
+interface DatePickerRootBaseProps {
+  /** 라이트/다크. 기본 "light". */
+  theme?: DatePickerTheme;
+
+  /** Intl locale. 기본 "en-US". 한국어는 "ko-KR". */
+  locale?: string;
+  /** 주 시작. 0=일 ~ 6=토. 미지정 시 locale 유추. */
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+  /** input 표시 포맷. 기본 "yyyy-MM-dd". */
+  format?: string;
+  /** 파싱 모드. "lenient" 기본, "strict" 는 format 과 1:1 일치만 허용. */
+  parseMode?: "lenient" | "strict";
+
+  /** minDate / maxDate (inclusive). */
+  minDate?: CalendarDate | Date;
+  maxDate?: CalendarDate | Date;
+  /** 추가 비활성화 판정. min/max 외에 사용자 정의. */
+  isDisabled?: (day: CalendarDate) => boolean;
+
+  /** 팝업 open 상태. */
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+
+  /** 현재 보이는 월. */
+  month?: CalendarDate;          // day 는 의미 없음(1로 정규화).
+  defaultMonth?: CalendarDate;
+  onMonthChange?: (month: CalendarDate) => void;
+
+  /** 비활성화 (전체 DatePicker). */
+  disabled?: boolean;
+
+  /** input 파싱 실패 시 호출. */
+  onParseError?: (rawInput: string) => void;
+
+  /** 포커스/blur 으로부터의 자동 open 정책. 기본 true. */
+  openOnFocus?: boolean;
+  /** 선택 직후 팝업 닫기. single 기본 true, range 기본 end 선택 시 true. */
+  closeOnSelect?: boolean;
+
+  /** root className/style. */
+  className?: string;
+  style?: React.CSSProperties;
+
+  /** children: 미지정 시 기본 조립(§2.4)을 사용. */
+  children?: React.ReactNode;
+}
+
+export interface DatePickerRootSingleProps extends DatePickerRootBaseProps {
+  mode?: "single";
+  value?: SingleValue;
+  defaultValue?: SingleValue;
+  onValueChange?: (value: SingleValue) => void;
+}
+
+export interface DatePickerRootRangeProps extends DatePickerRootBaseProps {
+  mode: "range";
+  value?: RangeValue;
+  defaultValue?: RangeValue;
+  onValueChange?: (value: RangeValue) => void;
+}
+
+export type DatePickerRootProps =
+  | DatePickerRootSingleProps
+  | DatePickerRootRangeProps;
+
+/** Input */
+export interface DatePickerInputProps {
+  placeholder?: string;
+  className?: string;
+  style?: React.CSSProperties;
+  /** range 모드에서 어느 필드인지. "start" | "end". 단일 input 이면 미지정. */
+  part?: "start" | "end";
+  /** aria-label override. */
+  "aria-label"?: string;
+}
+
+/** Trigger (달력 아이콘 버튼) */
+export interface DatePickerTriggerProps {
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+  "aria-label"?: string;
+}
+
+/** Calendar (popover body) */
+export interface DatePickerCalendarProps {
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}
+
+/** Header */
+export interface DatePickerHeaderProps {
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}
+
+/** MonthLabel */
+export interface DatePickerMonthLabelProps {
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/** Nav (prev/next month/year) */
+export interface DatePickerNavProps {
+  direction: "prev-year" | "prev-month" | "next-month" | "next-year";
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+  "aria-label"?: string;
+}
+
+/** Grid */
+export interface DatePickerGridProps {
+  /** custom day renderer. 기본은 내부 Day 를 사용. */
+  children?: (day: DatePickerDayInfo) => React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/** Day */
+export interface DatePickerDayProps {
+  day: DatePickerDayInfo;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/** 한 셀의 정보 (Grid 가 renderer 에게 전달) */
+export interface DatePickerDayInfo {
+  date: CalendarDate;
+  /** 현재 보이는 달에 속하는지. false 면 이전/다음 달 "스필오버". */
+  inCurrentMonth: boolean;
+  isToday: boolean;
+  isSelected: boolean;
+  isRangeStart: boolean;
+  isRangeEnd: boolean;
+  isInRange: boolean;         // start~end 사이(양 끝 포함)
+  isRangePreview: boolean;    // hover 중 예상 구간
+  isDisabled: boolean;
+  /** keyboard focus 타깃 day. grid 에서 tabindex=0 대상. */
+  isFocused: boolean;
+}
+```
+
+### 2.2 배럴
+
+```ts
+// src/components/DatePicker/index.ts
+export { DatePicker } from "./DatePicker";
+export type {
+  DatePickerRootProps,
+  DatePickerRootSingleProps,
+  DatePickerRootRangeProps,
+  DatePickerInputProps,
+  DatePickerTriggerProps,
+  DatePickerCalendarProps,
+  DatePickerHeaderProps,
+  DatePickerMonthLabelProps,
+  DatePickerNavProps,
+  DatePickerGridProps,
+  DatePickerDayProps,
+  DatePickerDayInfo,
+  DatePickerMode,
+  DatePickerTheme,
+  CalendarDate,
+  SingleValue,
+  RangeValue,
+} from "./DatePicker.types";
+```
+
+그리고 `src/components/index.ts` 에 `export * from "./DatePicker";` 한 줄 추가.
+
+### 2.3 Compound namespace
+
+```ts
+export const DatePicker = {
+  Root: DatePickerRoot,
+  Input: DatePickerInput,
+  Trigger: DatePickerTrigger,
+  Calendar: DatePickerCalendar,
+  Header: DatePickerHeader,
+  MonthLabel: DatePickerMonthLabel,
+  Nav: DatePickerNav,
+  Grid: DatePickerGrid,
+  Day: DatePickerDay,
+  Footer: DatePickerFooter,
+};
+```
+
+displayName 은 각각 `"DatePicker.Root"` 등. Footer 는 `Today`/`Clear` 내장 버튼을 포함(사용자가 children 으로 override 가능).
+
+### 2.4 기본 조립(fallback)
+
+사용자가 `<DatePicker.Root>...</DatePicker.Root>` 의 children 을 생략하면 Root 내부에서 아래 조립을 자동 렌더한다:
+
+```tsx
+<DatePicker.Input />
+<DatePicker.Trigger />
+<DatePicker.Calendar>
+  <DatePicker.Header>
+    <DatePicker.Nav direction="prev-year" />
+    <DatePicker.Nav direction="prev-month" />
+    <DatePicker.MonthLabel />
+    <DatePicker.Nav direction="next-month" />
+    <DatePicker.Nav direction="next-year" />
+  </DatePicker.Header>
+  <DatePicker.Grid />
+  <DatePicker.Footer />
+</DatePicker.Calendar>
+```
+
+원자 단위 재조립이 필요한 경우만 children 을 명시한다.
+
+---
+
+## 3. 도메인 모델
+
+### 3.1 `CalendarDate` vs `Date`
+
+`Date` 객체는 본질적으로 "UTC millisecond" 에 타임존 필터를 씌운 것이다. `2026-04-23T00:00:00Z` 와 `2026-04-23T00:00:00-09:00` 은 같은 UTC 순간이지만 "로컬 달력" 에서는 다른 날이 될 수 있다. 사용자 관점에서 날짜는 "4월 23일" 이라는 **좌표**지 순간이 아니다. 따라서 내부 도메인 타입은 `CalendarDate = { year, month(1~12), day }` 로 고정한다.
+
+- 외부 boundary (사용자가 prop 으로 `Date` 를 넘겼을 때) 에서만 `toCalendarDate(d: Date): CalendarDate = { year: d.getFullYear(), month: d.getMonth()+1, day: d.getDate() }` 로 로컬 TZ 기준 변환.
+- 반대 변환 `toDate(c: CalendarDate): Date = new Date(c.year, c.month-1, c.day)` 는 항상 **로컬 자정**.
+- 동등성은 `year` `month` `day` 삼자 비교. `Date` 객체 참조 비교는 금지 (useMemo 의 의존성 등에서 무한루프 유발).
+
+### 3.2 타임존
+
+v1 은 "브라우저 로컬 TZ" 고정. 명시 TZ 를 받지 않는다. 이는 의도적 단순화:
+
+- 사용자가 `new Date("2026-04-23")` 를 prop 으로 넘기면 이 Date 는 UTC 자정이고, 로컬 TZ 가 UTC-09:00 인 서울이라면 `getDate() === 23`, 뉴욕(UTC-04:00)이라면 `getDate() === 22` 가 된다. **혼란의 원인.**
+- 따라서 **권장 prop 은 `CalendarDate` 타입**이고, `Date` 를 넘기는 경우는 문서에 "로컬 TZ 로 해석됨" 경고를 명시.
+- `value` 를 다시 직렬화하려는 소비자는 `CalendarDate` → `"YYYY-MM-DD"` 변환을 직접 하거나, 내보내는 `format` 을 활용한다.
+
+### 3.3 순수 Date 산술 유틸 (외부 라이브러리 없음)
+
+```ts
+// DatePicker.dateMath.ts
+
+export function isValidCalendarDate(c: CalendarDate): boolean {
+  const d = new Date(c.year, c.month - 1, c.day);
+  return (
+    d.getFullYear() === c.year &&
+    d.getMonth() === c.month - 1 &&
+    d.getDate() === c.day
+  );
+}
+
+export function compareCalendarDate(a: CalendarDate, b: CalendarDate): number {
+  if (a.year !== b.year) return a.year - b.year;
+  if (a.month !== b.month) return a.month - b.month;
+  return a.day - b.day;
+}
+
+export function isSameDay(a: CalendarDate | null, b: CalendarDate | null): boolean {
+  if (!a || !b) return false;
+  return a.year === b.year && a.month === b.month && a.day === b.day;
+}
+
+/** 윤년 안전. getDaysInMonth(2024, 2) === 29. */
+export function getDaysInMonth(year: number, month: number): number {
+  // new Date(year, month, 0) 은 "month-1 월의 마지막 날" (0-index 기준 month).
+  return new Date(year, month, 0).getDate();
+}
+
+/** 해당 월 1일의 요일 (0=일 ~ 6=토), 로컬 TZ 기준. */
+export function startOfMonthWeekday(year: number, month: number): number {
+  return new Date(year, month - 1, 1).getDay();
+}
+
+export function addMonths(c: CalendarDate, delta: number): CalendarDate {
+  // 월만 산술 → 존재하지 않는 날짜(1/31 + 1month)는 clamp.
+  const targetMonthIndex = c.month - 1 + delta; // 0-index
+  const year = c.year + Math.floor(targetMonthIndex / 12);
+  const monthIdx = ((targetMonthIndex % 12) + 12) % 12;
+  const monthHuman = monthIdx + 1;
+  const day = Math.min(c.day, getDaysInMonth(year, monthHuman));
+  return { year, month: monthHuman, day };
+}
+
+export function addDays(c: CalendarDate, delta: number): CalendarDate {
+  const d = new Date(c.year, c.month - 1, c.day + delta);
+  return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
+}
+
+export function addYears(c: CalendarDate, delta: number): CalendarDate {
+  return addMonths(c, delta * 12);
+}
+
+export function todayCalendarDate(): CalendarDate {
+  const d = new Date();
+  return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
+}
+
+/** 주 시작일을 weekStartsOn 에 맞춰 정렬한 7 요일 인덱스 배열. */
+export function orderedWeekdays(weekStartsOn: number): number[] {
+  return [0, 1, 2, 3, 4, 5, 6].map((i) => (i + weekStartsOn) % 7);
+}
+```
+
+> **주의**: 위의 `addDays` 는 `new Date(y, m-1, d + delta)` 의 "day 인자 자동 carry" 를 이용. DST 전환 일(예: 뉴욕 3월 둘째 일요일)에도 `getDate()` 는 안전(JS Date 는 DST 보정 내장). 단 자정 생성이 존재하지 않는 TZ 에지 케이스(브라질 일부)에 대해 `§13.3` 에 검증 체크 포함.
+
+### 3.4 Root Context
+
+```ts
+interface DatePickerContextValue {
+  // 모드
+  mode: "single" | "range";
+
+  // 선택값
+  single: SingleValue;                          // mode==="single"
+  range: RangeValue;                            // mode==="range"
+  rangeHoverEnd: CalendarDate | null;           // range 모드 hover preview
+
+  // UI 상태
+  open: boolean;
+  setOpen: (v: boolean) => void;
+
+  currentMonth: CalendarDate;                   // day 는 1 로 정규화
+  setCurrentMonth: (m: CalendarDate) => void;
+
+  focusedDay: CalendarDate;                     // grid keyboard cursor
+  setFocusedDay: (d: CalendarDate) => void;
+
+  // 제약
+  minDate: CalendarDate | null;
+  maxDate: CalendarDate | null;
+  isDisabled: (d: CalendarDate) => boolean;
+
+  // Locale
+  locale: string;
+  weekStartsOn: number;
+
+  // 포맷
+  format: string;
+  parseMode: "lenient" | "strict";
+
+  // 액션
+  selectDay: (d: CalendarDate) => void;
+  clear: () => void;
+  setToToday: () => void;
+
+  // 메타
+  disabled: boolean;
+  theme: DatePickerTheme;
+
+  // 포매터 (useMemo 캐시)
+  formatters: {
+    monthLabel: Intl.DateTimeFormat;            // "2026년 4월" / "April 2026"
+    weekdayShort: Intl.DateTimeFormat;          // "Mon" / "월"
+    ariaDate: Intl.DateTimeFormat;              // "Thursday, April 23, 2026"
+  };
+
+  // 내부 id (ARIA)
+  ids: {
+    root: string;
+    input: string;
+    inputStart: string;
+    inputEnd: string;
+    trigger: string;
+    dialog: string;
+    grid: string;
+    monthLabel: string;
+  };
+
+  // refs
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  inputEndRef: React.RefObject<HTMLInputElement | null>;
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
+  gridRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const DatePickerContext = React.createContext<DatePickerContextValue | null>(null);
+
+export function useDatePickerContext() {
+  const ctx = useContext(DatePickerContext);
+  if (!ctx) throw new Error("DatePicker components must be used within <DatePicker.Root>");
+  return ctx;
+}
+```
+
+---
+
+## 4. 시각 / 구조 설계
+
+### 4.1 DOM 구조
+
+`mode="single"` + 기본 조립:
+
+```
+<div role="group" class="dp-root" aria-labelledby={ids.input}>
+  <div class="dp-input-wrap">
+    <input
+      type="text"
+      id={ids.input}
+      class="dp-input"
+      aria-haspopup="dialog"
+      aria-expanded={open}
+      aria-controls={ids.dialog}
+      value={typed ?? format(value)}
+      onChange onBlur onKeyDown />
+    <button
+      id={ids.trigger}
+      class="dp-trigger"
+      aria-label="Open calendar"
+      aria-haspopup="dialog"
+      aria-expanded={open}
+      aria-controls={ids.dialog}>
+      <CalendarIcon />
+    </button>
+  </div>
+
+  {open && (
+    <Popover anchor={inputRef} onClose={closeAndRestoreFocus}>
+      <div
+        role="dialog"
+        id={ids.dialog}
+        aria-modal="false"
+        aria-labelledby={ids.monthLabel}
+        class="dp-calendar">
+        <div class="dp-header">
+          <button class="dp-nav" aria-label="Previous year">«</button>
+          <button class="dp-nav" aria-label="Previous month">‹</button>
+          <div id={ids.monthLabel} class="dp-month-label" aria-live="polite">
+            2026년 4월
+          </div>
+          <button class="dp-nav" aria-label="Next month">›</button>
+          <button class="dp-nav" aria-label="Next year">»</button>
+        </div>
+
+        <div role="grid" id={ids.grid} class="dp-grid" aria-labelledby={ids.monthLabel}>
+          <div role="row" class="dp-weekdays">
+            <div role="columnheader">일</div>
+            <div role="columnheader">월</div>
+            ...
+          </div>
+          <div role="row">
+            <div role="gridcell" aria-selected={...} tabindex={...}>29</div>
+            ...
+          </div>
+          ... (총 6 weeks)
+        </div>
+
+        <div class="dp-footer">
+          <button class="dp-ghost">Today</button>
+          <button class="dp-ghost">Clear</button>
+        </div>
+      </div>
+    </Popover>
+  )}
+</div>
+```
+
+`mode="range"` 는 `.dp-input-wrap` 내부에 input 두 개(`part="start"` / `"end"`) 렌더.
+
+### 4.2 grid = 6 × 7 고정
+
+매 달 42 셀 고정. 첫 주 앞쪽의 "빈 자리" 는 이전 달의 말일로 채움(스필오버), 마지막 주 뒤쪽은 다음 달의 초일로 채움. 스필오버 셀은 `inCurrentMonth=false` 로 렌더되어 흐림 처리. 장점:
+- 높이 jitter 없음 (전달 30일 vs 31일 vs 28일 vs 29일 혼재로 grid 높이가 변하지 않음 → Popover 높이 안정).
+- `aria-rowindex` 일관성.
+
+`rowCount = 6`, `columnCount = 7` 을 `grid` 에 `aria-rowcount="7"` (weekday row 포함 7), `aria-colcount="7"` 로 선언.
+
+### 4.3 palette
+
+```ts
+// theme.ts
+export const datePickerPalette = {
+  light: {
+    bg:              "#ffffff",
+    border:          "rgba(0,0,0,0.12)",
+    inputBg:         "#ffffff",
+    inputFg:         "#111827",
+    inputPlaceholder:"#9ca3af",
+    inputFocusRing:  "#2563eb",
+    inputError:      "#dc2626",
+
+    calendarBg:      "#ffffff",
+    calendarBorder:  "rgba(0,0,0,0.12)",
+    calendarShadow:  "0 8px 24px rgba(0,0,0,0.12)",
+
+    weekdayFg:       "#6b7280",
+
+    dayFg:           "#111827",
+    dayBg:           "transparent",
+    dayHoverBg:      "#eef2ff",
+    dayOutsideFg:    "#9ca3af",
+
+    todayRing:       "#2563eb",
+    selectedBg:      "#2563eb",
+    selectedFg:      "#ffffff",
+
+    rangeBg:         "#dbeafe",
+    rangeFg:         "#111827",
+    rangePreviewBg:  "rgba(37,99,235,0.12)",
+
+    disabledFg:      "#d1d5db",
+
+    navFg:           "#374151",
+    navHoverBg:      "#f3f4f6",
+
+    footerBorder:    "rgba(0,0,0,0.08)",
+    ghostHoverBg:    "#f3f4f6",
+    ghostFg:         "#374151",
+  },
+  dark: {
+    bg:              "#0f172a",
+    border:          "rgba(255,255,255,0.08)",
+    inputBg:         "#1f2937",
+    inputFg:         "#e5e7eb",
+    inputPlaceholder:"#6b7280",
+    inputFocusRing:  "#60a5fa",
+    inputError:      "#f87171",
+
+    calendarBg:      "#1f2937",
+    calendarBorder:  "rgba(255,255,255,0.08)",
+    calendarShadow:  "0 8px 24px rgba(0,0,0,0.4)",
+
+    weekdayFg:       "#9ca3af",
+
+    dayFg:           "#e5e7eb",
+    dayBg:           "transparent",
+    dayHoverBg:      "#334155",
+    dayOutsideFg:    "#6b7280",
+
+    todayRing:       "#60a5fa",
+    selectedBg:      "#60a5fa",
+    selectedFg:      "#0f172a",
+
+    rangeBg:         "#1e3a8a",
+    rangeFg:         "#e5e7eb",
+    rangePreviewBg:  "rgba(96,165,250,0.18)",
+
+    disabledFg:      "#4b5563",
+
+    navFg:           "#e5e7eb",
+    navHoverBg:      "#334155",
+
+    footerBorder:    "rgba(255,255,255,0.08)",
+    ghostHoverBg:    "#334155",
+    ghostFg:         "#e5e7eb",
+  },
+} as const;
+```
+
+### 4.4 레이아웃 치수
+
+- input: height 32, padding 0 28px 0 10px (우측 trigger 아이콘용), border-radius 6, font 13.
+- trigger: 28 × 28 absolute right:0.
+- calendar: width 280, padding 12, border-radius 8.
+- day 셀: 36 × 32, inline-flex center, font-variant-numeric: tabular-nums (숫자 정렬).
+- weekday 헤더 행: height 24, text-transform: uppercase (en 만; ko 는 원본 유지).
+- footer: padding-top 8, border-top 1px, flex gap 8, justify-end.
+
+---
+
+## 5. 핵심 로직
+
+### 5.1 "한 달의 42 셀" 계산
+
+```ts
+export function buildMonthGrid(
+  currentMonth: CalendarDate,        // day 무시
+  weekStartsOn: number,              // 0..6
+): CalendarDate[] {
+  const { year, month } = currentMonth;
+  const firstWeekday = startOfMonthWeekday(year, month); // 0=Sun
+  // 첫 주가 몇 칸 비는가 = (firstWeekday - weekStartsOn + 7) % 7
+  const lead = (firstWeekday - weekStartsOn + 7) % 7;
+
+  // 시작일 = this month 1일 - lead
+  const start: CalendarDate = addDays({ year, month, day: 1 }, -lead);
+
+  const grid: CalendarDate[] = [];
+  for (let i = 0; i < 42; i++) grid.push(addDays(start, i));
+  return grid;
+}
+```
+
+해당 셀이 현재 달에 속하는지 판단: `g.year === year && g.month === month`.
+
+### 5.2 월 네비게이션
+
+```ts
+function goPrevMonth() { setCurrentMonth(addMonths(currentMonth, -1)); }
+function goNextMonth() { setCurrentMonth(addMonths(currentMonth, +1)); }
+function goPrevYear()  { setCurrentMonth(addYears(currentMonth,  -1)); }
+function goNextYear()  { setCurrentMonth(addYears(currentMonth,  +1)); }
+```
+
+`minDate`/`maxDate` 를 벗어나는 월로 이동은 차단 — Nav 버튼 `disabled` 속성. 판정: "이동 후 월의 마지막 날 < minDate" 또는 "이동 후 월의 첫 날 > maxDate" 면 해당 방향 비활성화.
+
+### 5.3 day 선택
+
+```ts
+function selectDay(d: CalendarDate) {
+  if (disabled || isDisabledInternal(d)) return;
+  if (mode === "single") {
+    commitSingle(d);
+    if (closeOnSelect) setOpen(false);
+    return;
+  }
+  // range
+  const r = rangeInternal;
+  if (!r.start || (r.start && r.end)) {
+    // (re)start
+    commitRange({ start: d, end: null });
+  } else {
+    // completing
+    const [a, b] = compareCalendarDate(r.start, d) <= 0 ? [r.start, d] : [d, r.start];
+    commitRange({ start: a, end: b });
+    if (closeOnSelect !== false) setOpen(false);
+  }
+}
+```
+
+`rangeInternal.end` 가 정해지는 순간 `onValueChange` 최종 호출.
+
+### 5.4 range hover preview
+
+pointermove 가 아닌 **`onMouseEnter` per cell** 로 구현 (React event 로 충분). 상태는 `rangeHoverEnd: CalendarDate | null`.
+
+```ts
+function onDayMouseEnter(d: CalendarDate) {
+  if (mode !== "range") return;
+  if (!range.start || range.end) return; // start 만 있고 end 대기 중인 상태에서만
+  setRangeHoverEnd(d);
+}
+function onDayMouseLeaveGrid() {
+  setRangeHoverEnd(null);
+}
+```
+
+preview 구간 계산:
+```ts
+function isRangePreview(d: CalendarDate): boolean {
+  if (mode !== "range" || !range.start || range.end || !rangeHoverEnd) return false;
+  const [a, b] = compareCalendarDate(range.start, rangeHoverEnd) <= 0
+    ? [range.start, rangeHoverEnd]
+    : [rangeHoverEnd, range.start];
+  return compareCalendarDate(d, a) >= 0 && compareCalendarDate(d, b) <= 0;
+}
+```
+
+preview 는 `.dp-day--range-preview` 배경으로 렌더.
+
+### 5.5 Input 파싱
+
+`format` 토큰: `yyyy` | `yy` | `MM` | `M` | `dd` | `d`. 리터럴은 비-영숫자(`/`, `-`, `.`, ` `). MVP 는 6 토큰으로 충분.
+
+Lenient 모드:
+```ts
+// "2026.4.3", "2026/04/03", "20260403" 등 숫자 3 덩어리 매칭.
+const nums = raw.trim().split(/[^\d]+/).filter(Boolean);
+if (nums.length === 3) {
+  const [y, m, d] = guessYMD(nums, format); // format 에서 순서 힌트
+  return maybeValidate({ year: y, month: m, day: d });
+}
+```
+
+Strict 모드:
+```ts
+// format 을 정확히 RegExp 로 변환:
+//   "yyyy-MM-dd" -> /^(\d{4})-(\d{2})-(\d{2})$/
+const re = compileFormatRegex(format);
+const m = re.exec(raw.trim());
+if (!m) return null;
+...
+```
+
+실패 시:
+- input 에 `aria-invalid="true"` + `border-color = inputError`.
+- `onParseError(raw)` 호출.
+- **값은 유지**: 사용자가 계속 타이핑 중일 수 있으므로 blur/Enter 시점까지는 value 에 반영하지 않고 `typedRaw` 상태만 유지. 아래 8.5 참조.
+
+### 5.6 Input 포매팅
+
+```ts
+function formatCalendarDate(c: CalendarDate, format: string, locale: string): string {
+  // format 토큰 기반의 로컬 포매팅.
+  // (locale 은 weekday/month 이름 로컬라이즈에는 쓰이지만
+  //  기본 format "yyyy-MM-dd" 는 숫자만이라 locale 영향 없음.)
+  return format
+    .replace(/yyyy/g, String(c.year).padStart(4, "0"))
+    .replace(/yy/g,   String(c.year % 100).padStart(2, "0"))
+    .replace(/MM/g,   String(c.month).padStart(2, "0"))
+    .replace(/M/g,    String(c.month))
+    .replace(/dd/g,   String(c.day).padStart(2, "0"))
+    .replace(/d/g,    String(c.day));
+}
+```
+
+> 한국어/영어에 따른 "월 이름" 이 필요할 때(예: format="MMMM dd, yyyy") 는 v1.1 에서 `MMMM` / `MMM` / `EEEE` / `EEE` 토큰 추가 → `Intl.DateTimeFormat.formatToParts` 로 매핑. v1 범위는 숫자 토큰(yyyy/MM/dd)만 지원.
+
+---
+
+## 6. 제약 (minDate / maxDate / isDisabled)
+
+```ts
+function isDisabledInternal(d: CalendarDate): boolean {
+  if (minDate && compareCalendarDate(d, minDate) < 0) return true;
+  if (maxDate && compareCalendarDate(d, maxDate) > 0) return true;
+  if (userIsDisabled?.(d)) return true;
+  return false;
+}
+```
+
+- minDate/maxDate 는 inclusive.
+- `userIsDisabled` 의 반환이 바뀔 수 있으므로 Grid 렌더 시 셀 42 개에 대해 호출. 성능: month 당 한 번 렌더이므로 42 call × 1 render = 무시 가능.
+- range 모드에서 start 선택 후 end 로 `isDisabled` 셀이 있으면 **해당 end 선택 자체가 불가** (클릭 무시). 단, start~end 범위 "내부" 에 disabled 셀이 포함될 수는 있다(예: 주말 비활성화된 스케줄에서도 5일 연속 구간을 걸치도록 허용). v1 정책: "끝 점만 disabled 면 선택 불가" / "중간의 disabled 는 허용". 이는 react-day-picker 기본 정책과 동일.
+- 초기 `currentMonth` 는 `value` 가 있으면 value 의 달, 없으면 "오늘" 의 달. 단 min/max 가 있으면 min 이상 max 이하로 clamp.
+
+---
+
+## 7. 키보드
+
+Input 에 포커스가 있는 경우:
+
+| 키 | 동작 |
+|---|---|
+| 타이핑 | typedRaw 업데이트, 즉시 value 반영 안 함 |
+| Enter | typedRaw parse 시도 → 성공 시 commit + 팝업 닫기, 실패 시 aria-invalid |
+| Escape | typedRaw 취소(value 포맷팅 복원), 팝업 닫기 |
+| ArrowDown (openOnFocus or 이미 open) | 팝업 open + focus 를 `focusedDay` 로 이동 |
+| Tab | 다음 포커스 가능 요소 (팝업은 열린 채 유지, body 에서 focus 가 이탈하면 닫힘) |
+
+Grid (dialog) 내 포커스가 있는 경우 (`gridcell` focus):
+
+| 키 | 동작 |
+|---|---|
+| `ArrowLeft` | focusedDay -= 1 일 (RTL 은 +1) |
+| `ArrowRight` | focusedDay += 1 일 (RTL 은 -1) |
+| `ArrowUp` | focusedDay -= 7 일 |
+| `ArrowDown` | focusedDay += 7 일 |
+| `Home` | 주의 시작 (`weekStartsOn` 기준) |
+| `End` | 주의 끝 |
+| `PageUp` | 이전 달 (같은 day-of-month 유지; 없으면 clamp) |
+| `PageDown` | 다음 달 |
+| `Shift + PageUp` | 이전 해 |
+| `Shift + PageDown` | 다음 해 |
+| `Enter` / `Space` | selectDay(focusedDay) |
+| `Escape` | 팝업 닫고 input 에 포커스 복귀 |
+| `Tab` | Footer(Today/Clear) 또는 Nav 버튼으로 이동 |
+
+focusedDay 가 currentMonth 밖으로 나가면 currentMonth 자동 전환 + grid 재렌더 → roving tabindex 로 새 focusedDay 셀에 DOM focus 이동 (`useLayoutEffect` + `ref` 기반).
+
+min/max 를 넘는 이동 시:
+- 방향 키로 넘어가면 clamp (이동을 minDate/maxDate 에 멈춤). 선택 시점에도 `isDisabled` 로 막히므로 이중 안전.
+
+---
+
+## 8. 상태 관리 (3-축 controlled / uncontrolled)
+
+### 8.1 축 정의
+
+1. **value**: `SingleValue` 또는 `RangeValue`. 실제 선택값.
+2. **open**: 팝업 열림 여부.
+3. **currentMonth**: 달력이 현재 보여주는 달(day=1 정규화).
+
+각 축은 independent 하게 controlled/uncontrolled 가능. 조합 가능.
+
+### 8.2 `useControllable` 활용
+
+세 축 모두 기존 훅:
+
+```ts
+const [single, setSingle] = useControllable<SingleValue>({
+  value: props.mode !== "range" ? props.value : undefined,
+  defaultValue: props.mode !== "range" ? props.defaultValue : null,
+  onChange: (v) => props.mode !== "range" && props.onValueChange?.(v),
+});
+
+const [range, setRange] = useControllable<RangeValue>({
+  value: props.mode === "range" ? props.value : undefined,
+  defaultValue: props.mode === "range" ? props.defaultValue : { start: null, end: null },
+  onChange: (v) => props.mode === "range" && props.onValueChange?.(v),
+});
+
+const [open, setOpen] = useControllable<boolean>({
+  value: props.open,
+  defaultValue: props.defaultOpen ?? false,
+  onChange: props.onOpenChange,
+});
+
+const [currentMonth, setCurrentMonth] = useControllable<CalendarDate>({
+  value: props.month,
+  defaultValue: props.defaultMonth ?? deriveInitialMonth(),
+  onChange: props.onMonthChange,
+});
+```
+
+### 8.3 month 자동 동기화
+
+value 가 controlled 로 외부에서 변할 때 currentMonth 가 uncontrolled 면 자동으로 **value 의 달** 로 동기화:
+
+```ts
+useEffect(() => {
+  if (props.month !== undefined) return; // controlled month 면 개입 안 함
+  const target = currentValueDate(single, range);
+  if (!target) return;
+  if (target.year !== currentMonth.year || target.month !== currentMonth.month) {
+    setCurrentMonth({ year: target.year, month: target.month, day: 1 });
+  }
+}, [single, range]);
+```
+
+### 8.4 focusedDay
+
+focusedDay 는 **controlled prop 없음**. 내부 state. 초기값:
+- value 있으면 value, 없으면 today (min/max clamp).
+- open 될 때마다 재계산: value 또는 today 로 reset (focus 가 지저분해지는 걸 방지).
+
+### 8.5 Input typedRaw
+
+input 타이핑 중 값을 즉시 commit 하지 않기 위한 buffer state:
+
+```ts
+const [typedRaw, setTypedRaw] = useState<string | null>(null);
+
+// input 표시값:
+const displayValue = typedRaw !== null
+  ? typedRaw
+  : (single ? formatCalendarDate(single, format, locale) : "");
+
+// onChange: 타이핑
+function onInputChange(e: ChangeEvent<HTMLInputElement>) {
+  setTypedRaw(e.target.value);
+}
+
+// onBlur / Enter: parse try
+function commitTyped() {
+  if (typedRaw === null) return;
+  const parsed = parseRaw(typedRaw, format, parseMode);
+  if (parsed === null) {
+    if (typedRaw === "") { commitSingle(null); setTypedRaw(null); return; }
+    setInvalid(true);
+    onParseError?.(typedRaw);
+    return;
+  }
+  if (isDisabledInternal(parsed)) { setInvalid(true); onParseError?.(typedRaw); return; }
+  commitSingle(parsed);
+  setTypedRaw(null);
+  setInvalid(false);
+}
+```
+
+### 8.6 controlled + storage 충돌
+
+DatePicker 는 localStorage persist 를 내장하지 않는다(= SplitPane 과 다름). 날짜는 대개 서버 상태/URL 과 묶이므로 owner 책임. 향후 `storageKey` 는 v1.1 에 `defaultValue` 보완용으로 선택적 추가 가능.
+
+---
+
+## 9. Locale & formatting
+
+### 9.1 `Intl.DateTimeFormat` 만 사용
+
+```ts
+const fmtMonthLabel = useMemo(
+  () => new Intl.DateTimeFormat(locale, { year: "numeric", month: "long" }),
+  [locale],
+);
+// en-US -> "April 2026"
+// ko-KR -> "2026년 4월"
+
+const fmtWeekdayShort = useMemo(
+  () => new Intl.DateTimeFormat(locale, { weekday: "short" }),
+  [locale],
+);
+// en-US "Mon", ko-KR "월"
+
+const fmtAriaDate = useMemo(
+  () => new Intl.DateTimeFormat(locale, { dateStyle: "full" }),
+  [locale],
+);
+// en-US "Thursday, April 23, 2026"
+// ko-KR "2026년 4월 23일 목요일"
+```
+
+**왜 date-fns/dayjs 를 쓰지 않는가**:
+- `date-fns` locale 패키지는 `date-fns/locale/ko` 하나만 ~40 KB. 영어 포함 2 locale 이면 80 KB+. 반면 `Intl.DateTimeFormat` 은 **V8/JSC 내장** 으로 번들 0 바이트.
+- 기능 매칭: "월·요일 이름 로컬라이즈" + "숫자 포매팅" 이라는 본 컴포넌트 필요 범위가 `Intl` 로 100% 커버됨.
+- plastic 은 "zero runtime dependency" 를 핵심 slogan 으로 하므로 협상 불가.
+
+### 9.2 `weekStartsOn` 유추
+
+```ts
+function deriveWeekStartsOn(locale: string): number {
+  try {
+    // @ts-expect-error getWeekInfo 는 일부 런타임 필요(Chrome 99+, Node 20+)
+    const info = new Intl.Locale(locale).getWeekInfo?.();
+    if (info?.firstDay != null) {
+      // info.firstDay: 1=Mon ~ 7=Sun
+      return info.firstDay === 7 ? 0 : info.firstDay;
+    }
+  } catch { /* ignore */ }
+  // fallback: en-US/ko-KR 모두 일요일(0) 시작 관례.
+  return 0;
+}
+```
+
+지원하지 않는 런타임에서는 0 으로 안전 폴백. 호출자가 `weekStartsOn` 명시하면 유추 생략.
+
+### 9.3 parse 관대 vs strict
+
+- **Lenient (기본)**: 구분자 무시, 숫자 3 덩어리로 분해. "2026.4.3", "2026 4 3", "20260403" 모두 동일 해석. `format` 에서 yyyy/MM/dd 순서만 힌트로 사용.
+- **Strict**: format 정규식과 정확히 매칭. padding(`02`) 여부까지 일치해야 함. 폼 검증 UX 에 유리.
+
+양 모드 공통:
+- 파싱 후 `isValidCalendarDate` 로 존재 여부 체크(예: `2026-02-30` 거부).
+- `isDisabledInternal` 로 제약 확인.
+
+---
+
+## 10. 파일 구조
+
+```
+src/components/DatePicker/
+├── DatePicker.tsx              # Root + Input + Trigger + Calendar + 하위 조립 + namespace export
+├── DatePicker.types.ts         # 공개 타입 + 내부 Info 타입
+├── DatePicker.dateMath.ts      # isValidCalendarDate / compare / addDays / addMonths / addYears / getDaysInMonth / startOfMonthWeekday / todayCalendarDate / orderedWeekdays
+├── DatePicker.format.ts        # formatCalendarDate / parseRaw (lenient+strict) / compileFormatRegex
+├── DatePicker.intl.ts          # Intl.DateTimeFormat 팩토리 + deriveWeekStartsOn
+├── DatePickerContext.ts        # Context 정의 + useDatePickerContext
+├── useDatePickerState.ts       # 3-축 controllable + 액션(selectDay, clear, setToToday) 훅
+├── useCalendarGrid.ts          # buildMonthGrid + 각 셀의 Info 계산 (memo)
+├── useDatePickerKeyboard.ts    # grid keydown + input keydown 분리 훅
+├── DatePicker.theme.ts         # datePickerPalette (light/dark)
+├── DatePicker.parts.tsx        # Input / Trigger / Calendar / Header / Nav / MonthLabel / Grid / Day / Footer 구현
+└── index.ts                    # 배럴
+```
+
+각 파일 책임:
+
+- **DatePicker.tsx**: `DatePickerRoot` 가 `useDatePickerState` 호출, Context.Provider 로 감싸고, children 이 없으면 기본 조립(§2.4) 렌더. namespace export(`DatePicker.Root` 등).
+- **DatePicker.dateMath.ts**: 날짜 산술 pure functions. **외부 의존 금지**.
+- **DatePicker.format.ts**: format 토큰 compile, formatCalendarDate, parseRaw.
+- **DatePicker.intl.ts**: Intl 인스턴스 생성 헬퍼. SSR-safe (`typeof Intl !== "undefined"` 가드).
+- **DatePickerContext.ts**: Context + hook. null throw.
+- **useDatePickerState.ts**: value/open/currentMonth 를 useControllable 로 묶고, selectDay/clear/setToToday 등 액션 반환.
+- **useCalendarGrid.ts**: buildMonthGrid + 각 셀 DayInfo 계산. `useMemo` 의존성 `[year, month, weekStartsOn, single, range, rangeHoverEnd, focusedDay, minDate, maxDate, userIsDisabled]`.
+- **useDatePickerKeyboard.ts**: onInputKeyDown, onGridKeyDown, onDayMouseEnter 등 handler 반환.
+- **DatePicker.theme.ts**: palette.
+- **DatePicker.parts.tsx**: 자식 컴포넌트들. 모두 `useDatePickerContext` 로 상태 수령.
+
+---
+
+## 11. 구현 단계 (후속 agent 가 순차 실행)
+
+각 단계는 독립 커밋 권장. 각 커밋이 `npm run typecheck` + `npx tsup` 통과 상태.
+
+### Step 1 — 타입 + 배럴 + 테마 + 유틸 스켈레톤
+1. `DatePicker.types.ts` 작성 (§2.1 전부). single/range discriminated union.
+2. `DatePicker.theme.ts` palette.
+3. `DatePicker.dateMath.ts` 에 7 개 pure 함수 작성 + unit test 대상(수동 console 검증).
+4. `DatePicker.intl.ts` factory 3개 + deriveWeekStartsOn.
+5. `DatePicker.format.ts` 에 formatCalendarDate 우선 (yyyy/MM/dd 만).
+6. `index.ts` 배럴.
+7. `src/components/index.ts` 에 `export * from "./DatePicker";`.
+8. `DatePicker.tsx` placeholder: `{ Root:()=>null, Input:()=>null, Trigger:()=>null, Calendar:()=>null, Header:()=>null, Nav:()=>null, MonthLabel:()=>null, Grid:()=>null, Day:()=>null, Footer:()=>null }`.
+9. 커밋: `feat(DatePicker): 타입 + 유틸 + 테마 스켈레톤`.
+
+### Step 2 — Context + state 훅
+1. `DatePickerContext.ts`.
+2. `useDatePickerState.ts` — value 단일(single) 부터. open/currentMonth 포함. range 는 Step 7.
+3. `DatePicker.tsx` Root 실제 Provider 렌더. children 없으면 기본 조립.
+4. 커밋: `feat(DatePicker): context + state 훅`.
+
+### Step 3 — Input + Trigger + Popover 연결
+1. `DatePicker.parts.tsx` 의 `DatePickerInput`, `DatePickerTrigger`.
+2. Popover 열림(input focus / trigger click) 처리.
+3. typedRaw 상태 + blur/Enter 커밋.
+4. 커밋: `feat(DatePicker): input + trigger + popover 연결`.
+
+### Step 4 — Calendar 골격 (Header + MonthLabel + Nav)
+1. `DatePicker.parts.tsx` 의 Calendar / Header / MonthLabel / Nav.
+2. `Intl.DateTimeFormat` 으로 month label 렌더. ko-KR 검증 포함.
+3. Nav 버튼으로 currentMonth 변경.
+4. 커밋: `feat(DatePicker): calendar header + navigation`.
+
+### Step 5 — Grid + Day 렌더 (single 선택)
+1. `useCalendarGrid.ts` 로 42 셀 계산.
+2. DayInfo 의 `isSelected`/`isToday`/`isDisabled`/`inCurrentMonth`/`isFocused` 반영.
+3. 셀 클릭으로 `selectDay` 동작.
+4. `closeOnSelect` 기본 true.
+5. 커밋: `feat(DatePicker): grid + day 선택 (single)`.
+
+### Step 6 — min/max/isDisabled + parseRaw
+1. minDate/maxDate 반영 (Grid 셀 disabled, Nav 버튼 disabled).
+2. `parseRaw` (lenient + strict) 구현.
+3. invalid 시 `aria-invalid` + red border.
+4. 커밋: `feat(DatePicker): 제약 + input parsing`.
+
+### Step 7 — range 모드
+1. `mode="range"` 경로 — Input 두 개 (start/end), value 타입 `RangeValue`.
+2. `selectDay` 로직 확장 (2-step 선택).
+3. hover preview 상태 + Day 셀 `isRangePreview`.
+4. start/end 스왑(역방향 선택 허용).
+5. 커밋: `feat(DatePicker): range 모드`.
+
+### Step 8 — 키보드 탐색
+1. `useDatePickerKeyboard.ts`.
+2. Input: Enter/Escape/ArrowDown.
+3. Grid: Arrow/Home/End/PageUp/PageDown/Shift+PageUp/PageDown/Enter/Escape.
+4. focusedDay 이동 시 DOM focus 동기화(ref + useLayoutEffect).
+5. 월 자동 전환.
+6. 커밋: `feat(DatePicker): 키보드 탐색`.
+
+### Step 9 — Today/Clear Footer + 상호작용 다듬기
+1. `DatePicker.Footer` 내장 Today/Clear 버튼.
+2. Today: currentMonth 를 오늘의 달로 이동 + focusedDay=today.
+3. Clear: value 초기화 + typedRaw 초기화.
+4. 커밋: `feat(DatePicker): footer + 보조 액션`.
+
+### Step 10 — 접근성 감사 + Dark theme
+1. role/aria-* 전수 점검 (§15).
+2. palette dark 통합.
+3. focus ring 일관.
+4. 커밋: `feat(DatePicker): 접근성 + 다크 테마`.
+
+### Step 11 — 데모 페이지
+1. `demo/src/pages/DatePickerPage.tsx` (§12).
+2. `demo/src/App.tsx` NAV 추가.
+3. 커밋: `feat(DatePicker): 데모 페이지`.
+
+### Step 12 — 마감
+1. Props 표 + Usage 예제 (§12).
+2. `§20 DoD` 전수 체크.
+3. 커밋: `feat(DatePicker): props 표 + usage`.
+
+---
+
+## 12. 데모 페이지
+
+`demo/src/pages/DatePickerPage.tsx`. 기존 `CommandPalettePage` 의 구조를 복제. 섹션별 `<section id="...">` + 우측 사이드바 섹션 nav 연동.
+
+### 12.1 NAV 추가 (App.tsx)
+
+```ts
+{ id: "datepicker", label: "DatePicker", description: "날짜 선택", sections: [
+  { label: "Basic (single)",      id: "basic" },
+  { label: "Range",               id: "range" },
+  { label: "Min / Max",           id: "minmax" },
+  { label: "Disabled dates",      id: "disabled-dates" },
+  { label: "Locale (ko-KR)",      id: "locale" },
+  { label: "Dark",                id: "dark" },
+  { label: "Controlled",          id: "controlled" },
+  { label: "Format & parse",      id: "format" },
+  { label: "Playground",          id: "playground" },
+  { label: "Props",               id: "props" },
+  { label: "Usage",               id: "usage" },
+]},
+```
+
+그리고 `Page` 타입에 `"datepicker"` 추가 + 하단 `{current === "datepicker" && <DatePickerPage />}`.
+
+### 12.2 섹션 구성
+
+**Basic (single)**
+```tsx
+<DatePicker.Root defaultValue={{ year: 2026, month: 4, day: 23 }}>
+  <DatePicker.Input />
+  <DatePicker.Trigger />
+  <DatePicker.Calendar />
+</DatePicker.Root>
+```
+
+**Range**
+```tsx
+<DatePicker.Root
+  mode="range"
+  defaultValue={{ start: { year: 2026, month: 4, day: 5 }, end: { year: 2026, month: 4, day: 12 } }}
+>
+  <DatePicker.Input part="start" placeholder="Start" />
+  <DatePicker.Input part="end" placeholder="End" />
+  <DatePicker.Trigger />
+  <DatePicker.Calendar />
+</DatePicker.Root>
+```
+
+**Min / Max**
+```tsx
+<DatePicker.Root
+  minDate={{ year: 2026, month: 4, day: 1 }}
+  maxDate={{ year: 2026, month: 5, day: 31 }}
+/>
+```
+"4월 1일 이전 / 5월 31일 이후는 비활성" 안내 문구.
+
+**Disabled dates (주말 비활성)**
+```tsx
+<DatePicker.Root
+  isDisabled={(d) => {
+    const weekday = new Date(d.year, d.month - 1, d.day).getDay();
+    return weekday === 0 || weekday === 6;
+  }}
+/>
+```
+
+**Locale (ko-KR)**
+```tsx
+<DatePicker.Root locale="ko-KR" weekStartsOn={0} format="yyyy년 M월 d일" />
+```
+월 라벨이 "2026년 4월", weekday 가 "일 월 화 수 목 금 토" 로 표시.
+
+**Dark**
+```tsx
+<div style={{ background: "#0f172a", padding: 24 }}>
+  <DatePicker.Root theme="dark" />
+</div>
+```
+
+**Controlled**
+```tsx
+const [value, setValue] = useState<CalendarDate | null>({ year: 2026, month: 4, day: 23 });
+const [open, setOpen] = useState(false);
+const [month, setMonth] = useState<CalendarDate>({ year: 2026, month: 4, day: 1 });
+
+return (
+  <>
+    <div className="flex gap-2">
+      <button onClick={() => setValue({ year: 2026, month: 1, day: 1 })}>New Year</button>
+      <button onClick={() => setValue({ year: 2026, month: 12, day: 25 })}>Christmas</button>
+      <button onClick={() => setOpen(o => !o)}>Toggle popup</button>
+    </div>
+    <DatePicker.Root
+      value={value} onValueChange={setValue}
+      open={open} onOpenChange={setOpen}
+      month={month} onMonthChange={setMonth}
+    />
+    <pre>{JSON.stringify({ value, open, month }, null, 2)}</pre>
+  </>
+);
+```
+
+**Format & parse**
+```tsx
+<DatePicker.Root format="yyyy/MM/dd" parseMode="strict"
+  onParseError={(raw) => toast(`Cannot parse: "${raw}"`)} />
+```
+사용자가 `2026-04-23` (하이픈) 입력 → strict 에서는 실패 + error 토스트.
+
+**Playground**
+상단 컨트롤 바:
+- `mode` 라디오 (single / range)
+- `locale` select (en-US / ko-KR / ja-JP / de-DE)
+- `weekStartsOn` 슬라이더 (0~6)
+- `minDate` / `maxDate` date input 폴리필(일반 `<input type="date">` 로 받기)
+- `format` text input
+- `parseMode` 라디오 (lenient / strict)
+- `closeOnSelect` 체크박스
+- `disabled` 체크박스
+- `theme` 토글 (light / dark)
+
+아래에 실제 `<DatePicker.Root {...args}>` 렌더 + `pre` 로 현재 value / open / month 상태 JSON 표시.
+
+**Props 표**
+기존 페이지 패턴 그대로. Root, Input, Trigger, Calendar, Header, Nav, MonthLabel, Grid, Day, Footer 각각 table.
+
+**Usage (4개)**
+1. 기본 single (form 의 due-date 필드).
+2. Range (travel 예약 start/end).
+3. ko-KR + 주말 비활성 + 한 달 시그널 (회의 예약 UI).
+4. Controlled + server state (날짜 변경 시 fetch 재요청 예시).
+
+**IDE-급 샘플 코드 (travel 예약)**:
+```tsx
+function TravelBooking() {
+  const [range, setRange] = useState<RangeValue>({ start: null, end: null });
+  const today = todayCalendarDate();
+  return (
+    <DatePicker.Root
+      mode="range"
+      value={range}
+      onValueChange={setRange}
+      minDate={today}
+      maxDate={addYears(today, 1)}
+      locale="ko-KR"
+      weekStartsOn={0}
+      format="yyyy.MM.dd"
+      theme="light"
+    >
+      <div className="flex items-center gap-2 rounded border px-3 py-2">
+        <span className="text-sm text-slate-500">여행</span>
+        <DatePicker.Input part="start" placeholder="출발" />
+        <span>—</span>
+        <DatePicker.Input part="end" placeholder="도착" />
+        <DatePicker.Trigger aria-label="달력 열기" />
+      </div>
+      <DatePicker.Calendar />
+    </DatePicker.Root>
+  );
+}
+```
+
+---
+
+## 13. 검증 계획
+
+### 13.1 자동화
+
+```bash
+cd /Users/neo/workspace/plastic
+npm run typecheck
+npx tsup
+```
+
+특히 `exactOptionalPropertyTypes`: `DatePickerRootSingleProps` / `RangeProps` discriminated union 이 탄탄해야 하므로, `mode` 를 지정하지 않은 경우 단일 모드 default 가 타입 추론되는지 테스트.
+
+`noUncheckedIndexedAccess`: `React.Children.toArray(children)[i]` 는 undefined 가능.
+
+### 13.2 수동 (demo dev server)
+
+```bash
+cd demo && npm run dev
+```
+
+체크리스트:
+- [ ] Basic: 날짜 클릭 → input 에 "2026-04-23" 반영 + 팝업 닫힘.
+- [ ] Basic: input 에 "2026-4-3" 타이핑 → Enter → 2026년 4월 3일 선택.
+- [ ] Basic: input 에 "not-a-date" → Enter → aria-invalid + red border.
+- [ ] Range: 4/5 클릭 → hover 이동 시 preview 구간 강조 → 4/12 클릭 → range 확정, 팝업 닫힘.
+- [ ] Range: 역방향 선택(4/12 먼저 → 4/5) 도 start/end 스왑 정상.
+- [ ] Min/Max: minDate 이전 / maxDate 이후 셀은 fg=disabled, 클릭 무반응, Nav 버튼 경계에서 disabled.
+- [ ] Disabled dates: 주말 비활성. 키보드로 이동은 가능하지만 Enter 로 선택 불가.
+- [ ] Locale ko-KR: 헤더 "2026년 4월", weekday "일 월 화 …".
+- [ ] Locale en-US: 헤더 "April 2026", weekday "Sun Mon …".
+- [ ] Dark: 모든 요소 다크로 전환, focus ring 보임.
+- [ ] Controlled: 외부 버튼으로 value/open/month 제어. 내부 클릭 시 onValueChange 만 호출되고 외부 state 가 주도.
+- [ ] Format & parse strict: `yyyy/MM/dd` 만 허용, 다른 구분자 거부.
+- [ ] Playground: 모든 컨트롤 조합 실시간 반영.
+- [ ] 다른 페이지 리그레션 없음 (CommandPalette, SplitPane 등).
+
+### 13.3 엣지 케이스
+
+- [ ] **윤년**: `getDaysInMonth(2024, 2) === 29`, `getDaysInMonth(2023, 2) === 28`, `getDaysInMonth(2100, 2) === 28` (평년), `getDaysInMonth(2000, 2) === 29` (400의 배수). Grid 렌더에서 2월 말일이 정확히 포함되는지 육안 확인.
+- [ ] **DST (Daylight Saving Time)**: 뉴욕 2026-03-08 (spring forward) + 11-01 (fall back) 에서 해당 주 grid 가 7 셀 모두 정상 표시. `addDays` 가 24 시간 가감이 아니라 calendar-day 기반이므로 영향 없어야 함. `TZ=America/New_York node -e "..."` 로 dateMath 유닛 검증.
+- [ ] **cross-month range**: 2026-04-28 ~ 2026-05-03 선택 → Grid 를 4월/5월 넘나들며 `isInRange` 가 일관되게 true.
+- [ ] **12월 → 1월**: 2026-12-31 에서 next-month → 2027-01. 연도 rollover 안전.
+- [ ] **1월 → 12월**: 2026-01 에서 prev-month → 2025-12.
+- [ ] **min/max 와 currentMonth**: minDate=2026-04-01 일 때 prev-month/prev-year 버튼 disabled. 그러나 키보드 ArrowLeft 로 3월 30일로 이동 시도 → 4월 1일에서 멈춤(clamp).
+- [ ] **value 를 prop 변경**: controlled 시 value 바뀌면 currentMonth 자동 동기화 (uncontrolled month 일 때만).
+- [ ] **자정이 없는 TZ**: 과거 브라질의 DST 개시일처럼 자정이 skip 되는 날 — `new Date(2018, 10, 4)` 가 `00:00` 대신 `01:00` 을 반환. `getDate()` 는 `4` 로 여전히 올바르므로 Grid 렌더 정상. (이 경우에도 동작해야 한다는 사실을 문서화.)
+- [ ] **SSR**: `DatePicker.intl.ts` 의 `typeof Intl` 가드. `todayCalendarDate()` 가 서버/클라 렌더 불일치 없도록 최초 마운트 후에만 호출(`useEffect` 로 set).
+- [ ] **controlled value 에 null 전달 → 해제**: input 비워짐, currentMonth 유지(점프 없음).
+- [ ] **range 모드 start 만 있는 채로 팝업 닫기**: end=null 상태 유지. 다음 open 시 start 부터 재개.
+- [ ] **disabled prop 전체**: input readonly, trigger disabled, grid 상호작용 불가.
+
+---
+
+## 14. 성능
+
+### 14.1 비용 견적
+
+- **한 달 렌더 = 42 day 셀**. 매우 가벼움. React reconciliation 이 42 key 를 diff 하는 것은 <1 ms.
+- memo 필요 없음. 다만 `Intl.DateTimeFormat` 인스턴스는 재사용 필요(다음 절).
+- parse regex 는 format 변경 시마다 compile — useMemo.
+
+### 14.2 핵심 최적화
+
+1. **`Intl.DateTimeFormat` 캐싱**: `useMemo` with `[locale]` 의존성. locale 바뀌지 않는 한 같은 인스턴스.
+2. **buildMonthGrid memoization**: `useMemo` with `[year, month, weekStartsOn]`.
+3. **DayInfo 배열 memoization**: 위 grid + `[single, range, rangeHoverEnd, focusedDay, minDate, maxDate, userIsDisabled]`.
+4. **hover preview**: state update 가 day cell 마다 발생하지만, 42 셀 * 단일 re-render 로 <2 ms. 별도 throttle 불필요.
+5. **Day 컴포넌트 React.memo**: `DayInfo` shallow compare. DayInfo 를 매번 새 ref 로 만들되 값이 같으면 memo 가 어쨌든 리렌더하므로, 사실상 memo 효과는 크지 않음. v1 은 memo 생략, 데모로 프로파일링 후 v1.1 검토.
+
+### 14.3 측정
+
+DevTools Performance 탭에서 "open → navigate 12 month → close" 시퀀스 녹화 → 총 scripting 시간 <50 ms 목표.
+
+---
+
+## 15. 접근성
+
+- root: `role="group"` + `aria-label="Date picker"` (사용자 override 가능).
+- input: `type="text"`, `inputmode="numeric"`, `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls={dialog id}`, `aria-invalid` (parse 실패 시).
+- trigger button: `aria-label="Open calendar"`, `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls`.
+- dialog: `role="dialog"`, `aria-modal="false"` (modal 아님), `aria-labelledby={monthLabel id}`.
+- month label: `aria-live="polite"` + `aria-atomic="true"` — 스크린리더가 월 이동을 읽음.
+- grid: `role="grid"`, `aria-labelledby={monthLabel id}`, `aria-readonly="false"`, `aria-multiselectable="false"` (range 에서도 screen-reader 의미는 단일 셀 선택을 연속).
+- weekday 헤더: `role="row"` + 각 `role="columnheader"` + `abbr` 속성(예: "Monday").
+- 날짜 셀:
+  - `role="gridcell"`
+  - `aria-selected={isSelected || isRangeStart || isRangeEnd || isInRange}`
+  - `aria-disabled={isDisabled}`
+  - `aria-current="date"` (today 인 경우)
+  - `tabindex={isFocused ? 0 : -1}` — roving tabindex
+  - 스크린리더용 전체 label: `aria-label` 에 `fmtAriaDate.format(toDate(day))` — "Thursday, April 23, 2026".
+- Nav 버튼: 각각 `aria-label`:
+  - prev-year: "Go to previous year"
+  - prev-month: "Go to previous month"
+  - next-month: "Go to next month"
+  - next-year: "Go to next year"
+- Today / Clear: 일반 `<button>` + 명시 label.
+- Escape 복귀: 팝업 닫을 때 input 또는 trigger 로 focus 복귀.
+- 색상 대비: palette 내 모든 fg/bg 조합 WCAG AA (4.5:1) 이상.
+- prefers-reduced-motion: 팝업 fade 만 사용, 추가 애니메이션 없음.
+
+---
+
+## 16. 알려진 트레이드오프 · 결정
+
+1. **`Intl.DateTimeFormat` vs `date-fns` / `dayjs`**: plastic 이 zero-deps 를 천명. 포맷 범위(월/요일/full date)가 Intl 로 100% 커버되며 런타임 내장이므로 번들 영향 0. 손해: `Intl` 은 런타임별 output 이 미세 상이(예: `dateStyle: "full"` 의 쉼표 유무 등)지만 라벨 용도에서는 문제 없음. **채택: Intl 전용.**
+2. **내부 표현 `CalendarDate` vs `Date`**: Date 객체는 TZ 슬립(UTC 자정 ↔ 로컬) 버그의 원천. `{year, month, day}` 로 좌표화하여 대부분의 버그 차단. 손해: 사용자가 Date 를 넘기면 한 번 변환 비용. API 에서 Date 도 받되 즉시 변환하여 context 에는 CalendarDate 로만 유지.
+3. **UTC vs Local**: 로컬 TZ 고정. 명시 TZ 지원은 `Temporal` API 가 안정화된 시점(또는 `Intl.DateTimeFormat.formatToParts` + 자체 TZ 계산)에 v2 로 재평가. 다중 TZ 가 필요한 앱(글로벌 예약)은 value 레이어에서 자체 변환 — 라이브러리는 "로컬 grid" 역할만.
+4. **single + range 를 같은 `Root`**: Radix/react-aria 처럼 컴포넌트 자체를 분리(`DatePicker` vs `DateRangePicker`) 하는 선택지도 있었다. 선택 근거: **상당수 로직 공유**(Grid, Keyboard, Header, Nav), UI 외관이 동일, `mode` 런타임 토글 수요 존재(필터 위젯). 단점: value 타입 union 이 된다 → TS 상 discriminated union 으로 해결.
+5. **range hover preview: hover vs click-and-hold**: Notion 은 hover, react-day-picker 도 hover. 일관성 우선 → hover.
+6. **range end 가 start 보다 앞선 경우**: 역방향도 허용, 내부에서 swap. 사용자가 실수로 "5일 → 3일" 을 고르면 3~5로 해석. 대안(거부)은 UX 가 답답.
+7. **month picker (drop-down)**: 월/년 라벨을 클릭하면 year grid 가 나오는 UX 도 고려. v1 은 Nav 4 개(‹ ‹‹ › ››)로 충분. "연도 바로 이동" 은 v1.1.
+8. **close on select 정책**: single 은 true 가 자연. range 는 end 확정 때만 닫음. 사용자 override 가능.
+9. **controlled month 시 value 변경 동기화 안 함**: 사용자가 month 를 완전 제어한다면 value 와 독립. 애매해 보이나 owner 명시 선택이 맞음.
+10. **ARIA live region 범위**: month label 만 live. 셀 선택 자체는 screen reader 가 focus 변경으로 알림.
+11. **format 토큰 수 v1 제한**: yyyy/yy/MM/M/dd/d 만. MMMM(월 이름) 등은 v1.1 — Intl.formatToParts 로 literal map 생성.
+12. **parse lenient 기본**: "타이핑 편의 > 형식 엄격" 이 공용 폼 UX 의 중론. 엄격이 필요한 경우만 strict 지정.
+13. **팝업 구현체로 plastic 의 `Popover` 사용**: 직접 `createPortal` 하지 않고 기존 컴포넌트에 위임하여 일관성 확보. 내부 close 로직(outside click, Escape)을 재구현하지 않는다.
+14. **42 셀 고정 vs 가변 (4~6 weeks)**: 가변 시 Popover 높이 jitter. UX 손실 > 스필오버 1~5 셀의 혼란. 고정 채택.
+15. **Input 두 개 vs 하나 (range)**: 하나의 input 에 "2026-04-05 ~ 2026-04-12" 로 묶는 방법도 가능. 타이핑 편집이 난감해서 두 개로 분리. 필요 시 v1.1 `SingleInputRange` prop.
+
+---
+
+## 17. 후속 작업 (v1.1+)
+
+- **Time picker**: `<DateTimePicker>` 또는 `<DatePicker timePrecision="minute">`. 시/분 스피너 + AM/PM.
+- **2-month view**: `numberOfMonths={2}` — range 선택 UX 가 크게 개선.
+- **Preset ranges**: "오늘", "어제", "지난 7일", "이번 달", "지난 달" 프리셋. `presets: { label: string; value: RangeValue }[]`.
+- **Masked input**: `<DatePicker.Input mask="yyyy-mm-dd" />` — cursor 자동 jump.
+- **Custom footer**: 현재 Footer 는 children override 가능하지만, `<DatePicker.Preset label="Today" />` 같은 편의 컴포넌트 세트 추가.
+- **Week / Month / Year picker**: `picker="week"` 등.
+- **Multiple selection**: `mode="multiple"` — 배열 값.
+- **Year grid navigation**: 헤더의 "2026" 클릭 시 12 년 grid 로 전환.
+- **Locale-specific format 토큰**: MMMM(월 이름), EEE(요일 이름) 지원.
+- **Animation**: 월 좌/우 슬라이드 전환.
+- **Form integration**: `react-hook-form` / `zod` 어댑터 없이도 기본적으로 HTML form 에 잘 통합되는지 검토(hidden input).
+- **`storageKey` persist**: SplitPane 과 유사한 localStorage 복원 지원 (선택).
+- **Temporal API 지원**: Chrome 129+ 에서 `Temporal.PlainDate` 표준화. adapter prop.
+
+---
+
+## 18. 관련 파일 인벤토리 (구현 시 참조)
+
+| 용도 | 경로 |
+|---|---|
+| useControllable (3-축 이중 API 모델) | `/Users/neo/workspace/plastic/src/components/_shared/useControllable.ts` |
+| Popover (팝업 앵커·outside click·Escape) | `/Users/neo/workspace/plastic/src/components/Popover/` |
+| PathInput (text input + suggestion popover + light/dark 패턴) | `/Users/neo/workspace/plastic/src/components/PathInput/` |
+| 배럴 등록 | `/Users/neo/workspace/plastic/src/components/index.ts` |
+| 데모 App 라우팅 / NAV | `/Users/neo/workspace/plastic/demo/src/App.tsx` |
+| 데모 페이지 레이아웃 최신 레퍼런스 | `/Users/neo/workspace/plastic/demo/src/pages/CommandPalettePage.tsx` |
+| tsconfig 제약 (`exactOptionalPropertyTypes` 등) | `/Users/neo/workspace/plastic/tsconfig.json` |
+
+---
+
+## 19. 의존성 영향
+
+신규 런타임 의존 **없음**. React 18.3 (기존) + 브라우저 내장 API (`Intl.DateTimeFormat`, `Intl.Locale`, `Date`, `useId`, DOM 표준) 만 사용.
+
+번들 영향:
+- DatePicker 자체 예상 크기: ~7~9 KB (min), ~3~4 KB (min+gzip). 유사한 헤드리스 구현(react-day-picker headless core) 대비 30~40% 작은 수준으로 예측 — 이유: `date-fns` 미사용으로 ~15 KB 절감.
+- plastic 전체 dist 영향: 기존 Popover/PathInput 을 재사용하므로 추가 footprint 는 DatePicker 파일군 본체만.
+
+Browser 지원:
+- `Intl.DateTimeFormat`, `Intl.Locale`: 모든 모던 브라우저.
+- `Intl.Locale.prototype.getWeekInfo`: Chrome 99+, Firefox 회피(폴백 경로 보유), Safari 16+. 폴백이 있으므로 지원 대상에 포함.
+- `useId`: React 18+.
+
+---
+
+## 20. 구현 완료 정의 (Definition of Done)
+
+- [ ] `npm run typecheck` 통과.
+- [ ] `npx tsup` 통과 (타입 선언 포함).
+- [ ] demo 에 `/#/datepicker` 라우트 동작.
+- [ ] §13.2 수동 체크리스트 항목 전부 눈으로 확인.
+- [ ] §13.3 엣지 케이스 항목 전부 눈으로 확인 또는 "v1 범위 밖" 이유 기재.
+- [ ] 다른 페이지(CommandPalette, SplitPane, PipelineGraph, CodeView, HexView, DataTable 등) 리그레션 없음.
+- [ ] `src/components/index.ts` 배럴에 `export * from "./DatePicker";` 추가됨.
+- [ ] `package.json` dependencies 변경 없음 (신규 의존 없음).
+- [ ] Props 문서 섹션이 Props 표로 채워져 있음 (Root / Input / Trigger / Calendar / Header / Nav / MonthLabel / Grid / Day / Footer).
+- [ ] Usage 섹션에 최소 4 개 스니펫 (basic / range / ko-KR+주말 비활성 / controlled).
+- [ ] 데모 Playground 에서 모든 prop 토글 가능.
+- [ ] Light/Dark 테마 전환 시 시각 이상 없음.
+- [ ] 키보드 단독으로 (마우스 없이) Basic/Range 양쪽 선택 완료 가능.
+- [ ] 스크린리더(VoiceOver) 에서 "dialog" 진입, month label 변경, 날짜 셀 label(full date) 전부 읽힘.
+- [ ] `Intl.DateTimeFormat` 이외의 외부 날짜 라이브러리 import 없음 (eslint/수동 grep 검증: `import .* from "date-fns|dayjs|luxon|moment"` 0 건).
+- [ ] ko-KR / en-US 두 locale 에서 각각 월 라벨·weekday 라벨·ARIA full date 가 자연스러움.
+
+---
+
+**끝.**

--- a/docs/plans/016-tabs-component.md
+++ b/docs/plans/016-tabs-component.md
@@ -1,0 +1,1557 @@
+# Tabs 컴포넌트 설계문서
+
+## Context
+
+plastic 라이브러리에 "여러 개의 화면/섹션을 탭으로 전환하는 내비게이션 프리미티브" `Tabs` 를 추가한다. 역할 비유: VSCode 의 에디터 탭 바, Chrome 의 탭 UI, IntelliJ Tool Window 의 상단 탭, DevTools 의 Elements/Console/Network 전환. 이 컴포넌트는 IDE 스타일 UI 의 기본 조립 블록이며, plastic 상위에서 `PipelineGraphInspector` 가 이미 자체적으로 Logs/Timing/Error 탭 UI 를 임시 구현하고 있다 — 이 구현을 추출·일반화하여 재사용 가능한 공용 컴포넌트로 승격하는 것이 목적이다.
+
+참고 (prior art — UX 근거):
+- **Radix UI `Tabs`** — compound API (`Root`/`List`/`Trigger`/`Content`), activation mode("automatic" | "manual"), controlled/uncontrolled 이중 API, 완전한 ARIA. 본 설계의 가장 가까운 모델.
+- **Headless UI `<Tab.Group>`** — render-props 기반, index 기반 selection. plastic 은 "key 기반 value" 로 다르게 가되 keyboard/ARIA 는 유사 규약.
+- **Ant Design `Tabs`** — `items` prop 선언형, closable ×, overflow scroll(⟨ ⟩ 버튼), lazy-mount(`destroyInactiveTabPane`), centered/card/editable 여러 type. plastic v1 은 closable + overflow scroll + lazy-mount 만 채택.
+- **VSCode 에디터 탭 바** — active 탭 아래 2 px indicator, close ×, overflow 시 arrow scroll, drag reorder (plastic 은 reorder 를 v1.1 로 연기).
+- **Chrome 탭 바** — title + favicon + ×, overflow compression. plastic 은 title + icon + × 를 지원하되 compression 대신 scroll.
+- **Material UI `Tabs`** — `variant="scrollable"` 모드 시 양 끝 arrow 버튼, underline indicator transition. plastic 의 indicator transition 직접 벤치마크.
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/PipelineGraph/PipelineGraphInspector.tsx` — 이미 Logs/Timing/Error 탭 UI 를 자체 구현 중 (내부 `tab` state + `button` 3개). plastic `Tabs` 로 교체할 수 있는 **추출 대상**. 후속 PR 로 분리 (§17).
+- `src/components/_shared/useControllable.ts` — controlled/uncontrolled 이중 API 표준 훅. `value` / `defaultValue` / `onValueChange` 에 그대로 적용.
+- `src/components/index.ts` — 배럴에 한 줄 추가.
+- `demo/src/App.tsx` — 데모 NAV 추가 대상. 사이드바 + 본문 라우팅 패턴.
+- `demo/src/pages/CommandPalettePage.tsx` — 데모 페이지 레이아웃 · Props 표 · Usage · Playground 섹션 구조 레퍼런스.
+- `tsconfig.json` — `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax` 제약.
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+<Tabs.Root
+  defaultValue="logs"                 // uncontrolled 초기값
+  orientation="horizontal"            // "horizontal" | "vertical"
+  activationMode="automatic"          // "automatic" (default) | "manual"
+  theme="light"
+  onValueChange={(v) => console.log(v)}
+>
+  <Tabs.List aria-label="Inspector tabs">
+    <Tabs.Trigger value="logs">Logs</Tabs.Trigger>
+    <Tabs.Trigger value="timing">Timing</Tabs.Trigger>
+    <Tabs.Trigger value="error" disabled>Error</Tabs.Trigger>
+    <Tabs.Trigger value="draft" closable onClose={(v) => remove(v)}>Draft</Tabs.Trigger>
+  </Tabs.List>
+
+  <Tabs.Content value="logs"><LogsPanel /></Tabs.Content>
+  <Tabs.Content value="timing" forceMount={false}><TimingPanel /></Tabs.Content>
+  <Tabs.Content value="error"><ErrorPanel /></Tabs.Content>
+  <Tabs.Content value="draft"><DraftPanel /></Tabs.Content>
+</Tabs.Root>
+```
+
+렌더 결과 (개념, horizontal):
+```
+┌──────────────────────────────────────────────────────────────┐
+│ ⟨  [Logs]  Timing   Error(d)   Draft ×   + more...         ⟩ │   ← Tabs.List (scrollable + overflow arrows)
+│ ────────                                                     │   ← active indicator (2px, transition)
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│                   <Tabs.Content value="logs">                │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+렌더 결과 (개념, vertical):
+```
+┌──────────┬──────────────────────────────────┐
+│ ▸ Logs   │                                  │
+││ Timing  │     Content of active tab        │
+│  Error   │                                  │
+│  Draft × │                                  │
+│    ⋮     │                                  │
+└──────────┴──────────────────────────────────┘
+   ↑
+ indicator (left border 2px on active)
+```
+
+핵심 설계 원칙:
+- **compound 컴포넌트**. `Root`/`List`/`Trigger`/`Content` 4 계층. Context 를 통해 value 상태 + orientation + activation mode 공유.
+- **value 는 string 고정**(v1). index 기반이 아닌 key 기반 — Radix 규약. 동적 추가/제거에도 안정적 매칭.
+- **controlled/uncontrolled 이중 API**. `value`/`defaultValue`/`onValueChange`. `useControllable` 훅 그대로 사용.
+- **activation mode**: `automatic` 은 화살표로 이동하면 즉시 해당 탭 activate(= content 전환). `manual` 은 화살표로 focus 만 이동하고 Enter/Space 로 activate. WAI-ARIA tab pattern 따름.
+- **overflow scroll**: 탭 수가 List 폭을 초과하면 양 끝 `⟨ ⟩` arrow 버튼이 자동 노출. 클릭 시 scrollBy, active 탭이 viewport 밖일 때 `scrollIntoView({ inline: "nearest" })` 자동 호출.
+- **closable `×`**: 개별 Trigger 에 `closable` + `onClose(value)` prop. plastic 은 close 후의 상태(다음 active, 리스트에서 제거) 는 **owner(app) 가 결정** — controlled 패턴으로 일관.
+- **lazy-mount**: 기본은 active 탭의 Content 만 렌더. `forceMount` 지정 시 항상 렌더 (iframe/비싼 컨텐츠 캐시 목적).
+- **animated indicator**: active 탭 아래(또는 좌측)의 2 px 라인이 transform 으로 부드럽게 이동. `requestAnimationFrame` + trigger 의 `offsetLeft/offsetWidth` 측정.
+- **런타임 의존 zero**. DOM + React 만. ResizeObserver / pointer / keyboard 는 web standard.
+- **접근성 · 키보드 우선**. `role="tablist"`/`"tab"`/`"tabpanel"`, `aria-selected`, `aria-controls`, `aria-labelledby`, roving tabindex (-1 for inactive).
+- **v1 은 reorder 제외**. drag reorder / 새 창 drag-out / 컨텍스트 메뉴 는 v1.1 이후 (§17).
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. 수평/수직 오리엔테이션(`orientation`: `"horizontal"` | `"vertical"`).
+2. automatic / manual activation mode (WAI-ARIA tab pattern 준수).
+3. controlled/uncontrolled 이중 API: `value`/`defaultValue`/`onValueChange`.
+4. closable `×` 버튼 (선택적, per-Trigger). `onClose(value)` 콜백.
+5. overflow scroll: 탭이 List 폭을 초과하면 양 끝 `⟨ ⟩` 버튼 노출. active 탭 자동 스크롤 in-view.
+6. lazy-mount: 기본은 active 만, `forceMount` 로 항상 렌더 선택 가능.
+7. animated indicator: active 탭 아래(horizontal) 또는 좌측(vertical) 2 px 인디케이터의 transform 기반 transition (200 ms).
+8. 키보드 내비게이션: Arrow(automatic 자동 activate / manual 은 focus 만), Home / End, Enter / Space (manual activate), Delete (closable 일 때 close).
+9. disabled 탭: 선택 불가, focus skip.
+10. Light / Dark 테마.
+11. RTL 대응: horizontal 에서 ArrowLeft/ArrowRight 의미 반전.
+12. ARIA 완전 지원: `role=tablist/tab/tabpanel`, `aria-selected`, `aria-orientation`, `aria-controls`, `aria-labelledby`, `tabindex` roving.
+
+### Non-goals (v1 제외)
+- **drag reorder**: 탭을 드래그해 순서 변경. v1.1.
+- **drag-out to new window** (Chrome 식): v1.2+.
+- **컨텍스트 메뉴** (우클릭 "close others / close right / pin ..."): v1.1.
+- **pin tab**: 고정 탭. v1.1.
+- **dirty indicator (●)**: 저장 안 됨 표시 점. 사용자가 Trigger children 에 직접 그려 넣을 수 있으므로 v1 은 API 제공 안 함. v1.2 에서 `dirty?: boolean` 고려.
+- **compression overflow** (탭이 좁아지며 글자 줄이기): v1 은 스크롤 방식. compression 은 v1.2.
+- **`type="card"` / `type="editable-card"`** (Ant Design 스타일): 시각 variant. v1 은 기본 underline 만. CSS 커스터마이즈로 대부분 커버 가능.
+- **add-new-tab (+) 버튼**: 사용자가 List 바깥에 자유롭게 배치하거나, 특별 Trigger 로 두어도 됨. v1 은 전용 API 제공 안 함.
+- **async Content (Suspense wrapper)**: 사용자가 Content 내부에서 직접 Suspense 를 두면 됨. v1 은 Tabs 자체의 suspense API 없음.
+- **animation variant**: 현재는 indicator transition 만. Content 전환(fade/slide)은 v1.2.
+- **nested Tabs**: 사용자는 Content 안에 또다른 Tabs.Root 를 자유롭게 중첩 가능. 추가 API 없음.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Tabs/Tabs.types.ts`
+
+```ts
+export type TabsTheme = "light" | "dark";
+export type TabsOrientation = "horizontal" | "vertical";
+export type TabsActivationMode = "automatic" | "manual";
+
+export interface TabsRootProps {
+  /** 초기 value (uncontrolled). */
+  defaultValue?: string;
+  /** 제어 value. 지정 시 controlled. */
+  value?: string;
+  /** value 변경 콜백. */
+  onValueChange?: (value: string) => void;
+
+  /** 오리엔테이션. 기본 "horizontal". */
+  orientation?: TabsOrientation;
+  /** 활성화 모드. 기본 "automatic". */
+  activationMode?: TabsActivationMode;
+
+  /** 라이트/다크. 기본 "light". */
+  theme?: TabsTheme;
+
+  /** 비활성(전체). 기본 false. */
+  disabled?: boolean;
+
+  /** 루트 요소의 id. 내부 ARIA id 생성의 접두사로 사용. 미지정 시 useId. */
+  id?: string;
+
+  /** 추가 className / style (root). */
+  className?: string;
+  style?: React.CSSProperties;
+
+  /** 자식: List, Content... */
+  children: React.ReactNode;
+}
+
+export interface TabsListProps {
+  /** 접근성 라벨. 스크린리더용. */
+  "aria-label"?: string;
+  /** 다른 요소로부터 라벨을 참조 (`aria-label` 대신 사용 가능). */
+  "aria-labelledby"?: string;
+
+  /** 오버플로우 시 좌우 scroll 버튼 노출 여부. 기본 true. */
+  scrollable?: boolean;
+
+  /** 추가 className / style */
+  className?: string;
+  style?: React.CSSProperties;
+
+  /** 자식: Trigger 들 */
+  children: React.ReactNode;
+}
+
+export interface TabsTriggerProps {
+  /** 식별자 (Content 와 매칭). 필수. */
+  value: string;
+
+  /** 해당 탭 비활성. 기본 false. */
+  disabled?: boolean;
+
+  /** × 닫기 버튼 노출. 기본 false. */
+  closable?: boolean;
+  /** × 클릭/Delete 키 입력 시 호출. closable=true 인 경우 필수. */
+  onClose?: (value: string) => void;
+
+  /** 앞쪽 아이콘 슬롯. */
+  icon?: React.ReactNode;
+
+  /** 추가 className / style */
+  className?: string;
+  style?: React.CSSProperties;
+
+  /** 트리거 라벨 */
+  children: React.ReactNode;
+}
+
+export interface TabsContentProps {
+  /** 매칭 value. 필수. */
+  value: string;
+
+  /**
+   * true 로 지정하면 inactive 일 때도 DOM 에 계속 렌더.
+   * (iframe/무거운 컨텐츠 캐시 목적.) 기본 false.
+   * inactive 일 때는 `hidden` 속성 + aria-hidden="true" 로 접근성 차단.
+   */
+  forceMount?: boolean;
+
+  /** 추가 className / style */
+  className?: string;
+  style?: React.CSSProperties;
+
+  /** 컨텐츠 */
+  children: React.ReactNode;
+}
+```
+
+### 2.2 배럴
+
+```ts
+// src/components/Tabs/index.ts
+export { Tabs } from "./Tabs";
+export type {
+  TabsRootProps,
+  TabsListProps,
+  TabsTriggerProps,
+  TabsContentProps,
+  TabsTheme,
+  TabsOrientation,
+  TabsActivationMode,
+} from "./Tabs.types";
+```
+
+그리고 `src/components/index.ts` 에 `export * from "./Tabs";` 한 줄 추가.
+
+### 2.3 Compound namespace
+
+```ts
+// Tabs.tsx
+export const Tabs = {
+  Root: TabsRoot,
+  List: TabsList,
+  Trigger: TabsTrigger,
+  Content: TabsContent,
+};
+```
+
+사용자는 `<Tabs.Root>…</Tabs.Root>`, `<Tabs.List>`, `<Tabs.Trigger>`, `<Tabs.Content>` 형태로 접근. `displayName` 은 각각 `"Tabs.Root"`, `"Tabs.List"`, `"Tabs.Trigger"`, `"Tabs.Content"`.
+
+---
+
+## 3. 도메인 모델
+
+### 3.1 value ↔ tab id 매핑
+
+- 사용자가 제공하는 식별자는 **`value: string`** 단일 키.
+- 내부 ARIA id 는 root 의 `id`(또는 `useId()`) 를 접두사로, 각 trigger/content 가 `-trigger-${value}` / `-content-${value}` 접미어를 붙여 생성:
+  - trigger element id = `${rootId}-trigger-${value}`
+  - content element id = `${rootId}-content-${value}`
+- 이로써 `aria-controls` / `aria-labelledby` 를 양방향으로 연결 가능:
+  - trigger: `aria-controls="{contentId}"`
+  - content: `aria-labelledby="{triggerId}"`
+- `value` 는 **DOM id-safe 해야 함** (공백/특수문자 회피 권장). 검증은 dev warn 만 하고 강제하지 않음.
+- 중복 `value` 는 dev warn + 마지막 것만 유효 (React key 경고도 동시 발생).
+
+### 3.2 등록(registry) 패턴
+
+여러 Trigger 가 동일 Root 하위에 존재하며, 키보드 내비게이션 시 "등록 순서" 로 이웃 탭을 찾아야 한다. 접근 방법 비교:
+
+1. **React.Children.map(children) 로 Root 가 직접 순회**:
+   Root 가 Trigger 들을 직접 알고 있어야 하는데, `<Tabs.List>` 가 사이에 끼어 있어 단순한 `Children.map` 으로는 Trigger 를 찾기 어렵다. `React.Children.toArray(root.children).find(List)` → `React.Children.toArray(list.children).filter(Trigger)` 식의 재귀가 필요하며, 사용자가 List 를 감싸는 div 를 끼워 넣으면 깨진다. **기각**.
+
+2. **Context + imperative register**:
+   Trigger 가 mount 시 Context 의 `register(value, el, disabled)` 를 호출하고, unmount 시 `unregister(value)`. Root 가 등록된 탭의 `value` 순서 배열을 유지. 등록 순서는 **mount 순서** — React 는 DOM 순서대로 effect 가 실행되므로 자연스럽게 DOM 순서와 일치.
+
+v1 은 **패턴 2** 채택. Radix 와 동일 전략.
+
+```ts
+interface RegisteredTab {
+  value: string;
+  element: HTMLElement;
+  disabled: boolean;
+  closable: boolean;
+}
+
+interface TabsContextValue {
+  rootId: string;
+  value: string | null;
+  setValue: (v: string) => void;
+  orientation: TabsOrientation;
+  activationMode: TabsActivationMode;
+  theme: TabsTheme;
+  disabled: boolean;
+  rtl: boolean;
+
+  register: (tab: RegisteredTab) => () => void;
+  getTabs: () => RegisteredTab[];
+  onTriggerKeyDown: (e: React.KeyboardEvent, value: string) => void;
+  onClose?: (value: string) => void;
+}
+```
+
+`getTabs()` 는 register 된 탭들을 **DOM 순서** 로 정렬해 반환. DOM 순서 정렬은:
+```ts
+function getTabs(): RegisteredTab[] {
+  const list = Array.from(registeredRef.current.values());
+  list.sort((a, b) => {
+    const pos = a.element.compareDocumentPosition(b.element);
+    if (pos & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+    if (pos & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+    return 0;
+  });
+  return list;
+}
+```
+
+### 3.3 controlled / uncontrolled
+
+`useControllable<string | null>(value, defaultValue ?? null, onValueChange)` 그대로. 단 초기에 `defaultValue` 가 없고 `value` 도 없는 경우(모두 undefined): **첫 번째로 register 된 non-disabled Trigger 의 value** 를 초기값으로 설정 (Radix 동일). 이를 위해 내부적으로 `internalValue === null` 상태일 때 register 콜백에서 첫 호출만 `setValue(tab.value)` 호출.
+
+### 3.4 inactive → active 전환 시 focus 이동
+
+키보드로 activate(automatic 은 Arrow, manual 은 Enter/Space) 했을 때는 **새 activate 된 trigger 에 focus 이동**. 마우스 클릭으로 activate 한 경우는 사용자 의도가 불명확하므로 focus 는 클릭된 요소(click 자동 focus)에 남겨 둠.
+
+---
+
+## 4. 시각 / 구조 설계
+
+### 4.1 DOM 구조 (horizontal 기준)
+
+```
+<div class="tabs-root" data-orientation="horizontal" data-theme="light">
+  <div class="tabs-list-wrap">
+    <button class="tabs-scroll-btn tabs-scroll-btn--start" aria-label="Scroll tabs left" hidden={!canScrollStart}>⟨</button>
+
+    <div role="tablist"
+         class="tabs-list"
+         aria-orientation="horizontal"
+         aria-label="{aria-label}"
+         style="overflow-x:auto; scroll-behavior:smooth">
+
+      <button role="tab"
+              id="{rootId}-trigger-logs"
+              aria-selected="true"
+              aria-controls="{rootId}-content-logs"
+              tabindex="0"
+              data-state="active"
+              data-disabled="false"
+              class="tabs-trigger">
+        <span class="tabs-trigger-icon">📜</span>
+        <span class="tabs-trigger-label">Logs</span>
+        {/* no close button: closable=false */}
+      </button>
+
+      <button role="tab"
+              id="{rootId}-trigger-draft"
+              aria-selected="false"
+              aria-controls="{rootId}-content-draft"
+              tabindex="-1"
+              data-state="inactive"
+              class="tabs-trigger">
+        <span class="tabs-trigger-label">Draft</span>
+        <span role="button"
+              aria-label="Close Draft"
+              tabindex="-1"
+              class="tabs-trigger-close"
+              onClick={(e) => { e.stopPropagation(); onClose("draft"); }}>
+          ×
+        </span>
+      </button>
+
+      <div class="tabs-indicator"
+           style="transform: translateX({offsetLeft}px); width: {offsetWidth}px" />
+    </div>
+
+    <button class="tabs-scroll-btn tabs-scroll-btn--end" aria-label="Scroll tabs right" hidden={!canScrollEnd}>⟩</button>
+  </div>
+
+  <div role="tabpanel"
+       id="{rootId}-content-logs"
+       aria-labelledby="{rootId}-trigger-logs"
+       tabindex="0"
+       data-state="active"
+       class="tabs-content">
+    {children}
+  </div>
+  <div role="tabpanel"
+       id="{rootId}-content-draft"
+       aria-labelledby="{rootId}-trigger-draft"
+       tabindex="0"
+       data-state="inactive"
+       hidden
+       class="tabs-content">
+    {children /* forceMount 면 항상 렌더, 아니면 unmount */}
+  </div>
+</div>
+```
+
+vertical 은:
+- `data-orientation="vertical"`, `aria-orientation="vertical"`
+- List 레이아웃이 `flex-direction: column`.
+- 인디케이터가 left border(transform: translateY). scroll 은 `overflow-y:auto` + 상/하 arrow 버튼.
+- Content 는 List 옆(flex row)에 위치 — 단, DOM 순서는 여전히 List 다음에 Content. 시각 배치는 `display:flex` + CSS 로 해결.
+
+### 4.2 flex-based list layout
+
+```css
+.tabs-list-wrap {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+}
+.tabs-list {
+  display: flex;
+  flex: 1 1 0;
+  overflow-x: auto;
+  scrollbar-width: none;       /* Firefox */
+  scroll-behavior: smooth;
+  position: relative;          /* indicator absolute 기준 */
+}
+.tabs-list::-webkit-scrollbar { display: none; }
+```
+
+스크롤바 숨김 이유: 탭 바는 일반 스크롤 영역이 아니므로 스크롤바 표시가 시각 노이즈. arrow 버튼으로 대체. 키보드(Arrow) 로도 스크롤 대체 가능.
+
+vertical 은 `.tabs-list { flex-direction: column; overflow-y: auto; overflow-x: hidden; }` + `.tabs-list-wrap { flex-direction: column }`.
+
+### 4.3 trigger 스타일
+
+```css
+.tabs-trigger {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 8px 12px;
+  font: inherit;
+  color: var(--tabs-trigger-fg);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  position: relative;
+  user-select: none;
+  border-radius: 0;
+  transition: color 120ms, background 120ms;
+}
+.tabs-trigger:hover:not([data-disabled="true"]) {
+  color: var(--tabs-trigger-hover-fg);
+  background: var(--tabs-trigger-hover-bg);
+}
+.tabs-trigger[data-state="active"] {
+  color: var(--tabs-trigger-active-fg);
+}
+.tabs-trigger[data-disabled="true"] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.tabs-trigger:focus-visible {
+  outline: 2px solid var(--tabs-focus-ring);
+  outline-offset: -2px;
+}
+.tabs-trigger-close {
+  width: 18px; height: 18px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 120ms, background 120ms;
+  cursor: pointer;
+}
+.tabs-trigger:hover .tabs-trigger-close,
+.tabs-trigger[data-state="active"] .tabs-trigger-close,
+.tabs-trigger-close:focus-visible {
+  opacity: 1;
+}
+.tabs-trigger-close:hover {
+  background: var(--tabs-close-hover-bg);
+}
+```
+
+### 4.4 active indicator
+
+horizontal:
+```css
+.tabs-indicator {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  background: var(--tabs-indicator-bg);
+  transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1),
+              width 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  pointer-events: none;
+  will-change: transform, width;
+}
+```
+
+vertical:
+```css
+.tabs-root[data-orientation="vertical"] .tabs-indicator {
+  top: 0; left: 0;
+  width: 2px; height: 0;
+  transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1),
+              height 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+```
+
+JS 로 active trigger 의 `offsetLeft/offsetWidth`(또는 `offsetTop/offsetHeight`) 를 측정해 CSS 변수 또는 inline style 로 주입:
+
+```ts
+useLayoutEffect(() => {
+  if (!value) return;
+  const tab = getTabs().find(t => t.value === value);
+  if (!tab) return;
+  const el = tab.element;
+  if (orientation === "horizontal") {
+    indicatorRef.current!.style.transform = `translateX(${el.offsetLeft}px)`;
+    indicatorRef.current!.style.width     = `${el.offsetWidth}px`;
+  } else {
+    indicatorRef.current!.style.transform = `translateY(${el.offsetTop}px)`;
+    indicatorRef.current!.style.height    = `${el.offsetHeight}px`;
+  }
+}, [value, orientation, containerPx /* List size observer */]);
+```
+
+첫 마운트에서는 `transition` 을 잠시 제거(`data-first="true"` → 다음 frame 에 제거)해서 불필요한 애니메이션을 방지.
+
+### 4.5 palette 토큰
+
+```ts
+// Tabs/theme.ts
+export const tabsPalette = {
+  light: {
+    rootBg:              "transparent",
+    listBorder:          "rgba(0,0,0,0.08)",
+    triggerFg:           "#6b7280",
+    triggerHoverFg:      "#111827",
+    triggerHoverBg:      "rgba(0,0,0,0.03)",
+    triggerActiveFg:     "#2563eb",
+    indicatorBg:         "#2563eb",
+    closeHoverBg:        "rgba(0,0,0,0.08)",
+    scrollBtnFg:         "#6b7280",
+    scrollBtnHoverBg:    "rgba(0,0,0,0.05)",
+    focusRing:           "#2563eb",
+    disabledFg:          "rgba(0,0,0,0.35)",
+  },
+  dark: {
+    rootBg:              "transparent",
+    listBorder:          "rgba(255,255,255,0.08)",
+    triggerFg:           "#9ca3af",
+    triggerHoverFg:      "#f3f4f6",
+    triggerHoverBg:      "rgba(255,255,255,0.04)",
+    triggerActiveFg:     "#60a5fa",
+    indicatorBg:         "#60a5fa",
+    closeHoverBg:        "rgba(255,255,255,0.1)",
+    scrollBtnFg:         "#9ca3af",
+    scrollBtnHoverBg:    "rgba(255,255,255,0.06)",
+    focusRing:           "#60a5fa",
+    disabledFg:          "rgba(255,255,255,0.3)",
+  },
+} as const;
+```
+
+`data-theme` attribute 로 root 에 부착하고 CSS 변수로 전파:
+
+```css
+.tabs-root[data-theme="light"] {
+  --tabs-trigger-fg:        #6b7280;
+  --tabs-trigger-hover-fg:  #111827;
+  --tabs-trigger-hover-bg:  rgba(0,0,0,0.03);
+  --tabs-trigger-active-fg: #2563eb;
+  --tabs-indicator-bg:      #2563eb;
+  --tabs-close-hover-bg:    rgba(0,0,0,0.08);
+  --tabs-scroll-btn-fg:     #6b7280;
+  --tabs-scroll-btn-bg:     rgba(0,0,0,0.05);
+  --tabs-focus-ring:        #2563eb;
+  --tabs-list-border:       rgba(0,0,0,0.08);
+}
+.tabs-root[data-theme="dark"] {
+  --tabs-trigger-fg:        #9ca3af;
+  /* ... */
+}
+```
+
+### 4.6 List 하단 border
+
+horizontal: List 아래에 1 px 하단 border, indicator 는 이 border 위에 겹치게 (z-index > 0). vertical: List 우측에 1 px 우측 border.
+
+```css
+.tabs-list::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 1px;
+  background: var(--tabs-list-border);
+  pointer-events: none;
+}
+.tabs-root[data-orientation="vertical"] .tabs-list::after {
+  left: auto; right: 0; top: 0; bottom: 0;
+  width: 1px; height: auto;
+}
+```
+
+### 4.7 RTL
+
+horizontal + `dir="rtl"` 일 때 List 는 브라우저가 자동으로 flex-direction 반전. indicator 의 `offsetLeft` 는 RTL 에서도 "왼쪽부터의 거리" 를 돌려주므로 그대로 사용 가능. 다만 스크롤 `scrollLeft` 의 부호가 브라우저마다 다르므로 (`scrollLeft < 0` on Firefox RTL), `element.scrollBy({ left })` 에서 `rtl ? -delta : delta` 로 조정.
+
+키보드 Arrow 의미: RTL 에서 ArrowLeft = "다음" / ArrowRight = "이전" 으로 반전 (§7).
+
+---
+
+## 5. 핵심 로직
+
+### 5.1 activation mode
+
+**automatic**: Trigger 가 focus 를 받는 순간 (= 화살표 키 이동, 클릭, 프로그램적 focus) 해당 탭이 즉시 activate.
+
+**manual**: 화살표 키는 focus 만 이동시키고, Enter/Space 로 activate. 클릭은 여전히 즉시 activate (click = intent).
+
+```ts
+function onTriggerKeyDown(e: React.KeyboardEvent, triggerValue: string) {
+  const tabs = getTabs().filter(t => !t.disabled);
+  const idx = tabs.findIndex(t => t.value === triggerValue);
+  if (idx < 0) return;
+
+  const isNext =
+    orientation === "horizontal"
+      ? (e.key === "ArrowRight") !== rtl
+      : e.key === "ArrowDown";
+  const isPrev =
+    orientation === "horizontal"
+      ? (e.key === "ArrowLeft") !== rtl
+      : e.key === "ArrowUp";
+
+  if (isNext || isPrev) {
+    e.preventDefault();
+    const nextIdx = isNext
+      ? (idx + 1) % tabs.length
+      : (idx - 1 + tabs.length) % tabs.length;
+    const next = tabs[nextIdx]!;
+    next.element.focus();
+    if (activationMode === "automatic") setValue(next.value);
+    return;
+  }
+
+  if (e.key === "Home") {
+    e.preventDefault();
+    const first = tabs[0];
+    if (first) {
+      first.element.focus();
+      if (activationMode === "automatic") setValue(first.value);
+    }
+    return;
+  }
+  if (e.key === "End") {
+    e.preventDefault();
+    const last = tabs[tabs.length - 1];
+    if (last) {
+      last.element.focus();
+      if (activationMode === "automatic") setValue(last.value);
+    }
+    return;
+  }
+  if (activationMode === "manual" && (e.key === "Enter" || e.key === " ")) {
+    e.preventDefault();
+    setValue(triggerValue);
+    return;
+  }
+  if (e.key === "Delete" || e.key === "Backspace") {
+    // closable 인 경우에만 onClose
+    const tab = tabs.find(t => t.value === triggerValue);
+    if (tab?.closable) {
+      e.preventDefault();
+      // root 의 onClose prop 또는 Trigger 개별 onClose 호출
+      // (per-trigger onClose 가 우선)
+      closeTab(triggerValue);
+    }
+    return;
+  }
+}
+```
+
+### 5.2 overflow scroll
+
+List 폭(`scrollWidth`) 이 자신의 clientWidth 를 초과하면 좌/우 arrow 버튼 노출.
+
+```ts
+const [canScrollStart, setCanScrollStart] = useState(false);
+const [canScrollEnd, setCanScrollEnd] = useState(false);
+
+useEffect(() => {
+  const el = listRef.current;
+  if (!el) return;
+  const update = () => {
+    const axis = orientation === "horizontal" ? "scrollLeft" : "scrollTop";
+    const maxAxis = orientation === "horizontal"
+      ? el.scrollWidth - el.clientWidth
+      : el.scrollHeight - el.clientHeight;
+    const s = Math.abs(el[axis]);   // RTL 음수 대응
+    setCanScrollStart(s > 1);
+    setCanScrollEnd(s < maxAxis - 1);
+  };
+  update();
+  el.addEventListener("scroll", update, { passive: true });
+  const ro = new ResizeObserver(update);
+  ro.observe(el);
+  // children 변경(add/remove)도 감지
+  const mo = new MutationObserver(update);
+  mo.observe(el, { childList: true });
+  return () => {
+    el.removeEventListener("scroll", update);
+    ro.disconnect();
+    mo.disconnect();
+  };
+}, [orientation]);
+```
+
+arrow 버튼 클릭:
+```ts
+function scrollBy(dir: 1 | -1) {
+  const el = listRef.current!;
+  const step = (orientation === "horizontal" ? el.clientWidth : el.clientHeight) * 0.8;
+  const signed = (orientation === "horizontal" && rtl) ? -dir * step : dir * step;
+  if (orientation === "horizontal") el.scrollBy({ left: signed, behavior: "smooth" });
+  else                              el.scrollBy({ top:  dir * step, behavior: "smooth" });
+}
+```
+
+active 탭이 viewport 밖이면 자동 스크롤:
+```ts
+useEffect(() => {
+  if (!value) return;
+  const tab = getTabs().find(t => t.value === value);
+  if (!tab) return;
+  tab.element.scrollIntoView({
+    behavior: "smooth",
+    inline: "nearest",
+    block: "nearest",
+  });
+}, [value]);
+```
+
+### 5.3 closable × 버튼 이벤트 처리
+
+`×` 클릭은 **Trigger 의 `onClick` 버블을 막아야** activate 가 일어나지 않는다:
+
+```tsx
+<button role="tab" onClick={() => setValue(value)} ...>
+  {children}
+  {closable && (
+    <span
+      role="button"
+      aria-label={`Close ${children}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClose?.(value);
+      }}
+      onPointerDown={(e) => e.stopPropagation()}
+      className="tabs-trigger-close"
+    >
+      ×
+    </span>
+  )}
+</button>
+```
+
+HTML 상 `<button>` 안에 interactive `<span role="button">` 은 공식적으론 정상이 아니지만, 실제 많은 라이브러리(Material UI, Ant)가 이 패턴을 사용. 대안은 Trigger 를 `<div>` 로 만들고 내부에 button 을 두 개 두는 것이지만, 루트 Trigger 가 `button` 이 아니면 스페이스/엔터 기본 제출이 번거로워진다. **v1 은 nested interactive 허용 (대신 inner span 은 `role="button"` + `tabindex=-1` + 키보드 Delete 로도 접근 가능).**
+
+close 후의 상태:
+- **controlled**: owner 가 list 에서 해당 value 제거 + 다음 value 로 setState. plastic 은 `onClose(value)` 만 알려주고 내부 상태 변경 없음. close 된 value 가 현재 active 였다면 owner 가 다음 value 를 선택해야 함.
+- **uncontrolled**: plastic 은 list/items 를 모르므로 자동 next selection 이 어렵다. 그러나 Trigger 자체가 DOM 에서 제거되면 (등록 해제) 현재 active value 가 "존재하지 않는 상태"가 된다. v1 정책: **unmount 시 current value 가 존재하지 않으면, 이웃(다음 → 이전) 중 첫 non-disabled 탭으로 fallback**. 이 처리는 register/unregister 시점에:
+  ```ts
+  const unregister = (val: string) => {
+    registered.current.delete(val);
+    if (value === val) {
+      // 다음 non-disabled 탭으로
+      const tabs = getTabs().filter(t => !t.disabled);
+      const next = tabs[0];
+      if (next) setValue(next.value);
+      else setValue(null as any /* no tabs */);
+    }
+  };
+  ```
+
+### 5.4 lazy-mount 컨텐츠
+
+```tsx
+function TabsContent({ value, forceMount, children, ... }: TabsContentProps) {
+  const ctx = useTabsContext();
+  const isActive = ctx.value === value;
+  if (!isActive && !forceMount) return null;
+  return (
+    <div
+      role="tabpanel"
+      id={`${ctx.rootId}-content-${value}`}
+      aria-labelledby={`${ctx.rootId}-trigger-${value}`}
+      tabIndex={0}
+      data-state={isActive ? "active" : "inactive"}
+      hidden={!isActive}
+      {...(!isActive ? { "aria-hidden": true } : {})}
+    >
+      {children}
+    </div>
+  );
+}
+```
+
+- `forceMount=false` (default): inactive 일 때 return null → 완전히 unmount. 무거운 컨텐츠 초기화 없음, 대신 탭 전환 때마다 재마운트(state 초기화).
+- `forceMount=true`: 항상 렌더, inactive 는 `hidden` + `aria-hidden`. 브라우저 `hidden` 속성은 `display:none` 과 동등하므로 layout/paint 비용 제거. iframe, video, 스크롤 위치 유지, 복잡한 리스트 가상화 등에 유용.
+
+### 5.5 포커스 관리 (roving tabindex)
+
+- List 안의 Trigger 들 중 오직 **active 탭만** `tabindex=0`. 나머지는 `tabindex=-1`.
+- 사용자가 Tab 으로 List 에 들어오면 active trigger 가 focus 받는다.
+- Arrow 로 이동 시 focus 는 이웃 trigger 로 프로그램적 이동.
+- Tab 으로 List 를 빠져나가면 active trigger 에 tabindex 가 남아 있으므로 다음 Tab 때 다시 그것이 focus.
+
+구현은 Trigger 에서:
+```tsx
+const isActive = ctx.value === value;
+<button
+  role="tab"
+  aria-selected={isActive}
+  tabIndex={isActive ? 0 : -1}
+  ...
+>
+```
+
+단, disabled trigger 는 `aria-disabled="true"` + `tabIndex={-1}` + click handler 무시. HTML `disabled` 도 추가하여 폼 제출 차단(inside form 맥락 고려).
+
+---
+
+## 6. 제약
+
+### 6.1 disabled
+
+- **전체 비활성** (`Tabs.Root disabled`): 모든 Trigger 가 disabled 처럼 동작. 활성 탭 전환 불가, keyboard/click 모두 무시. indicator / 인디케이터 위치는 현재 value 기준 유지.
+- **개별 비활성** (`Tabs.Trigger disabled`): 해당 탭만 선택 불가. 키보드 Arrow 이동 시 skip (§5.1). 클릭 무시.
+
+### 6.2 min size / overflow
+
+- List 의 최소 높이(horizontal) 는 trigger padding + font-size 기준으로 자연스럽게 결정. v1 은 고정값 강제 안 함.
+- Trigger 최소 너비 제약 없음. 긴 라벨은 `white-space: nowrap; text-overflow: ellipsis;` 없이 그대로(자연 폭). 라벨이 매우 길면 overflow scroll 로 감당.
+- 사용자가 label 자체에 `max-width` + ellipsis 를 CSS 로 줄 수 있음 (playground 예시에 포함).
+
+### 6.3 closable 제약
+
+- Trigger 개별 `closable=true` 이되 `onClose` 미지정 → dev warn `"closable=true requires onClose"`. × 버튼은 렌더되지만 클릭 시 no-op.
+- Delete 키 close 는 해당 trigger 가 focus 인 상태에서만.
+
+### 6.4 children 검증
+
+- `Tabs.Root` 자식은 `Tabs.List` 1 개 + `Tabs.Content` N 개. 순서 무관(Content 가 List 앞에 와도 DOM 상 동작은 함). 그러나 관용 순서는 List, Content... → dev warn: List 가 2 개 이상 있으면 warn, Content 가 없으면 warn(탭만 있고 패널 없음).
+- 잘못된 타입 자식(예: 일반 `<div>`): v1 은 런타임 검사 없이 통과(Context 가 없어 그냥 렌더). 사용자 의도이면 공간 차지 요소(구분선 등)로 허용.
+
+---
+
+## 7. 키보드
+
+Trigger 가 focus 상태에서:
+
+| 키 | 동작 (automatic) | 동작 (manual) |
+|---|---|---|
+| `ArrowRight` (horizontal) | 다음 trigger 로 focus + activate | focus 만 이동 |
+| `ArrowLeft` (horizontal) | 이전 trigger 로 focus + activate | focus 만 이동 |
+| `ArrowDown` (vertical) | 다음 trigger 로 focus + activate | focus 만 이동 |
+| `ArrowUp` (vertical) | 이전 trigger 로 focus + activate | focus 만 이동 |
+| `Home` | 첫 trigger 로 focus + activate | focus 만 이동 |
+| `End` | 마지막 trigger 로 focus + activate | focus 만 이동 |
+| `Enter` / `Space` | (no-op — 이미 automatic 이니 activate 상태) | 현재 focus trigger 를 activate |
+| `Delete` / `Backspace` | closable 이면 `onClose(value)` 호출 | 동일 |
+| `Tab` | List 밖으로 이동 (roving tabindex 덕) | 동일 |
+
+RTL 이면 horizontal 에서 ArrowRight/ArrowLeft 의 "다음/이전" 의미 반전. Home/End 는 여전히 "첫 번째/마지막 tab" 의미 (논리적 순서 기준).
+
+disabled trigger 는 keyboard 이동 시 skip (건너뛰기). "wrap around" 은 v1 에서 활성(마지막 → 다음 = 첫번째). Radix 는 default wrap. WAI-ARIA 는 wrap 가능하다고 허용.
+
+### 7.1 focus trap 없음
+
+List 안에서 Tab 을 누르면 List 밖으로 나간다(roving tabindex). 이는 tab pattern 의 표준 동작. List 내에서만 순환하는 focus trap 은 하지 않음.
+
+### 7.2 Content 안의 focusable
+
+Content 는 `tabindex=0` 이므로 Tab 순서 상 `Trigger → Content wrapper → Content 내부 요소` 순. "Tab 을 누르면 List 의 active trigger → Content 영역 자체 → Content 내부 첫 focusable" 로 자연스럽게 이동. 사용자가 Content wrapper 의 focus 를 생략하고 싶으면 `tabindex={-1}` 을 추가로 지정할 수 있지만 v1 은 default 0.
+
+### 7.3 추가 단축키 (v1 제외)
+
+- `Cmd+1~9` 로 N번째 탭: 브라우저 단축키 충돌. v1 제외.
+- `Ctrl+Tab` / `Ctrl+Shift+Tab` (Chrome 식): 브라우저 단축키 충돌. v1 제외.
+
+---
+
+## 8. 상태 관리
+
+### 8.1 Context 구성
+
+```ts
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+export function useTabsContext(): TabsContextValue {
+  const ctx = useContext(TabsContext);
+  if (!ctx) throw new Error("Tabs components must be used within <Tabs.Root>.");
+  return ctx;
+}
+```
+
+Root 에서:
+```tsx
+function TabsRoot(props: TabsRootProps) {
+  const rootId = useId();
+  const {
+    defaultValue,
+    value: controlledValue,
+    onValueChange,
+    orientation = "horizontal",
+    activationMode = "automatic",
+    theme = "light",
+    disabled = false,
+  } = props;
+
+  const [value, setValue] = useControllable<string | null>(
+    controlledValue ?? undefined,
+    defaultValue ?? null,
+    (v) => onValueChange?.(v as string),
+  );
+
+  const registered = useRef<Map<string, RegisteredTab>>(new Map());
+  const getTabs = useCallback(() => {
+    const list = Array.from(registered.current.values());
+    list.sort((a, b) => {
+      const pos = a.element.compareDocumentPosition(b.element);
+      if (pos & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+      if (pos & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+      return 0;
+    });
+    return list;
+  }, []);
+
+  const register = useCallback((tab: RegisteredTab) => {
+    registered.current.set(tab.value, tab);
+    // 첫 등록 + value 미설정 시 auto-select
+    if (value == null && !tab.disabled) {
+      setValue(tab.value);
+    }
+    return () => {
+      registered.current.delete(tab.value);
+      if (value === tab.value) {
+        const tabs = getTabs().filter(t => !t.disabled);
+        const next = tabs[0];
+        setValue(next ? next.value : (null as any));
+      }
+    };
+  }, [value, setValue, getTabs]);
+
+  // ...
+}
+```
+
+`useControllable` 은 `<T>` generic 이므로 `string | null` 로 사용. null 은 "아직 선택 없음" (초기 mount 첫 trigger 등록 직전) 의미.
+
+### 8.2 orientation / activationMode / theme 전파
+
+Context 에 실어 둔다. 하위 컴포넌트에서 동적 참조. Root 에서만 prop 을 받아 중복 지정 없음.
+
+### 8.3 controlled + close 상호작용
+
+controlled 모드에서 외부 owner 가 items 배열을 관리. close 시:
+- `onClose("draft")` 콜백 호출.
+- owner 는 items 에서 "draft" 제거 + 필요 시 다음 value 로 `value` prop 변경.
+- plastic 은 register/unregister 로 DOM 상태를 추적하되, controlled value 가 register 안 된 value 로 설정된 경우 dev warn.
+
+---
+
+## 9. 고유 기능
+
+### 9.1 closable × 버튼
+
+- per-Trigger `closable?: boolean`. 기본 false. true 시 `×` 아이콘이 hover/active/focus-within 시 노출.
+- per-Trigger `onClose?: (value) => void`. 부모가 list 조작.
+- Delete / Backspace 키로도 close 가능 (해당 trigger focus 상태).
+
+### 9.2 overflow scroll ⟨ ⟩
+
+- `scrollable` prop (List) — 기본 true. false 면 arrow 버튼 숨김(단순 overflow hidden).
+- active 탭이 viewport 밖이면 자동 `scrollIntoView`.
+- arrow 버튼은 `canScrollStart` / `canScrollEnd` 가 true 일 때만 노출 (`hidden` 속성 토글).
+- 클릭 시 `clientWidth * 0.8` 만큼 smooth scroll.
+- 키보드 Home/End 는 arrow 버튼 없이도 처음/끝 탭 이동 + scrollIntoView 발생.
+- horizontal 의 arrow 버튼 아이콘은 `⟨` / `⟩` (fallback `<` `>`), vertical 은 `▲` / `▼`.
+
+### 9.3 lazy-mount
+
+- default: active 가 아닌 content 는 DOM 에 없음 → first mount 시 초기화.
+- `forceMount` 지정 시 mount 유지, 비활성 시 `hidden` + `aria-hidden`.
+- 혼합 가능: 특정 content 만 `forceMount` (예: 복잡한 에디터 하나만 캐시).
+
+### 9.4 animated indicator
+
+- 첫 mount: transition 없이 바로 위치. `data-first-paint="true"` 를 한 프레임 적용 후 제거.
+- value 변경 시: `offsetLeft/offsetWidth` 기반 transform/width (또는 offsetTop/offsetHeight + translateY/height) transition.
+- List resize 시: ResizeObserver 로 감지해 재계산.
+- orientation 전환 시: 새 축으로 재계산.
+- inactive → active 바뀐 탭이 **스크롤로 인해** 현재 DOM 에서 안 보이는 경우에도 indicator 위치는 실제 offset 기준이며 `.tabs-list` 가 scroll container 이므로 indicator 도 함께 스크롤된다.
+
+---
+
+## 10. 파일 구조
+
+```
+src/components/Tabs/
+├── Tabs.tsx                # Root/List/Trigger/Content 조립, compound namespace
+├── Tabs.types.ts           # 공개 타입
+├── TabsContext.ts          # Context + useTabsContext
+├── useTabsIndicator.ts     # active 탭 위치 측정 → indicator style 업데이트 훅
+├── useTabsScroll.ts        # overflow scroll detection, arrow visibility, scrollIntoView
+├── theme.ts                # tabsPalette
+└── index.ts                # 배럴
+```
+
+책임 분리:
+
+- **Tabs.tsx**
+  - `TabsRoot`: Context 생성, `useControllable`, registry(Map), rtl 감지, root DOM (`<div data-orientation data-theme>`).
+  - `TabsList`: `role="tablist"`, arrow 버튼 2개(`TabsScrollButton` 내부 렌더), 인디케이터 `<div>` 렌더.
+  - `TabsTrigger`: `role="tab"`, 등록(effect), 클릭/키보드 핸들러, close ×.
+  - `TabsContent`: `role="tabpanel"`, lazy-mount / forceMount.
+  - 네 컴포넌트를 `Tabs` 객체로 묶어 export.
+
+- **TabsContext.ts**
+  - `TabsContext`, `useTabsContext`.
+
+- **useTabsIndicator.ts**
+  - `useLayoutEffect` + ResizeObserver 로 active trigger 위치 측정.
+  - indicator ref 에 style 적용.
+  - 첫 paint 감지 및 transition 일시 해제.
+
+- **useTabsScroll.ts**
+  - List ref 의 scroll/resize 감지 → `canScrollStart/end` 상태.
+  - `scrollBy(dir)` / `scrollIntoView(value)` 함수 반환.
+
+- **theme.ts**
+  - `tabsPalette` + CSS injector (lazy once).
+
+- **index.ts**
+  - `export { Tabs } from "./Tabs"` + 타입.
+
+---
+
+## 11. 구현 단계
+
+각 단계는 독립 커밋 권장. 각 커밋이 `npm run typecheck` + `npx tsup` 통과 상태.
+
+### Step 1 — 타입 + 배럴 + 테마 스켈레톤
+1. `Tabs.types.ts` 작성(§2.1 전부).
+2. `theme.ts` 작성(palette).
+3. `TabsContext.ts` 작성(타입만, value 는 null).
+4. `Tabs.tsx` placeholder: `export const Tabs = { Root: () => null, List: () => null, Trigger: () => null, Content: () => null };` 각 displayName 지정.
+5. `index.ts` 배럴.
+6. `src/components/index.ts` 에 `export * from "./Tabs";`.
+7. `npm run typecheck` 통과.
+8. 커밋: `feat(Tabs): 타입 + 테마 + 배럴 스켈레톤`.
+
+### Step 2 — Root + Context + Registry
+1. `TabsRoot` 실제 구현: `useControllable`, `useId`, registry Map, `register`/`getTabs`.
+2. Context value 생성 및 Provider 렌더.
+3. root DOM: `<div class="tabs-root" data-orientation data-theme>` + children 통과.
+4. `noUncheckedIndexedAccess` 로 `tabs[0]` 반환이 `RegisteredTab | undefined` → optional chaining.
+5. 커밋: `feat(Tabs): Root + Context + registry`.
+
+### Step 3 — List + Trigger + Content 기본 렌더
+1. `TabsList`: `role="tablist"`, aria-orientation, children 렌더.
+2. `TabsTrigger`: mount 시 register, unmount 시 unregister. `role="tab"`, aria-selected, tabindex roving, onClick = setValue.
+3. `TabsContent`: active 만 렌더(`forceMount` 는 step 8 에서). role/aria/id.
+4. 클릭으로 탭 전환 동작 확인.
+5. 기본 CSS 주입(한 번만).
+6. 커밋: `feat(Tabs): List/Trigger/Content 기본 구현`.
+
+### Step 4 — 키보드 내비게이션 + activationMode
+1. `onTriggerKeyDown` 핸들러: Arrow / Home / End / Enter / Space.
+2. `activationMode` 분기.
+3. disabled trigger skip.
+4. RTL 감지 (`getComputedStyle(root).direction`) + Arrow 부호 반전.
+5. 커밋: `feat(Tabs): 키보드 + activationMode`.
+
+### Step 5 — 인디케이터 (animated)
+1. `useTabsIndicator.ts`: active trigger 의 offsetLeft/Width 측정.
+2. indicator `<div>` 를 List 내부에 추가.
+3. `useLayoutEffect` + ResizeObserver(List).
+4. 첫 마운트 transition 회피(`data-first-paint`).
+5. orientation 전환 대응.
+6. 커밋: `feat(Tabs): active indicator transition`.
+
+### Step 6 — overflow scroll + arrow 버튼
+1. `useTabsScroll.ts`: `canScrollStart` / `canScrollEnd` 계산.
+2. `TabsScrollButton` (내부 컴포넌트): hidden 토글, onClick scrollBy.
+3. active 변경 시 `scrollIntoView` 자동.
+4. vertical 에서 상/하 버튼.
+5. 커밋: `feat(Tabs): overflow scroll + arrow 버튼`.
+
+### Step 7 — closable × + onClose
+1. Trigger `closable` + `onClose` prop.
+2. `×` span 렌더 + `stopPropagation`.
+3. Delete/Backspace 키 처리.
+4. 후 상태 전이(close 된 탭이 active 였으면 이웃으로 fallback): uncontrolled 일 때 register cleanup 에서 처리.
+5. 커밋: `feat(Tabs): closable + onClose`.
+
+### Step 8 — lazy-mount + forceMount
+1. `TabsContent` 의 `forceMount` 옵션.
+2. active=false + forceMount=false → return null.
+3. active=false + forceMount=true → `hidden` + `aria-hidden`.
+4. 커밋: `feat(Tabs): lazy-mount + forceMount`.
+
+### Step 9 — Dark 테마 + 전체 시각 정리
+1. palette dark 통합.
+2. `data-theme="dark"` 전파.
+3. 아이콘 슬롯 처리 (`icon` prop on Trigger).
+4. scrollbar 숨김 CSS.
+5. 커밋: `feat(Tabs): dark 테마 + 시각 정돈`.
+
+### Step 10 — 데모 페이지
+1. `demo/src/pages/TabsPage.tsx` 작성 (§12).
+2. `demo/src/App.tsx` NAV 에 `"tabs"` 추가 + Page 타입.
+3. 커밋: `feat(Tabs): 데모 페이지`.
+
+### Step 11 — Props 표 + Usage
+1. TabsPage 의 Props 섹션에 Root/List/Trigger/Content 네 개 표 작성.
+2. Usage 섹션 최소 4 개 (Basic / Vertical / Closable / Controlled).
+3. 커밋: `feat(Tabs): 데모 Props + Usage`.
+
+### Step 12 — (후속, 본 PR 외) PipelineGraphInspector 리팩터링
+1. `src/components/PipelineGraph/PipelineGraphInspector.tsx` 의 Logs/Timing/Error tab UI 를 plastic `Tabs` 로 교체.
+2. 기존 동작 유지(탭 스타일/색상 가이드). 단, plastic Tabs 의 기본 시각으로 자연 이행.
+3. 다른 agent 의 PipelineGraph 브랜치 병합 충돌 위험 → **별도 PR**.
+4. 커밋 메시지(후속 PR): `refactor(PipelineGraph): inspector 탭을 Tabs 로 교체`.
+
+> **주의**: 현재 레포에는 013~022 브랜치로 다른 agent 들이 병렬 작업 중. PipelineGraph 파일 수정이 포함된 리팩터링은 본 PR 범위 밖으로 분리.
+
+---
+
+## 12. 데모 페이지
+
+`demo/src/pages/TabsPage.tsx` 작성. 기존 페이지(`CommandPalettePage`, `PipelineGraphPage` 등) 구조 복제. 좌측 사이드바 섹션 앵커 + 우측 본문.
+
+### 12.1 NAV 추가 (App.tsx)
+
+```ts
+{ id: "tabs", label: "Tabs", description: "탭 전환 프리미티브", sections: [
+  { label: "Basic",                id: "basic" },
+  { label: "Vertical",             id: "vertical" },
+  { label: "Closable",             id: "closable" },
+  { label: "Overflow scroll",      id: "overflow" },
+  { label: "Auto vs Manual",       id: "activation" },
+  { label: "Lazy mount",           id: "lazy" },
+  { label: "Dark",                 id: "dark" },
+  { label: "Controlled",           id: "controlled" },
+  { label: "Playground",           id: "playground" },
+  { label: "Props",                id: "props" },
+  { label: "Usage",                id: "usage" },
+]},
+```
+
+`Page` 타입에 `"tabs"` 추가 + 하단 `{current === "tabs" && <TabsPage />}`.
+
+### 12.2 섹션 구성
+
+**Basic**
+```tsx
+<Tabs.Root defaultValue="logs">
+  <Tabs.List aria-label="Inspector tabs">
+    <Tabs.Trigger value="logs">Logs</Tabs.Trigger>
+    <Tabs.Trigger value="timing">Timing</Tabs.Trigger>
+    <Tabs.Trigger value="error">Error</Tabs.Trigger>
+  </Tabs.List>
+  <Tabs.Content value="logs">로그 출력...</Tabs.Content>
+  <Tabs.Content value="timing">타이밍 차트...</Tabs.Content>
+  <Tabs.Content value="error">에러 상세...</Tabs.Content>
+</Tabs.Root>
+```
+
+**Vertical**
+```tsx
+<div style={{ display: "flex", height: 300 }}>
+  <Tabs.Root orientation="vertical" defaultValue="general" style={{ display: "flex", flex: 1 }}>
+    <Tabs.List aria-label="Settings">
+      <Tabs.Trigger value="general">General</Tabs.Trigger>
+      <Tabs.Trigger value="account">Account</Tabs.Trigger>
+      <Tabs.Trigger value="appearance">Appearance</Tabs.Trigger>
+      <Tabs.Trigger value="advanced" disabled>Advanced</Tabs.Trigger>
+    </Tabs.List>
+    <div style={{ flex: 1, padding: 16 }}>
+      <Tabs.Content value="general">...</Tabs.Content>
+      <Tabs.Content value="account">...</Tabs.Content>
+      <Tabs.Content value="appearance">...</Tabs.Content>
+    </div>
+  </Tabs.Root>
+</div>
+```
+
+**Closable**
+```tsx
+function Demo() {
+  const [items, setItems] = useState([
+    { value: "a", label: "tab-a.ts" },
+    { value: "b", label: "tab-b.ts" },
+    { value: "c", label: "tab-c.ts" },
+  ]);
+  const [active, setActive] = useState("a");
+  return (
+    <Tabs.Root value={active} onValueChange={setActive}>
+      <Tabs.List>
+        {items.map((it) => (
+          <Tabs.Trigger
+            key={it.value}
+            value={it.value}
+            closable
+            onClose={(v) => {
+              const nextItems = items.filter(i => i.value !== v);
+              setItems(nextItems);
+              if (active === v) {
+                const next = nextItems[0];
+                if (next) setActive(next.value);
+              }
+            }}
+          >
+            {it.label}
+          </Tabs.Trigger>
+        ))}
+      </Tabs.List>
+      {items.map((it) => (
+        <Tabs.Content key={it.value} value={it.value}>
+          {it.label} 의 컨텐츠
+        </Tabs.Content>
+      ))}
+    </Tabs.Root>
+  );
+}
+```
+
+**Overflow scroll**
+```tsx
+<div style={{ maxWidth: 420 }}>
+  <Tabs.Root defaultValue="t1">
+    <Tabs.List>
+      {Array.from({ length: 20 }, (_, i) => (
+        <Tabs.Trigger key={`t${i+1}`} value={`t${i+1}`}>tab-{i+1}</Tabs.Trigger>
+      ))}
+    </Tabs.List>
+    {Array.from({ length: 20 }, (_, i) => (
+      <Tabs.Content key={`t${i+1}`} value={`t${i+1}`}>Content {i+1}</Tabs.Content>
+    ))}
+  </Tabs.Root>
+</div>
+```
+바로 아래에 "⟨ ⟩ 버튼이 양 끝에 나타나고, 키보드 End 누르면 자동 스크롤" 안내.
+
+**Auto vs Manual**
+같은 구성 두 개를 나란히:
+- 좌: `activationMode="automatic"` — ArrowKey 로 화살표 이동 시 content 가 즉시 전환.
+- 우: `activationMode="manual"` — ArrowKey 는 focus 만 이동, Enter/Space 로 activate.
+
+각 우측에 설명 텍스트.
+
+**Lazy mount**
+```tsx
+<Tabs.Root defaultValue="a">
+  <Tabs.List>
+    <Tabs.Trigger value="a">A (lazy)</Tabs.Trigger>
+    <Tabs.Trigger value="b">B (forceMount)</Tabs.Trigger>
+    <Tabs.Trigger value="c">C (lazy)</Tabs.Trigger>
+  </Tabs.List>
+  <Tabs.Content value="a"><LoggingMount name="A" /></Tabs.Content>
+  <Tabs.Content value="b" forceMount><LoggingMount name="B" /></Tabs.Content>
+  <Tabs.Content value="c"><LoggingMount name="C" /></Tabs.Content>
+</Tabs.Root>
+```
+`LoggingMount` 는 mount/unmount 시 `console.log` 기록. 콘솔을 열어 "A, C 는 전환마다 mount/unmount, B 는 한 번만 mount" 를 확인.
+
+**Dark**
+```tsx
+<div style={{ background: "#0f172a", padding: 16, borderRadius: 8 }}>
+  <Tabs.Root defaultValue="logs" theme="dark">
+    ...
+  </Tabs.Root>
+</div>
+```
+
+**Controlled**
+외부 state + 버튼으로 프로그램적 전환 데모 + active 표시.
+```tsx
+const [v, setV] = useState("logs");
+return (
+  <>
+    <div style={{ display: "flex", gap: 8, marginBottom: 8 }}>
+      <button onClick={() => setV("logs")}>→ Logs</button>
+      <button onClick={() => setV("timing")}>→ Timing</button>
+      <button onClick={() => setV("error")}>→ Error</button>
+      <code>active = {v}</code>
+    </div>
+    <Tabs.Root value={v} onValueChange={setV}>...</Tabs.Root>
+  </>
+);
+```
+
+**Playground**
+상단 컨트롤 바:
+- `orientation` 라디오 (horizontal / vertical)
+- `activationMode` 라디오 (automatic / manual)
+- `theme` 라디오 (light / dark)
+- `disabled` 체크박스
+- "탭 추가/제거" 버튼 + 현재 탭 리스트
+- `closable` 토글 (모든 탭에 적용)
+- `forceMount` 토글 (모든 content)
+- `scrollable` 토글
+
+아래에 `<Tabs.Root {...args}>` 렌더 + 실시간 JSON config 출력.
+
+**Props 표**
+Root/List/Trigger/Content 네 개의 표. 각 행: prop / 타입 / 기본값 / 설명. CommandPalettePage 의 Props 섹션 포맷 참조.
+
+**Usage (4개 스니펫)**
+1. Basic — 3 탭 automatic.
+2. VSCode 스타일 에디터 탭 — closable, overflow scroll, forceMount 혼합.
+3. Settings 사이드바 — vertical, manual activation.
+4. Controlled + 외부 라우터와 연동 (`useSearchParam("tab")` 가상 예).
+
+---
+
+## 13. 검증 계획
+
+### 13.1 자동화
+```bash
+cd /Users/neo/workspace/plastic
+npm run typecheck
+npx tsup
+```
+
+주의:
+- `exactOptionalPropertyTypes: true` — optional prop 은 `?:` 로 받고 내부에서 undefined 분기. 예: `onClose?: (value: string) => void` 를 부모로 넘길 때 `{...(onClose ? { onClose } : {})}` 같이 전개.
+- `noUncheckedIndexedAccess: true` — `tabs[0]` 은 `RegisteredTab | undefined`. optional chaining 필수.
+- `verbatimModuleSyntax: true` — 타입은 `import type { ... }`.
+
+### 13.2 수동 (demo dev server)
+```bash
+cd demo && npm run dev
+```
+
+체크리스트:
+- [ ] **Basic**: 클릭으로 탭 전환, 콘텐츠 교체, indicator 이동 부드러움.
+- [ ] **Keyboard (automatic)**: Tab 으로 List 진입, Arrow 로 이동 + 즉시 content 전환, Home/End 동작.
+- [ ] **Keyboard (manual)**: Arrow 는 focus 만, Enter/Space 로 activate.
+- [ ] **Disabled trigger**: 키보드 Arrow 이동 시 skip, 클릭 무반응, aria-disabled="true".
+- [ ] **Vertical**: 상하 Arrow, left border indicator, 세로 스크롤.
+- [ ] **Closable**: × hover/focus 시 노출, 클릭 시 Trigger click 안 됨, onClose(value) 호출. Delete 키 동작.
+- [ ] **Overflow scroll**: 좁은 컨테이너에서 양 끝 ⟨ ⟩ 버튼 토글, scrollBy smooth, active 탭 자동 스크롤 in-view.
+- [ ] **Lazy mount**: 전환마다 mount/unmount 확인 (콘솔 로그). forceMount 탭은 한 번만 mount.
+- [ ] **Dark**: 모든 요소가 다크 palette.
+- [ ] **Controlled**: 외부 버튼으로 value 변경 즉시 반영, 내부 클릭도 onValueChange.
+- [ ] **Indicator**: 탭 폭 다른 경우 transform/width 변환 부드러움, List 리사이즈 시 재계산.
+- [ ] **RTL**: `<div dir="rtl">` 로 감싸 ArrowLeft/Right 의미 반전 확인.
+- [ ] **Nested Tabs**: Content 안에 또다른 `Tabs.Root` — 독립 동작.
+- [ ] **Playground**: 모든 컨트롤 조합.
+- [ ] 기존 페이지 regression 없음 (CommandPalette/HexView/PipelineGraph/CodeView/DataTable).
+
+### 13.3 엣지 케이스
+- [ ] 모든 Trigger 가 disabled → active value 없음, indicator 숨김(width 0).
+- [ ] Trigger 0 개 → List 렌더, Content 없음. OK.
+- [ ] 동일 value 중복 → 두 번째 register 시 dev warn(콘솔), DOM 은 React key 경고도.
+- [ ] 매우 긴 label (> 200 chars) → 자연 폭(스크롤로 해결). CSS 로 `max-width` 주면 ellipsis 대체.
+- [ ] controlled value 가 등록되지 않은 값 → dev warn + indicator 숨김 + 모든 trigger inactive.
+- [ ] 중간에 Trigger 를 동적으로 추가/제거(mutation) → register/unregister + indicator 재계산.
+- [ ] 화면 resize → indicator · scroll 상태 업데이트.
+- [ ] orientation 동적 전환 → indicator 축 전환.
+- [ ] closable 인데 onClose 미지정 → dev warn, × 클릭 no-op.
+- [ ] Content forceMount 이면서 iframe 포함 → 전환 후에도 iframe 상태 유지(HISTORY 테스트).
+- [ ] 극단 small height vertical (< trigger height) → list 스크롤 동작.
+- [ ] activationMode 동적 전환 → 다음 키 이벤트부터 새 모드.
+
+### 13.4 a11y 수동 (VoiceOver)
+- [ ] List 진입 시 "tablist, X tabs" 읽힘.
+- [ ] 탭 focus 시 "Logs, selected, tab 1 of 3" 읽힘.
+- [ ] Arrow 이동 시 automatic 모드에서 "Timing, selected, tab 2 of 3" 읽힘.
+- [ ] manual 모드에서 Arrow 로 이동 시 "Timing, tab 2 of 3" (선택 안됨) 읽힘, Enter 후 "selected" 추가.
+- [ ] Content 진입 시 "tabpanel, Logs" (aria-labelledby) 읽힘.
+- [ ] disabled trigger: "dimmed" 또는 "disabled" 힌트.
+
+---
+
+## 14. 성능
+
+### 14.1 목표
+- 탭 수 100 개까지도 초기 mount < 20 ms.
+- 탭 전환(content 교체) < 16 ms (60 fps 유지).
+- indicator transition 은 GPU 합성만 (transform/width는 width 만 layout trigger, 이는 허용).
+
+### 14.2 병목 + 완화
+1. **매 렌더마다 registry 재구성**: register/unregister 가 effect 기반이므로 렌더마다 발생 안 함. 실제 DOM mount/unmount 시에만.
+2. **value 변경 시 모든 Trigger re-render**: Context value 가 바뀌므로 모든 구독자 재렌더. 완화:
+   - Trigger 내부는 가벼운 span. 100 개 trigger 재렌더도 < 3 ms.
+   - 필요 시 Context 를 `valueContext` + `staticContext` 로 분리 (value 만 바뀌는 경우 staticContext 는 rerender 안 하도록). v1 은 단일 context, 성능 이슈 발견 시 분리.
+3. **indicator 측정 비용**: `offsetLeft/offsetWidth` 접근은 layout forcing. `useLayoutEffect` 안에서 **한 번만** 측정 후 style 적용. `cumulativeLayoutShift` 영향 없음 (이미 layout 이 확정된 시점).
+4. **ResizeObserver / MutationObserver 과다 호출**: List 한 개에 대해서만 설정. trigger 추가/제거 시만 callback 실행. 저비용.
+5. **lazy-mount 토글 시 Content 생성 비용**: 사용자 책임. plastic 은 forceMount 선택권만 제공.
+
+### 14.3 측정
+- Playground 탭 100 개로 전환 시 DevTools Performance 탭 1 초 녹화 → 60 fps 확인.
+- React Profiler 로 탭 전환 시 rerender commit < 5 ms.
+
+---
+
+## 15. 접근성
+
+### 15.1 ARIA
+
+| 요소 | 속성 |
+|---|---|
+| `Tabs.Root` | `<div>` (role 없음) + `data-*` |
+| `Tabs.List` | `role="tablist"`, `aria-orientation="horizontal"\|"vertical"`, `aria-label` or `aria-labelledby` |
+| `Tabs.Trigger` (active) | `role="tab"`, `aria-selected="true"`, `tabindex="0"`, `aria-controls="{contentId}"`, `id="{triggerId}"` |
+| `Tabs.Trigger` (inactive) | `role="tab"`, `aria-selected="false"`, `tabindex="-1"`, 나머지 동일 |
+| `Tabs.Trigger` (disabled) | 위에 더해 `aria-disabled="true"`, `disabled` HTML attr |
+| `Tabs.Trigger` (closable close btn) | `role="button"`, `aria-label="Close {tabLabel}"`, `tabindex="-1"` |
+| `Tabs.Content` (active) | `role="tabpanel"`, `id="{contentId}"`, `aria-labelledby="{triggerId}"`, `tabindex="0"` |
+| `Tabs.Content` (inactive, forceMount) | 위에 더해 `hidden`, `aria-hidden="true"` |
+| overflow scroll 버튼 | `<button>`, `aria-label="Scroll tabs left"` / `"right"`, `tabindex="-1"` (마우스 전용; 키보드 유저는 Arrow 로 대체) |
+
+### 15.2 focus 관리
+
+- List 에 tab 키로 진입 시 active trigger 가 focus.
+- Arrow 로 탭 간 이동 (roving tabindex).
+- 탭 focus 상태 시각 표시: `:focus-visible` outline.
+- 비활성 탭은 `tabindex="-1"` 이라 Tab 키로 focus 안 받음.
+- Content 는 `tabindex="0"` (panel 자체로 focus 가능) → 내부 focusable 이 있으면 그곳으로 이동.
+
+### 15.3 스크린리더 동작 예시 (VoiceOver)
+
+Basic 예제:
+```
+User: (Tab 키)
+VO:   "tablist, 3 items, Logs, selected, tab 1 of 3"
+User: (ArrowRight)
+VO:   "Timing, selected, tab 2 of 3"    # automatic 이라 selected 포함
+User: (ArrowRight)
+VO:   "Error, selected, tab 3 of 3"
+User: (Tab 키)
+VO:   "tabpanel, Error, (내부 컨텐츠)"
+```
+
+manual 모드:
+```
+User: (ArrowRight)
+VO:   "Timing, tab 2 of 3"               # selected 빠짐
+User: (Enter)
+VO:   "Timing, selected, tab 2 of 3"
+```
+
+### 15.4 고대비 / forced-colors 모드
+
+```css
+@media (forced-colors: active) {
+  .tabs-indicator { background: Highlight; }
+  .tabs-trigger[data-state="active"] { color: HighlightText; }
+  .tabs-trigger:focus-visible { outline-color: Highlight; }
+}
+```
+
+---
+
+## 16. 트레이드오프
+
+1. **value 가 string 단일 키**: index 기반(Headless UI 방식) 에 비해 DOM id 와 매핑이 자연스럽고 리스트 변경에 안정적. 단점: 사용자가 의미 없는 key 를 짓기 귀찮을 수 있음. 대안: 자동 index 기반 fallback. v1 은 명시적 string 강제.
+2. **closable 를 per-Trigger prop**: 모든 탭이 closable 일 때도 각 Trigger 에 지정해야 함(약간의 중복). 대안은 Root 에 `closable` + per-Trigger `closable={false}` override. v1 은 per-Trigger 만 — 더 명시적, Root 수준 "모든 탭 closable" 은 유저가 map 시 spread 로 해결 가능.
+3. **lazy-mount 기본값 = true**: 대부분 탭은 가벼우므로 캐시 필요 없음. forceMount 는 opt-in. Radix 와 반대(Radix 는 기본 unmount 지만 forceMount 도 동일 의미 제공) — plastic 은 사용자가 의식적으로 forceMount 결정.
+4. **Root 가 자동 첫 탭 선택**: `defaultValue` 미지정 시 첫 non-disabled trigger 자동 활성. 장점: 최소 구성으로도 동작. 단점: "아무 탭도 선택 안 된 상태" 를 표현하기 어려움(`value={null}` 을 명시적으로 두어야 함). v1 은 자동 선택 채택.
+5. **close 후 next selection 은 owner 책임 (controlled)**: plastic 이 자동으로 "다음 탭" 을 고르지 않음. 장점: owner 가 자유(닫힌 탭의 왼쪽? 오른쪽? 최근 사용 stack?). 단점: 간단한 케이스에서도 owner 코드 필요. uncontrolled 에서는 plastic 이 register cleanup 에서 첫 non-disabled 로 fallback — 이중 정책으로 편의 제공.
+6. **indicator 를 JS 측정 + transform**: CSS-only 접근(각 trigger 의 active state 에 ::after underline)도 가능하나 transition 이 탭 사이를 "이동" 하는 것이 아니라 "기존 underline fade out + 새 underline fade in" 이 됨. 사용자 경험은 이동이 더 자연스러움. 비용은 측정 1 회/value 변경.
+7. **scroll container = `.tabs-list`**: indicator 도 scroll 과 함께 이동. 단 arrow 버튼은 list-wrap 기준 absolute 배치. z-index 로 trigger 위에. 타협점: arrow 버튼이 첫/마지막 탭 일부를 가릴 수 있음 → padding-inline 확보로 완화.
+8. **closable close 를 `<span role="button">` nested**: HTML 상 `<button>` 안에 `role="button"` 은 불완전하나 실전에서 널리 사용됨. 완전 분리하려면 Trigger 를 `<div>` 로 (§5.3) — 이는 Enter/Space 기본 제출 동작 손실 → custom key handler 필요. v1 은 nested 허용.
+9. **`useControllable` 의 `onChange` 호출 타이밍**: 현재 훅은 setValue 시 onChange 호출. 사용자 prop `onValueChange` 도 같은 시점. close 시 fallback selection 도 setValue 경유 → onValueChange 호출됨. 이는 사용자가 원하는 행동(외부 state 동기화)이므로 정책 일관.
+10. **orientation 전환 시 스크롤 위치 리셋**: 현재 구현은 List 의 scrollLeft/scrollTop 을 보존하지 않음. 사용자 use case 가 없으므로 v1 수용.
+
+---
+
+## 17. 후속 작업 (v1.1+)
+
+- **drag reorder**: Trigger 를 pointerDown + drag threshold + dragover detection 으로 순서 변경. `onReorder(values: string[])` 콜백. dnd-kit 없이 순수 HTML5 DnD 또는 pointer 기반 구현.
+- **drag-out to new window**: Chrome 탭처럼 밖으로 드래그하면 pop-out. Electron/tauri 환경 전제 기능.
+- **컨텍스트 메뉴**: 우클릭으로 "Close others / Close right / Pin / Copy path" 표시. plastic 이 ContextMenu 컴포넌트를 먼저 가진 뒤 조합.
+- **pin tab**: 핀 고정 탭(close 불가 + 왼쪽 배치).
+- **dirty indicator**: `dirty?: boolean` prop 으로 `●` 닫기 아이콘 대체(VSCode 식).
+- **compression overflow**: 탭 수가 많으면 글자 줄이기 + hover 시 확장. scroll 과 병존 가능(우선순위).
+- **add (+) 버튼 전용 API**: `<Tabs.Add onClick={...} />` 로 스타일 일관성.
+- **PipelineGraphInspector 리팩터링**: 별도 PR (§11 Step 12).
+- **Content animation**: fade/slide transition (framer-motion 없이 CSS 만).
+- **keyboard shortcut**: `Cmd+1~9` 로 N번째 탭 이동 (opt-in `shortcuts: true`).
+- **TypeScript 강화**: value 유니온 타입 generic (`Tabs.Root<V extends string>`).
+- **aria-label 자동화**: aria-label 미지정 시 dev warn.
+
+---
+
+## 18. 관련 파일 인벤토리 (구현 시 참조)
+
+| 용도 | 경로 |
+|---|---|
+| controlled/uncontrolled 표준 훅 | `/Users/neo/workspace/plastic/src/components/_shared/useControllable.ts` |
+| 이미 탭 UI 구현된 prior impl (추출 대상) | `/Users/neo/workspace/plastic/src/components/PipelineGraph/PipelineGraphInspector.tsx` (Logs/Timing/Error 탭 — 후속 PR 로 Tabs 로 교체) |
+| 배럴 등록 | `/Users/neo/workspace/plastic/src/components/index.ts` |
+| 데모 App 라우팅 / NAV / 테마 컨텍스트 | `/Users/neo/workspace/plastic/demo/src/App.tsx` |
+| 데모 페이지 레이아웃 · Props 표 · Usage 구조 레퍼런스 | `/Users/neo/workspace/plastic/demo/src/pages/CommandPalettePage.tsx` |
+| tsconfig 제약 | `/Users/neo/workspace/plastic/tsconfig.json` |
+| 이전 plan 포맷 참고 (템플릿) | `/Users/neo/workspace/plastic/docs/plans/017-splitpane-component.md` |
+
+---
+
+## 19. 의존성 영향
+
+신규 런타임 의존 없음. React 18+ (기존) + DOM API (`ResizeObserver`, `MutationObserver`, `requestAnimationFrame`, `Element.scrollIntoView`, `Element.compareDocumentPosition`, `getComputedStyle`) 만 사용. 모두 모던 브라우저(Chrome 64+/Firefox 69+/Safari 13+) 에서 지원.
+
+번들 영향:
+- Tabs 자체 예상 크기: ~3 KB (min), ~1.3 KB (min+gzip).
+- plastic 전체 dist 거의 영향 없음.
+
+API 호환성:
+- `src/components/index.ts` 배럴에 한 줄 추가, 기존 export 영향 없음.
+- 다른 컴포넌트(`SplitPane`, `CommandPalette`, `PipelineGraph`, `DataTable`, `HexView`, `CodeView` 등)와 충돌 없음.
+- 같이 사용 가능(예: `SplitPane.Pane` 안에 `Tabs.Root`, `Tabs.Content` 안에 `DataTable`).
+
+Node/SSR:
+- `useId` 로 hydration-safe id 생성.
+- `getComputedStyle(root).direction` 접근은 `useLayoutEffect` 내부 → SSR 시 skip.
+- `document`/`window` 직접 접근은 event handler 안에서만, 최상위 파일 scope 에서 접근 금지.
+
+---
+
+## 20. 구현 완료 정의 (Definition of Done)
+
+- [ ] `npm run typecheck` 통과 (`exactOptionalPropertyTypes` / `noUncheckedIndexedAccess` / `verbatimModuleSyntax` 준수).
+- [ ] `npx tsup` 통과 (타입 선언 포함).
+- [ ] demo 에 `/#/tabs` 라우트 동작.
+- [ ] §13.2 수동 체크리스트 전부 확인.
+- [ ] §13.3 엣지 케이스 전부 확인 또는 "v1 범위 밖" 명시.
+- [ ] §13.4 a11y 수동 체크 (VoiceOver 또는 NVDA) 전부 확인.
+- [ ] CommandPalette / SplitPane / PipelineGraph / CodeView / HexView / DataTable / 기타 페이지 리그레션 없음.
+- [ ] `src/components/index.ts` 배럴에 `export * from "./Tabs";` 추가.
+- [ ] `package.json` dependencies 변경 없음.
+- [ ] Props 섹션에 Root / List / Trigger / Content 네 개 표 작성.
+- [ ] Usage 섹션 최소 4 개 스니펫 (Basic / VSCode-style / Settings vertical / Controlled).
+- [ ] Playground 에서 모든 prop 토글 가능.
+- [ ] Light / Dark 테마 전환 시 시각 이상 없음.
+- [ ] 키보드만으로 (마우스 없이) 모든 기능 사용 가능: 탭 이동, activate, close, overflow scroll(End 로 도달).
+- [ ] 스크린리더 확인: active 탭 안내, content 라벨, disabled 안내, close 버튼 라벨.
+- [ ] indicator transition 이 모든 탭 폭/오리엔테이션에서 자연스러움.
+- [ ] PipelineGraphInspector 리팩터링은 별도 PR 로 분리 (본 PR 포함하지 않음).
+
+---
+
+**끝.**

--- a/docs/plans/017-splitpane-component.md
+++ b/docs/plans/017-splitpane-component.md
@@ -1,0 +1,1207 @@
+# SplitPane 컴포넌트 설계문서
+
+## Context
+
+plastic 라이브러리에 "두 개의 영역을 드래그 가능한 divider 로 분할하는 레이아웃 프리미티브" `SplitPane` 을 추가한다. 역할 비유: VSCode/IntelliJ 의 에디터-사이드바 리사이즈, Chrome DevTools 의 Elements/Styles 분할, Finder 의 tree/list split. 이 컴포넌트는 IDE 스타일 레이아웃의 기본 블록이며, plastic 상위에서 `PipelineGraphInspector` 등이 이미 임시로 구현하던 divider 리사이즈 로직을 추출·일반화하여 재사용 가능한 공용 컴포넌트로 승격하는 것이 목적이다.
+
+참고 (prior art — UX 근거):
+- **Atlassian atlaskit `@atlaskit/navigation-next` / `@atlaskit/split`** — flex-basis 기반, collapse + persist.
+- **Electron/VSCode `SplitView`** — min/max/snap, keyboard, two-pane + recursive.
+- **react-split-pane** (구 표준, 비유지보수) — `primary` pane 기준으로 size 계산, pixel/% 포맷.
+- **react-resizable-panels** (현재 활발) — compound API (`PanelGroup`/`Panel`/`PanelResizeHandle`), localStorage autosave, snap.
+- **Splitter (Ant Design, BlueprintJS `Divider`)** — UI 일관성 참조.
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/PipelineGraph/PipelineGraphInspector.tsx` — 이미 `onDividerPointerDown` 구현 존재 (line 315~340). 추출·일반화 대상.
+- `src/components/_shared/useControllable.ts` — controlled/uncontrolled 이중 API 표준 훅.
+- `src/components/DataTable/useColumnResize.ts` — pointer drag 기반 리사이즈 패턴(컬럼). 훅 구조·cleanup·`document.body.style.cursor` 글로벌 토글 방식 참조.
+- `demo/src/App.tsx` — 사이드바 자체 resize 핸들 (min/max + localStorage) 로직이 이미 existent. **내부 리팩터링 기회**(§17).
+- `demo/src/pages/PipelineGraphPage.tsx`, `demo/src/pages/*Page.tsx` — 데모 페이지 레이아웃 관례.
+- `tsconfig.json` — `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax` 제약.
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+<SplitPane.Root
+  direction="horizontal"        // 기본. "vertical" 도 가능.
+  defaultSize="40%"             // 첫 번째 pane 기준. number(px) | `${number}%`
+  minSize={160}
+  maxSize="70%"
+  snapSize="50%"                // 드래그 중 이 근처 통과 시 스냅
+  collapsible="start"           // "start" | "end" | "both" | "none"
+  collapsedSize={0}
+  storageKey="ide:editor-split" // localStorage persist
+  theme="light"
+  onSizeChange={(px, pct) => log(px, pct)}
+>
+  <SplitPane.Pane>
+    <FileTree />
+  </SplitPane.Pane>
+  <SplitPane.Divider />
+  <SplitPane.Pane>
+    <Editor />
+  </SplitPane.Pane>
+</SplitPane.Root>
+```
+
+렌더 결과 (개념):
+```
+┌──────────┬──┬────────────────────────────────┐
+│ 파일트리 │::│            에디터              │
+│          │::│                                │
+│          │::│                                │
+└──────────┴──┴────────────────────────────────┘
+  ↑          ↑
+  Pane[0]   Divider (drag, keyboard, collapse)
+```
+
+핵심 설계 원칙:
+- **compound 컴포넌트**. `Root`/`Pane`/`Divider` 의 3 개 소계로 Context 통해 상태 공유. 자식 순서는 `Pane, Divider, Pane` 고정 (v1).
+- **size 는 첫 번째 pane 기준**. 두 번째 pane 은 `flex: 1`. `direction === "horizontal"` 이면 width, `vertical` 이면 height.
+- **dual unit**. `number` 은 픽셀, `"${number}%"` 문자열은 컨테이너 비율. 내부 상태는 항상 픽셀로 유지하되 onSizeChange 콜백에는 `(px, pct)` 둘 다 제공.
+- **controlled/uncontrolled 이중 API**. `useControllable` 동일 패턴.
+- **런타임 의존 zero**. DOM + React 만. ResizeObserver, PointerEvents 는 web standard.
+- **접근성 · 키보드 우선**. divider 는 `role="separator"` + `aria-valuenow/min/max` + Arrow / Shift+Arrow / Home/End 지원.
+- **v1 은 2-pane 만**. multi-pane(3+) 은 v1.1 에서 `Pane, Divider, Pane, Divider, Pane` 확장.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. 수평/수직 방향 2-pane 분할.
+2. pixel/percent 양쪽 단위로 size/minSize/maxSize 지정.
+3. pointer 드래그로 리사이즈. pointer capture 사용, drag 중 selection/iframe 간섭 차단.
+4. 키보드 리사이즈: Arrow ±10, Shift+Arrow ±100, Home=min, End=max, Enter/Space=collapse toggle (collapsible 일 때).
+5. controlled/uncontrolled 이중 API: `size`/`defaultSize`/`onSizeChange`.
+6. localStorage persist (`storageKey`). 없으면 memory-only.
+7. min/max clamp + snap (optional single breakpoint) + collapse threshold.
+8. collapsible: "start" | "end" | "both" | "none". 토글 버튼 옵션 + 키보드 트리거.
+9. ResizeObserver 로 컨테이너 크기 변화 감지 → percent 기반 크기는 자동 재계산, pixel 기반 크기는 clamp 재적용.
+10. Light / Dark 테마.
+11. RTL 대응: `direction="horizontal"` 에서 `[dir="rtl"]` 일 때 "start pane" 이 우측이 된다.
+
+### Non-goals (v1 제외)
+- **3+ pane** (multi-pane): Pane-Divider-Pane-Divider-Pane 패턴은 v1.1. v1 은 정확히 2 Pane + 1 Divider 만 허용하고 이외 구성은 dev warn.
+- **nested SplitPane**: 사용자는 `Pane` 안에 또다른 `SplitPane.Root` 를 자유롭게 중첩 가능. 그러나 "내부 중첩에 특화된 API" (예: 자동 분할 경로 기록) 는 v1 제외.
+- **layout presets / layout saving service**: v1 은 단순 storageKey 만. 다중 레이아웃 저장/복원 UI (예: "내 레이아웃 A/B") 는 v1.2.
+- **터치 제스처(핀치 등)** 특화: pointerEvents 가 touch 를 자동 커버하므로 기본 드래그는 동작. 그 이상 제스처 아님.
+- **동적 divider size**: v1 은 고정 6 px. 사용자 스타일 커스터마이즈는 `className`/`style` 로 가능.
+- **animation**: collapse transition 은 CSS transition 한 줄(200 ms cubic) 만, 그 외 JS 애니메이션 없음.
+- **touch drag handle affordance UI** (예: 큰 drag dot): v1.1.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/SplitPane/SplitPane.types.ts`
+
+```ts
+export type SplitPaneTheme = "light" | "dark";
+export type SplitPaneDirection = "horizontal" | "vertical";
+
+/**
+ * 크기 표현 단위.
+ * - number: 정수 픽셀 (0 이상)
+ * - `${number}%`: 컨테이너 크기 대비 %
+ */
+export type SplitPaneSize = number | `${number}%`;
+
+export type SplitPaneCollapsible = "start" | "end" | "both" | "none";
+
+export interface SplitPaneRootProps {
+  /** 분할 방향. 기본 "horizontal". */
+  direction?: SplitPaneDirection;
+  /** 초기 사이즈 (첫 번째 pane 기준). uncontrolled. 기본 "50%". */
+  defaultSize?: SplitPaneSize;
+  /** 제어 사이즈. 지정 시 controlled. */
+  size?: SplitPaneSize;
+  /** 사이즈 변경 콜백. px 와 percent 둘 다 제공. */
+  onSizeChange?: (sizePx: number, sizePercent: number) => void;
+  /**
+   * 드래그 완료 시(pointerup) 호출되는 콜백. persist 타이밍 조율용.
+   * size 변경 매 tick 에는 호출되지 않음. uncontrolled 일 때도 호출.
+   */
+  onSizeChangeEnd?: (sizePx: number, sizePercent: number) => void;
+
+  /** 최소 사이즈. 기본 48 (px). */
+  minSize?: SplitPaneSize;
+  /** 최대 사이즈. 기본 "90%". */
+  maxSize?: SplitPaneSize;
+
+  /**
+   * 드래그 중 이 값 근처(기본 ±8 px)를 통과하면 해당 값에 snap.
+   * 단일 지점만 지원 (v1). 여러 breakpoints 는 v1.1.
+   */
+  snapSize?: SplitPaneSize;
+  /** snap 활성 임계값 (px). 기본 8. */
+  snapThreshold?: number;
+
+  /** 어느 쪽을 collapse 가능으로 둘지. 기본 "none". */
+  collapsible?: SplitPaneCollapsible;
+  /** collapse 시 목표 크기 (기본 0). */
+  collapsedSize?: number;
+  /**
+   * 드래그 중 이 값 미만(첫 pane 이 start-collapse 대상일 때)으로 내려가면
+   * collapsedSize 로 스냅 collapse. 기본 minSize * 0.5.
+   */
+  collapseThreshold?: number;
+
+  /** localStorage 키. 지정되면 사이즈 persist. uncontrolled 일 때만 유효. */
+  storageKey?: string;
+
+  /** 라이트/다크. 기본 "light". */
+  theme?: SplitPaneTheme;
+
+  /** 비활성화 (드래그/키보드 모두 차단). 기본 false. */
+  disabled?: boolean;
+
+  /** 추가 className / style (root). */
+  className?: string;
+  style?: React.CSSProperties;
+
+  /** 자식: Pane, Divider, Pane 순서. */
+  children: React.ReactNode;
+}
+
+export interface SplitPaneProps {
+  /** pane 내용 */
+  children?: React.ReactNode;
+  /** 추가 className / style */
+  className?: string;
+  style?: React.CSSProperties;
+  /**
+   * 이 pane 이 collapse 대상일 때 툴팁/ARIA 라벨에 쓰일 이름.
+   * 예: "File tree", "Inspector".
+   */
+  label?: string;
+}
+
+export interface SplitPaneDividerProps {
+  /** 추가 className / style */
+  className?: string;
+  style?: React.CSSProperties;
+  /** divider 접근성 라벨 (기본 "Resize panes"). */
+  "aria-label"?: string;
+  /**
+   * 커스텀 affordance (드래그 핸들 내부에 표시할 요소, 예: `•••`).
+   * 지정하지 않으면 빈 라인.
+   */
+  children?: React.ReactNode;
+}
+```
+
+### 2.2 배럴
+
+```ts
+// src/components/SplitPane/index.ts
+export { SplitPane } from "./SplitPane";
+export type {
+  SplitPaneRootProps,
+  SplitPaneProps,
+  SplitPaneDividerProps,
+  SplitPaneSize,
+  SplitPaneTheme,
+  SplitPaneDirection,
+  SplitPaneCollapsible,
+} from "./SplitPane.types";
+```
+
+그리고 `src/components/index.ts` 에 `export * from "./SplitPane";` 한 줄 추가.
+
+### 2.3 Compound namespace
+
+```ts
+// SplitPane.tsx
+export const SplitPane = {
+  Root: SplitPaneRoot,
+  Pane: SplitPanePane,
+  Divider: SplitPaneDivider,
+};
+```
+
+사용자가 `<SplitPane.Root>…</SplitPane.Root>` 로 접근. `Root`, `Pane`, `Divider` 의 displayName 은 각각 `"SplitPane.Root"`, `"SplitPane.Pane"`, `"SplitPane.Divider"`.
+
+---
+
+## 3. 도메인 모델
+
+### 3.1 size 단위 정책
+
+- 내부 상태(`useState`) 는 **항상 픽셀(number)** 로 유지한다.
+- props 로 들어온 `"${n}%"` 는 "컨테이너 너비/높이를 곱해" 픽셀로 변환 후 저장.
+- `onSizeChange(px, pct)` 콜백에서 둘 다 돌려주므로, 호출자는 원하는 단위로 사용.
+- localStorage 에는 항상 `{ unit: "px" | "pct", value: number }` 형태 JSON 으로 저장 (사용자 입력 단위 보존 → 창 리사이즈 후 복원 시 의도 보존).
+
+### 3.2 size 변환 유틸
+
+```ts
+// SplitPane.utils.ts
+export function parseSize(s: SplitPaneSize): { unit: "px" | "pct"; value: number } {
+  if (typeof s === "number") return { unit: "px", value: s };
+  const m = /^(-?\d+(\.\d+)?)%$/.exec(s);
+  if (!m) throw new Error(`SplitPane: invalid size ${s}`);
+  return { unit: "pct", value: parseFloat(m[1]!) };
+}
+
+export function toPx(s: SplitPaneSize, containerPx: number): number {
+  const p = parseSize(s);
+  return p.unit === "px" ? p.value : (p.value / 100) * containerPx;
+}
+
+export function toPct(px: number, containerPx: number): number {
+  if (containerPx <= 0) return 0;
+  return (px / containerPx) * 100;
+}
+
+export function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+```
+
+### 3.3 fr (future) 단위
+
+v1 은 `px` 와 `%` 만. 향후 CSS Grid 의 `fr` 이나 `calc()` 기반 비율 표현이 필요하면 `SplitPaneSize` 유니온을 확장. 이 경우 계산을 GridTemplate 로 위임하는 리팩터링이 필요하므로 v1 범위 밖.
+
+### 3.4 root Context
+
+```ts
+interface SplitPaneContextValue {
+  direction: SplitPaneDirection;
+  sizePx: number;
+  containerPx: number;
+  minPx: number;
+  maxPx: number;
+  snapPx: number | null;
+  snapThreshold: number;
+  collapsible: SplitPaneCollapsible;
+  collapsedSize: number;
+  collapseThreshold: number;
+  isCollapsedStart: boolean;
+  isCollapsedEnd: boolean;
+  disabled: boolean;
+  theme: SplitPaneTheme;
+  onDividerPointerDown: (e: React.PointerEvent) => void;
+  onDividerKeyDown: (e: React.KeyboardEvent) => void;
+  toggleCollapse: (which: "start" | "end") => void;
+  isDragging: boolean;
+  rtl: boolean;
+  paneIndex: React.MutableRefObject<number>;
+}
+
+const SplitPaneContext = createContext<SplitPaneContextValue | null>(null);
+```
+
+---
+
+## 4. 시각 / 구조 설계
+
+### 4.1 DOM 구조 (horizontal 기준)
+
+```
+<div role="group" class="sp-root" style="display:flex; direction:horizontal">
+  <div class="sp-pane sp-pane--start" style="flex: 0 0 {sizePx}px; min-width:0; min-height:0; overflow:hidden">
+    {children}
+  </div>
+  <div role="separator"
+       aria-orientation="vertical"
+       aria-valuenow="{sizePct round}"
+       aria-valuemin="{minPct}"
+       aria-valuemax="{maxPct}"
+       tabindex="0"
+       class="sp-divider"
+       style="width:6px; cursor:col-resize; flex: 0 0 6px">
+    <div class="sp-divider-handle" />
+  </div>
+  <div class="sp-pane sp-pane--end" style="flex: 1 1 0; min-width:0; min-height:0; overflow:hidden">
+    {children}
+  </div>
+
+  {/* drag 중에만 overlay 삽입: iframe/selection 방지 */}
+  {isDragging && <div class="sp-drag-overlay" style="position:fixed;inset:0;z-index:9999;cursor:col-resize" />}
+</div>
+```
+
+`vertical` 은 flex-direction=column + aria-orientation="horizontal" + cursor=row-resize + height:6px.
+
+### 4.2 이유 — `flex-basis` vs `grid-template` vs absolute
+
+- **flex** (선택). start pane 은 `flex: 0 0 Npx`, end pane 은 `flex: 1 1 0`. divider 는 `flex: 0 0 6px`. 장점: 중간 크기 변화가 start pane 만 변경되고 end 는 자동 채움. `min-width:0` 로 내부 overflow 격리가 자연스러움.
+- grid 는 `grid-template-columns: Npx 6px 1fr` 도 가능하나, dynamic ResizeObserver 계산 시 grid track 재설정 cost + safari 의 track transition 버그 경험. v1 은 flex.
+- absolute positioning 은 내부 컨텐츠 natural flow 를 방해. 기각.
+
+### 4.3 RTL 대응
+
+horizontal + `dir="rtl"` 컨텍스트에서는 start pane 이 "화면 오른쪽" 에 표시된다. Flex 가 자동으로 뒤집어 주므로 DOM 순서는 동일하되, 드래그 `deltaX` 부호를 **반대**로 해석. `rtl` 여부는 컨테이너의 computed `direction` 으로 감지:
+
+```ts
+const rtl = useMemo(
+  () => getComputedStyle(rootRef.current!).direction === "rtl",
+  [containerPx /* 재측정 trigger */],
+);
+```
+
+vertical 은 RTL 무관.
+
+### 4.4 divider 스타일
+
+```css
+.sp-divider {
+  background: var(--sp-divider-bg);        /* light: rgba(0,0,0,0.08), dark: rgba(255,255,255,0.08) */
+  transition: background 120ms;
+  user-select: none;
+  touch-action: none;                       /* pointer capture 안정성 */
+  position: relative;
+}
+.sp-divider:hover,
+.sp-divider:focus-visible {
+  background: var(--sp-divider-hover);     /* light: rgba(37,99,235,0.35) */
+}
+.sp-divider[data-dragging="true"] {
+  background: var(--sp-divider-active);    /* #2563eb */
+}
+.sp-divider-handle {
+  position: absolute;
+  left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  width: 2px; height: 18px;
+  background: var(--sp-divider-handle-fg);
+  border-radius: 1px;
+  opacity: 0;
+  transition: opacity 120ms;
+}
+.sp-divider:hover .sp-divider-handle,
+.sp-divider[data-dragging="true"] .sp-divider-handle {
+  opacity: 0.6;
+}
+```
+
+### 4.5 palette 토큰
+
+```ts
+// SplitPane/theme.ts
+export const splitPanePalette = {
+  light: {
+    dividerBg:        "rgba(0,0,0,0.08)",
+    dividerHover:     "rgba(37,99,235,0.35)",
+    dividerActive:    "#2563eb",
+    dividerHandleFg:  "rgba(0,0,0,0.35)",
+    collapseBtnBg:    "#ffffff",
+    collapseBtnFg:    "#374151",
+    collapseBtnBorder:"rgba(0,0,0,0.12)",
+    focusRing:        "#2563eb",
+  },
+  dark: {
+    dividerBg:        "rgba(255,255,255,0.08)",
+    dividerHover:     "rgba(96,165,250,0.35)",
+    dividerActive:    "#60a5fa",
+    dividerHandleFg:  "rgba(255,255,255,0.5)",
+    collapseBtnBg:    "#1f2937",
+    collapseBtnFg:    "#e5e7eb",
+    collapseBtnBorder:"rgba(255,255,255,0.08)",
+    focusRing:        "#60a5fa",
+  },
+} as const;
+```
+
+---
+
+## 5. 리사이즈 로직
+
+### 5.1 pointer drag 시퀀스
+
+`PipelineGraphInspector` 의 `onDividerPointerDown` 를 일반화한 버전:
+
+```ts
+// usePaneResize.ts (내부 훅)
+interface DragState {
+  startClient: number;
+  startSize: number;
+  pointerId: number;
+}
+
+function onDividerPointerDown(e: React.PointerEvent) {
+  if (disabled) return;
+  e.preventDefault();
+  e.stopPropagation();
+  const rect = rootRef.current!.getBoundingClientRect();
+  const axis = direction === "horizontal" ? rect.width : rect.height;
+  setContainerPx(axis);
+
+  const startClient = direction === "horizontal" ? e.clientX : e.clientY;
+  dragRef.current = { startClient, startSize: sizePx, pointerId: e.pointerId };
+  dividerRef.current?.setPointerCapture(e.pointerId);
+  setIsDragging(true);
+  document.body.style.cursor = direction === "horizontal" ? "col-resize" : "row-resize";
+  document.body.style.userSelect = "none";
+
+  const onMove = (ev: PointerEvent) => {
+    if (!dragRef.current) return;
+    const cur = direction === "horizontal" ? ev.clientX : ev.clientY;
+    const delta = (cur - dragRef.current.startClient) * (rtl && direction === "horizontal" ? -1 : 1);
+    let next = dragRef.current.startSize + delta;
+
+    if (snapPx != null && Math.abs(next - snapPx) < snapThreshold) next = snapPx;
+
+    if (collapsible === "start" || collapsible === "both") {
+      if (next < collapseThreshold) next = collapsedSize;
+    }
+    if (collapsible === "end" || collapsible === "both") {
+      if (containerPx - next - DIVIDER_PX < collapseThreshold) next = containerPx - collapsedSize - DIVIDER_PX;
+    }
+
+    next = clamp(next, minPx, maxPx);
+
+    if (!pendingFrame.current) {
+      pendingFrame.current = requestAnimationFrame(() => {
+        pendingFrame.current = 0;
+        setSizePx(next);
+      });
+    } else {
+      pendingNext.current = next;
+    }
+  };
+
+  const onUp = (ev: PointerEvent) => {
+    if (pendingFrame.current) {
+      cancelAnimationFrame(pendingFrame.current);
+      pendingFrame.current = 0;
+      if (pendingNext.current != null) setSizePx(pendingNext.current);
+    }
+    dragRef.current = null;
+    dividerRef.current?.releasePointerCapture(ev.pointerId);
+    setIsDragging(false);
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+    document.removeEventListener("pointermove", onMove);
+    document.removeEventListener("pointerup", onUp);
+    document.removeEventListener("pointercancel", onUp);
+    onSizeChangeEnd?.(sizePxRef.current, toPct(sizePxRef.current, containerPxRef.current));
+  };
+
+  document.addEventListener("pointermove", onMove);
+  document.addEventListener("pointerup", onUp);
+  document.addEventListener("pointercancel", onUp);
+}
+```
+
+설계 포인트:
+- `setPointerCapture` 덕에 drag 중 마우스가 divider 밖으로 나가도 이벤트를 계속 받는다.
+- drag 중 `document.body.style.userSelect = "none"` 로 텍스트 선택 차단.
+- `touch-action: none` 을 divider CSS 에 두어 브라우저 기본 팬 제스처 차단.
+- drag 중 `isDragging=true` 상태를 pass → overlay `<div style="position:fixed;inset:0;z-index:9999">` 를 렌더하여 iframe 위를 덮어 pointer 이벤트가 document 로 계속 흐르게 한다. (iframe 위를 지나갈 때 pointermove 유실 방지.)
+
+### 5.2 getBoundingClientRect 기반 측정
+
+컨테이너 크기(`containerPx`) 는:
+- 최초 마운트 시 `rootRef.current.getBoundingClientRect()`.
+- **ResizeObserver** 로 root 를 관찰 → 변하면 state 업데이트.
+  ```ts
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const box = entry.contentBoxSize?.[0];
+      const w = box ? box.inlineSize : entry.contentRect.width;
+      const h = box ? box.blockSize  : entry.contentRect.height;
+      const nextAxis = direction === "horizontal" ? w : h;
+      setContainerPx(nextAxis);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [direction]);
+  ```
+- `containerPx` 가 변하면:
+  - percent 기반 저장값은 자동 재계산 (px 는 새로운 axis 기준).
+  - pixel 기반 저장값은 유지하되 `clamp(min, max)` 다시 적용.
+
+### 5.3 초기 size 계산
+
+```ts
+const [sizePx, setSizePx] = useState<number | null>(null);
+
+useLayoutEffect(() => {
+  if (sizePx != null) return;
+  const axis = direction === "horizontal" ? rootRef.current!.offsetWidth : rootRef.current!.offsetHeight;
+  if (storageKey) {
+    const raw = localStorage.getItem(storageKey);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as { unit: "px" | "pct"; value: number };
+        const initialPx = parsed.unit === "px" ? parsed.value : (parsed.value / 100) * axis;
+        setSizePx(clamp(initialPx, minPx, maxPx));
+        setContainerPx(axis);
+        return;
+      } catch { /* fall through */ }
+    }
+  }
+  const init = toPx(defaultSize, axis);
+  setSizePx(clamp(init, minPx, maxPx));
+  setContainerPx(axis);
+}, []);
+```
+
+mount 직후 `null` 상태에선 start pane 에 `flex-basis: 50%` 같은 fallback 을 적용하여 깜빡임 방지.
+
+---
+
+## 6. 제약 (min/max, snap, collapse threshold)
+
+### 6.1 min/max clamp
+
+모든 sizePx 변경 직전에 `clamp(next, minPx, maxPx)` 통과. 단 **collapsedSize** 로 snap 된 경우에는 clamp 에 걸리지 않도록 우회 (예: minSize=48 이고 collapsedSize=0 이면 0 이 minSize 아래임에도 허용).
+
+### 6.2 snapSize
+
+단일 breakpoint (`snapSize`) 근처를 통과할 때 그 값으로 멈춘다. 임계값 `snapThreshold` (기본 8 px). 드래그 중에만 snap, 키보드 이동에는 snap 미적용 (예측 가능성 우선).
+
+### 6.3 collapse threshold
+
+`collapsible="start"` 일 때:
+- 드래그 중 `sizePx < collapseThreshold` 를 통과하면 `sizePx = collapsedSize`.
+- 반대로 collapse 상태에서 드래그 시작해 `sizePx > collapseThreshold` 를 통과하면 해제.
+
+`collapsible="end"` 는 동일 로직을 `containerPx - sizePx - DIVIDER_PX` 기준으로 적용.
+
+`collapsible="both"` 는 둘 다 활성.
+
+### 6.4 resize 시 clamp 재적용
+
+ResizeObserver 로 containerPx 가 줄어들면 기존 sizePx 가 maxPx 를 초과할 수 있다 → clamp 재적용. 축소 시 end pane 의 min-width 를 확보하기 위한 safety 로 `sizePx = min(sizePx, containerPx - DIVIDER_PX - endMinPx)` 도 계산.
+
+---
+
+## 7. 키보드
+
+divider 는 `tabindex="0"`. focus 받은 상태에서:
+
+| 키 | 동작 |
+|---|---|
+| `ArrowLeft` (horizontal) / `ArrowUp` (vertical) | sizePx -= 10 |
+| `ArrowRight` (horizontal) / `ArrowDown` (vertical) | sizePx += 10 |
+| `Shift + Arrow` | ±100 대신 이동 |
+| `Home` | sizePx = minPx |
+| `End` | sizePx = maxPx |
+| `Enter` / `Space` | collapsible 이면 toggle collapse (start 쪽 우선; "end" 면 end). "both" 는 현재 더 가까운 쪽으로 collapse. "none" 은 무동작 |
+| `Escape` | drag 중이면 drag 취소 (startSize 로 복원) |
+
+RTL 이면 ArrowLeft/ArrowRight 의 부호 반전. RTL 에서도 Home/End 의미는 "minSize/maxSize" 이므로 물리적 화살표 해석만 반전.
+
+```ts
+function onDividerKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+  if (disabled) return;
+  const step = e.shiftKey ? 100 : 10;
+  const sign =
+    direction === "horizontal"
+      ? (e.key === "ArrowRight" ? 1 : e.key === "ArrowLeft" ? -1 : 0) * (rtl ? -1 : 1)
+      : (e.key === "ArrowDown" ? 1 : e.key === "ArrowUp" ? -1 : 0);
+  if (sign !== 0) {
+    e.preventDefault();
+    setSizePx(clamp(sizePxRef.current + sign * step, minPx, maxPx));
+    return;
+  }
+  if (e.key === "Home") { e.preventDefault(); setSizePx(minPx); return; }
+  if (e.key === "End")  { e.preventDefault(); setSizePx(maxPx); return; }
+  if (e.key === "Enter" || e.key === " ") {
+    if (collapsible === "none") return;
+    e.preventDefault();
+    const which = collapsible === "both"
+      ? (sizePxRef.current < containerPxRef.current / 2 ? "start" : "end")
+      : collapsible;
+    toggleCollapse(which);
+    return;
+  }
+  if (e.key === "Escape" && isDragging) {
+    setSizePx(dragRef.current!.startSize);
+    dragRef.current = null;
+    setIsDragging(false);
+  }
+}
+```
+
+---
+
+## 8. 상태 관리 (controlled / uncontrolled / localStorage)
+
+### 8.1 이중 API
+
+```ts
+const isControlled = props.size !== undefined;
+
+const [internalPx, setInternalPx] = useState<number | null>(null);
+const sizePx = isControlled
+  ? (toPx(props.size!, containerPx))
+  : (internalPx ?? fallbackInitialPx);
+
+function commitSize(nextPx: number) {
+  const pct = toPct(nextPx, containerPx);
+  if (!isControlled) setInternalPx(nextPx);
+  props.onSizeChange?.(nextPx, pct);
+}
+```
+
+> `useControllable` 기존 훅은 "값 그대로" 동기화 패턴이라, 이 컴포넌트처럼 "controlled 표현(SplitPaneSize) ↔ 내부 표현(number)" 사이에 변환이 필요한 경우에는 직접 작성한다. 그러나 훅의 contract(`isControlled` 판정, onChange 미러링) 는 동일하게 따라가 일관성 유지.
+
+### 8.2 localStorage persist
+
+```ts
+useEffect(() => {
+  if (!storageKey || isControlled || internalPx == null) return;
+  const payload = { unit: "px" as const, value: Math.round(internalPx) };
+  try { localStorage.setItem(storageKey, JSON.stringify(payload)); } catch { /* ignore quota */ }
+}, [storageKey, internalPx, isControlled]);
+```
+
+디스크립션:
+- controlled 일 때는 외부 owner 가 persist 책임을 가진다 (storageKey 무시 + dev warn).
+- 사용자가 `defaultSize="50%"` 로 시작했어도 persist 값은 px 로 저장 — 다음 마운트 시 px 고정(화면 폭 변경 시 같은 px 유지). percent 로 저장하고 싶으면 앞으로 `storageUnit?: "px"|"pct"` prop 을 v1.1 로.
+
+### 8.3 collapse 상태 유도
+
+별도 state 없이 유도:
+```ts
+const isCollapsedStart = sizePx <= collapsedSize + 0.5;
+const isCollapsedEnd   = (containerPx - sizePx - DIVIDER_PX) <= collapsedSize + 0.5;
+```
+
+collapse 해제 시 "collapse 직전 사이즈" 를 기억해 복원하려면 ref:
+```ts
+const preCollapseRef = useRef<number | null>(null);
+function toggleCollapse(which: "start" | "end") {
+  if (which === "start") {
+    if (isCollapsedStart) {
+      setSizePx(preCollapseRef.current ?? toPx(defaultSize, containerPx));
+      preCollapseRef.current = null;
+    } else {
+      preCollapseRef.current = sizePx;
+      setSizePx(collapsedSize);
+    }
+  } else {
+    if (isCollapsedEnd) {
+      setSizePx(preCollapseRef.current ?? toPx(defaultSize, containerPx));
+      preCollapseRef.current = null;
+    } else {
+      preCollapseRef.current = sizePx;
+      setSizePx(containerPx - collapsedSize - DIVIDER_PX);
+    }
+  }
+}
+```
+
+---
+
+## 9. Collapse / Expand (토글 버튼)
+
+### 9.1 내부 UI 훅
+
+`SplitPane.Pane` 에 `collapsible` 인 경우 작은 "▸ / ▾" 버튼을 붙일지 여부는 **사용자 선택**. v1 은 `<SplitPane.CollapseButton which="start" />` 컴포넌트를 추가로 export.
+
+```tsx
+<SplitPane.CollapseButton which="start" />
+```
+
+- 내부에서 `SplitPaneContext` 의 `toggleCollapse(which)` 를 호출.
+- 아이콘은 direction/which 조합에 따라 `◀ ▶ ▲ ▼` 자동.
+- 사용자 UI 는 자유. 원치 않으면 사용하지 않아도 됨 (키보드 Enter/Space + divider focus 로도 토글 가능).
+
+### 9.2 animation
+
+collapse 시 `flex-basis` 전환을 위한 CSS:
+```css
+.sp-root[data-animating="true"] .sp-pane--start {
+  transition: flex-basis 180ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+```
+`data-animating` 은 collapse 토글 클릭 시점에만 잠시 true 로 설정 후 `transitionend` 에 false 로. drag 중에는 절대 true 가 아니도록 주의 (매 프레임 transition 적용 시 시각 어긋남).
+
+---
+
+## 10. 파일 구조
+
+```
+src/components/SplitPane/
+├── SplitPane.tsx              # Root + Pane + Divider + CollapseButton 조립 + context 생성
+├── SplitPane.types.ts         # 공개 타입
+├── SplitPane.utils.ts         # parseSize/toPx/toPct/clamp + constants
+├── SplitPaneContext.ts        # Context 정의 + useSplitPaneContext 훅
+├── usePaneResize.ts           # pointer drag + keyboard + rAF throttle 로직
+├── theme.ts                   # splitPanePalette
+└── index.ts                   # 배럴
+```
+
+각 파일 책임:
+
+- **SplitPane.tsx**
+  - `SplitPaneRoot` 함수 컴포넌트. `useControllable`-스타일 듀얼 API + ResizeObserver + 초기 sizePx.
+  - Context 에 현재 값/핸들러 주입.
+  - children 검증 (§11 Step 1): 정확히 2 Pane + 1 Divider 순서인지 dev warn.
+  - drag overlay 렌더.
+  - `SplitPanePane`, `SplitPaneDivider`, `SplitPaneCollapseButton` 세 하위 컴포넌트 정의 + namespace export.
+
+- **SplitPane.utils.ts**
+  - `parseSize`, `toPx`, `toPct`, `clamp`.
+  - `DIVIDER_PX = 6` 상수.
+  - `isSizeString(x): x is \`${number}%\`` 타입 guard.
+
+- **SplitPaneContext.ts**
+  - `createContext<SplitPaneContextValue | null>(null)`.
+  - `useSplitPaneContext()` — null 이면 "must be used within SplitPane.Root" throw.
+
+- **usePaneResize.ts**
+  - `onDividerPointerDown` / `onDividerKeyDown` 반환.
+  - `isDragging` 상태.
+  - `toggleCollapse`.
+  - `sizePxRef`/`containerPxRef` 로 handler 안에서 stale closure 회피.
+
+- **theme.ts**
+  - `splitPanePalette` (light/dark).
+
+- **index.ts**
+  - `export { SplitPane } from "./SplitPane";` + 타입 재노출.
+
+---
+
+## 11. 구현 단계 (후속 agent 가 순차 실행)
+
+각 단계는 독립 커밋 권장. 각 커밋이 `npm run typecheck` + `npx tsup` 통과 상태.
+
+### Step 1 — 타입 + 배럴 + 테마 스켈레톤
+1. `SplitPane.types.ts` 작성 (§2.1 전부).
+2. `theme.ts` 작성 (palette).
+3. `SplitPane.utils.ts` 작성 (`parseSize`, `toPx`, `toPct`, `clamp`, `DIVIDER_PX`).
+4. `index.ts` 배럴.
+5. `src/components/index.ts` 에 `export * from "./SplitPane";`.
+6. `SplitPane.tsx` placeholder: `export const SplitPane = { Root: () => null, Pane: () => null, Divider: () => null };`.
+7. `npm run typecheck` 통과.
+8. 커밋: `feat(SplitPane): 타입 + 테마 + 배럴`.
+
+### Step 2 — Context + 기본 렌더
+1. `SplitPaneContext.ts` + `useSplitPaneContext`.
+2. `SplitPaneRoot` 의 flex 컨테이너 + Pane/Divider children 기본 DOM 만 렌더 (리사이즈 아직 없음).
+3. `SplitPanePane` 는 context 에서 자신이 start/end 인지 알기 위해 `React.Children.toArray(children)` 순서 기준으로 index 부여 — Root 가 Children.map 하면서 Pane 에 index prop 을 inject하는 방식이 가장 단순 (React 공식 패턴 참조).
+4. 초기 size 50% 하드코딩.
+5. 커밋: `feat(SplitPane): 기본 flex 레이아웃 + context`.
+
+### Step 3 — usePaneResize 훅 (pointer drag)
+1. `usePaneResize.ts`. pointerdown/move/up + pointer capture + userSelect lock.
+2. drag 중 `document.body.style.cursor` 토글.
+3. rAF throttle.
+4. dev 콘솔에 `[SplitPane] dragging size=...` 같은 임시 로그(차후 제거).
+5. `SplitPaneRoot` 에서 훅 호출, sizePx 상태 + flex-basis 적용.
+6. 커밋: `feat(SplitPane): pointer drag 리사이즈`.
+
+### Step 4 — min/max/snap/clamp + containerPx ResizeObserver
+1. min/max 를 SplitPaneSize → px 로 변환 + clamp.
+2. ResizeObserver 로 containerPx 동기화.
+3. snapSize + snapThreshold 반영.
+4. 커밋: `feat(SplitPane): min/max/snap + ResizeObserver`.
+
+### Step 5 — localStorage persist + controlled/uncontrolled
+1. `storageKey` 로직.
+2. `size` prop 지원 (controlled). controlled + storageKey 동시 지정 시 dev warn.
+3. `onSizeChange`, `onSizeChangeEnd` 콜백 호출 타이밍 정리.
+4. 커밋: `feat(SplitPane): controlled API + persist`.
+
+### Step 6 — 키보드 + ARIA
+1. divider `tabindex=0`, `role="separator"`, `aria-orientation`, `aria-valuenow/min/max`.
+2. `onDividerKeyDown`: Arrow / Shift+Arrow / Home / End / Escape.
+3. 커밋: `feat(SplitPane): 키보드 + ARIA`.
+
+### Step 7 — collapse / expand + CollapseButton
+1. `collapsible`, `collapsedSize`, `collapseThreshold` 반영.
+2. `toggleCollapse` 로직 + preCollapseRef.
+3. Enter/Space 로 divider focus 시 토글.
+4. `SplitPane.CollapseButton` 컴포넌트.
+5. CSS transition (drag 중 아님 확인).
+6. 커밋: `feat(SplitPane): collapse/expand`.
+
+### Step 8 — RTL + drag overlay
+1. `dir="rtl"` 감지 + delta 부호 반전.
+2. drag 중 `position:fixed;inset:0;z-index:9999` overlay 렌더로 iframe pointer 유실 방지.
+3. 커밋: `feat(SplitPane): RTL + drag overlay`.
+
+### Step 9 — Dark 테마
+1. palette dark 통합.
+2. `theme="dark"` prop 전파.
+3. 커밋: `feat(SplitPane): dark 테마`.
+
+### Step 10 — 데모 페이지
+1. `demo/src/pages/SplitPanePage.tsx` (§12).
+2. `demo/src/App.tsx` NAV 에 `"splitpane"` 추가.
+3. 커밋: `feat(SplitPane): 데모 페이지`.
+
+### Step 11 — PipelineGraphInspector 리팩터링 (후속, optional)
+1. `PipelineGraphInspector.tsx` 의 `onDividerPointerDown` 블록을 제거.
+2. 외부에서 `<SplitPane.Root direction={position === "right" ? "horizontal" : "vertical"} collapsible="end" ...>` 으로 감싸 inspector panel 을 구성하거나, inspector 내부에서 SplitPane 사용.
+3. 기존 동작 동일 유지 검증.
+4. 커밋: `refactor(PipelineGraph): inspector 리사이즈를 SplitPane 기반으로 교체`.
+
+> **주의**: 다른 agent 가 병렬 작업 중 — 013~022 브랜치. PipelineGraph 관련 파일을 수정하는 리팩터링(Step 11)은 PipelineGraph 를 만지는 다른 plan 과 충돌 위험이 있으므로 **v1 본 PR 에 포함하지 않고**, 별도 후속 PR 로 분리 권장 (§17 참조).
+
+### Step 12 — 마감
+1. Props 표 채움 + Usage 예제 (§12).
+2. `§20 Definition of Done` 전부 체크.
+3. 커밋: `feat(SplitPane): 데모 props 표 + usage`.
+
+---
+
+## 12. 데모 페이지
+
+`demo/src/pages/SplitPanePage.tsx`. 기존 페이지(HexViewPage, PipelineGraphPage 등) 구조 복제. 섹션별 `<section id="...">` + 우측 사이드바 연동.
+
+### 12.1 NAV 추가 (App.tsx)
+
+```ts
+{ id: "splitpane", label: "SplitPane", description: "드래그 분할 레이아웃", sections: [
+  { label: "Basic horizontal",     id: "basic" },
+  { label: "Vertical",             id: "vertical" },
+  { label: "Min / Max",            id: "minmax" },
+  { label: "Collapsible",          id: "collapsible" },
+  { label: "Nested (2×2)",         id: "nested" },
+  { label: "Snap",                 id: "snap" },
+  { label: "Persist",              id: "persist" },
+  { label: "Dark",                 id: "dark" },
+  { label: "Controlled size",      id: "controlled" },
+  { label: "Playground",           id: "playground" },
+  { label: "Props",                id: "props" },
+  { label: "Usage",                id: "usage" },
+]},
+```
+
+그리고 `Page` 타입에 `"splitpane"` 추가 + 하단 `{current === "splitpane" && <SplitPanePage />}`.
+
+### 12.2 섹션 구성
+
+**Basic horizontal**
+```tsx
+<div style={{ height: 240, border: "1px solid #e5e7eb", borderRadius: 8 }}>
+  <SplitPane.Root defaultSize="40%">
+    <SplitPane.Pane><FakeFileTree /></SplitPane.Pane>
+    <SplitPane.Divider />
+    <SplitPane.Pane><FakeEditor /></SplitPane.Pane>
+  </SplitPane.Root>
+</div>
+```
+
+**Vertical**
+```tsx
+<div style={{ height: 320 }}>
+  <SplitPane.Root direction="vertical" defaultSize="60%">
+    <SplitPane.Pane><FakeEditor /></SplitPane.Pane>
+    <SplitPane.Divider />
+    <SplitPane.Pane><FakeTerminal /></SplitPane.Pane>
+  </SplitPane.Root>
+</div>
+```
+
+**Min / Max**
+```tsx
+<SplitPane.Root defaultSize={240} minSize={160} maxSize={520}>...
+```
+
+**Collapsible (접고 펴기 버튼 포함)**
+```tsx
+<SplitPane.Root
+  defaultSize="30%"
+  collapsible="start"
+  collapsedSize={0}
+  collapseThreshold={80}
+>
+  <SplitPane.Pane>
+    <div className="flex justify-between p-2">
+      <span>Sidebar</span>
+      <SplitPane.CollapseButton which="start" />
+    </div>
+    <FakeFileTree />
+  </SplitPane.Pane>
+  <SplitPane.Divider />
+  <SplitPane.Pane>
+    <FakeEditor />
+  </SplitPane.Pane>
+</SplitPane.Root>
+```
+
+**Nested (2×2 복합)** — `Pane` 안에 `SplitPane.Root` 를 또 중첩하여 좌/우 + 우측의 상/하 분할.
+```tsx
+<SplitPane.Root defaultSize="30%">
+  <SplitPane.Pane><Left /></SplitPane.Pane>
+  <SplitPane.Divider />
+  <SplitPane.Pane>
+    <SplitPane.Root direction="vertical" defaultSize="70%">
+      <SplitPane.Pane><Editor /></SplitPane.Pane>
+      <SplitPane.Divider />
+      <SplitPane.Pane><Terminal /></SplitPane.Pane>
+    </SplitPane.Root>
+  </SplitPane.Pane>
+</SplitPane.Root>
+```
+
+**Snap (midpoint 에 snap)**
+```tsx
+<SplitPane.Root defaultSize="30%" snapSize="50%" snapThreshold={12}>...
+```
+
+**Persist (storageKey 로 새로고침해도 유지)**
+```tsx
+<SplitPane.Root storageKey="demo:splitpane:persist" defaultSize="40%">...
+```
+아래에 "Reload this page — 50% → 40% 조정 → 새로고침 → 유지됨" 안내 문구 + "Clear storage" 버튼.
+
+**Dark**
+`<SplitPane.Root theme="dark">` + 배경 `#0f172a` 래퍼.
+
+**Controlled size (외부 버튼으로 30% / 50% / 70% 프리셋)**
+```tsx
+const [size, setSize] = useState<SplitPaneSize>("50%");
+return (
+  <>
+    <div className="flex gap-2 mb-2">
+      <Button onClick={() => setSize("30%")}>30%</Button>
+      <Button onClick={() => setSize("50%")}>50%</Button>
+      <Button onClick={() => setSize("70%")}>70%</Button>
+    </div>
+    <div style={{ height: 240 }}>
+      <SplitPane.Root size={size} onSizeChange={(_, pct) => setSize(`${Math.round(pct)}%`)}>
+        <SplitPane.Pane><Left /></SplitPane.Pane>
+        <SplitPane.Divider />
+        <SplitPane.Pane><Right /></SplitPane.Pane>
+      </SplitPane.Root>
+    </div>
+  </>
+);
+```
+
+**Playground**
+상단 컨트롤 바:
+- `direction` 라디오 (horizontal / vertical)
+- `defaultSize` select ("25%", "50%", "75%", "200px")
+- `minSize` input (number)
+- `maxSize` input (px or %)
+- `collapsible` 라디오 (none / start / end / both)
+- `snapSize` 체크박스 + value
+- `storageKey` 토글 (on/off)
+- `theme` 토글 (light/dark)
+- `disabled` 체크박스
+
+아래에 400 px 높이 컨테이너에 `<SplitPane.Root {...args}>` 렌더, 각 pane 에 현재 크기를 표시하는 작은 패널.
+
+**Props 표**
+기존 페이지 패턴 그대로. `SplitPane.Root` 의 모든 prop × 타입 × 기본값 × 설명.
+
+**Usage (4개)**
+1. 기본 2-pane.
+2. IDE 스타일 (파일 트리 좌 + 에디터 우).
+3. Controlled + storageKey + collapse.
+4. Nested 2×2 (좌/우 + 우측의 상/하).
+
+**IDE 스타일 샘플 코드**:
+```tsx
+function IDELayout() {
+  return (
+    <SplitPane.Root
+      defaultSize={240}
+      minSize={160}
+      maxSize="40%"
+      collapsible="start"
+      collapsedSize={32}
+      storageKey="ide:sidebar"
+    >
+      <SplitPane.Pane label="File tree">
+        <aside className="h-full bg-slate-50 overflow-auto">
+          <FileTree />
+        </aside>
+      </SplitPane.Pane>
+      <SplitPane.Divider />
+      <SplitPane.Pane label="Editor">
+        <SplitPane.Root direction="vertical" defaultSize="70%" minSize={80}>
+          <SplitPane.Pane>
+            <Editor />
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane>
+            <Terminal />
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </SplitPane.Pane>
+    </SplitPane.Root>
+  );
+}
+```
+
+---
+
+## 13. 검증 계획
+
+### 13.1 자동화
+```bash
+cd /Users/neo/workspace/plastic
+npm run typecheck
+npx tsup
+```
+주의: `exactOptionalPropertyTypes: true` — optional prop 은 `?:` 로 받고 디폴트 머지에서 `undefined` 분기. `noUncheckedIndexedAccess: true` — `React.Children.toArray()[i]` 는 `ReactNode | undefined`. `verbatimModuleSyntax: true` — 타입은 `import type`.
+
+### 13.2 수동 (demo dev server)
+```bash
+cd demo && npm run dev
+```
+
+체크리스트:
+- [ ] Basic horizontal: 40% 시작, 드래그로 리사이즈, end pane 자동 확장.
+- [ ] Vertical: 상/하 분할, cursor=row-resize.
+- [ ] Min/Max: minSize 이하로 드래그 시 멈춤, maxSize 초과 시 멈춤.
+- [ ] Snap: snapSize 근처 8 px 이내로 진입 시 그 값에 고정, 벗어나면 해제.
+- [ ] Collapsible start: 드래그로 collapseThreshold 밑으로 → 0 으로 snap, 반대로 벌리면 복원.
+- [ ] CollapseButton: 버튼 클릭 시 current size 저장 후 collapse, 다시 클릭 시 저장값 복원.
+- [ ] Keyboard: divider focus 후 Arrow → 10px, Shift+Arrow → 100px, Home → minSize, End → maxSize, Enter/Space → collapse toggle, Esc (drag 중) → startSize 복원.
+- [ ] Persist: storageKey 설정 + drag → 새로고침 → 저장값으로 복원. Clear storage → defaultSize 로.
+- [ ] Controlled size: 외부 버튼 30/50/70% 프리셋 변화 즉시 반영. 사용자가 드래그 해도 onSizeChange 콜백만 호출되고 외부 state 주도.
+- [ ] Dark 테마: divider/hover/active 색상 전부 다크로 전환.
+- [ ] Nested: 내부 SplitPane 도 독립 drag/collapse/keyboard.
+- [ ] Playground: 모든 컨트롤 조합이 실시간 반영.
+- [ ] 다른 페이지 리그레션 없음.
+
+### 13.3 엣지 케이스
+- [ ] children 이 Pane, Divider, Pane 외의 조합 → dev warn `[SplitPane] expected exactly 2 Pane + 1 Divider in order`.
+- [ ] 컨테이너 크기 = 0 (initial render, display:none 전환 시) → `sizePx` 계산 가드 (`if (containerPx <= 0) return`).
+- [ ] controlled + storageKey 동시 → dev warn, storageKey 무시.
+- [ ] `defaultSize="50%"` + 드래그 → 내부는 px 로 전환. 이후 창 리사이즈 → 같은 px 유지 (%로 따라가지 않음). 원하면 percent persist 는 v1.1.
+- [ ] iframe 포함된 pane 위로 drag → overlay 가 iframe 을 덮어 이벤트 유실 없음.
+- [ ] textarea selection 과 드래그 혼동 → `userSelect:none` 으로 방지.
+- [ ] `disabled` 시 divider cursor default, pointerdown/keyboard 무효.
+- [ ] 매우 작은 container (< minSize * 2): min/max 가 서로 모순 → `minPx = min(minPx, containerPx/2)` 로 연화, maxPx 도 마찬가지. 경고 없이 최선.
+- [ ] direction 중간에 바꾸기 (horizontal ↔ vertical): sizePx 유지 (px 의미는 달라짐, 문서화). 필요하면 clamp 재적용.
+- [ ] Multi-pointer (멀티터치): `setPointerCapture` 덕에 첫 pointerId 만 추적, 나머지 무시.
+
+---
+
+## 14. 성능
+
+### 14.1 목표
+- 드래그 중 **60 fps** (일반 노트북 + React DevTools 없이).
+- 초기 마운트 < 2 ms (컨테이너 크기만 측정).
+
+### 14.2 병목 가설 + 완화
+1. **pointermove 빈도**: 120 Hz 트랙패드에서 초당 240+ 이벤트 → React state update 240+ 회 = drop frames 가능. 완화: `requestAnimationFrame` 로 한 프레임당 최대 1 회만 setState. 구현은 `pendingNext.current` 마지막 값만 반영 (§5.1).
+2. **flex-basis 변경 시 layout**: start pane 1 회 + end pane flex:1 재계산. 가벼움. 복잡한 child 가 있으면 re-layout cost 증가 → 사용자 측 overflow:hidden / contain:layout 권장 문서화.
+3. **Context 값 매 렌더**: Root 가 매 드래그 프레임마다 `SplitPaneContext.Provider value={{…}}` 새로 만들면 Pane/Divider 가 re-render. 완화: `Pane` 은 size 에 의존하지 않으므로 Context 를 **구독하지 않거나** size 를 별도 subcontext 로 분리하는 것도 가능. v1 은 단일 context 로 단순화하되 `Pane`, `Divider` 를 `React.memo` 로 감싸고, Pane 내부가 size 에 의존 않도록 — size 는 오직 Root 가 flex-basis 로 적용. Divider 는 `aria-valuenow` 를 ref 기반 DOM 업데이트로 동기화하여 rerender 회피.
+4. **ResizeObserver 스로틀**: ResizeObserver 는 브라우저가 이미 rAF 단위로 batch 하므로 추가 throttle 불필요.
+
+### 14.3 측정 방법
+- DevTools Performance 탭에서 드래그 1 초간 녹화 → 60 fps 유지 확인.
+- `console.time` 없이 육안 + "드래그 랙 없음" 체감.
+
+---
+
+## 15. 접근성
+
+- root: `role="group"` + `aria-label` (사용자 prop 으로 override 가능).
+- Pane: `role="region"` + `aria-label="{label ?? 'Pane 1' / 'Pane 2'}"`. `tabindex` 무지정(내부 포커스 가능한 요소가 있을 것).
+- Divider:
+  - `role="separator"`
+  - `aria-orientation="vertical"` (horizontal split 은 세로 divider) / `"horizontal"`
+  - `aria-valuemin="{minPct round}"`, `aria-valuemax="{maxPct round}"`, `aria-valuenow="{sizePct round}"`
+  - `aria-controls="{startPane.id} {endPane.id}"` (선택적, id 자동 생성)
+  - `aria-label="Resize panes"` (사용자 override 가능)
+  - `tabindex="0"` (항상 포커스 가능)
+- collapse 상태에서: divider 는 여전히 포커스 가능. `aria-valuenow` 는 0 (start collapse) 또는 100 (end collapse). 스크린리더는 "separator, 0%" 읽음.
+- drag 중 `data-dragging="true"` + role/aria 변경 없음 (screen reader 에는 value change announcement 만).
+- `CollapseButton`: `<button aria-expanded={!isCollapsed} aria-controls="{pane.id}" aria-label="Toggle sidebar">`.
+
+---
+
+## 16. 알려진 트레이드오프 · 결정
+
+1. **`flex-basis` vs `grid-template-columns`**: flex 선택 (§4.2). grid 는 `transition` 이 track 단위로 동작이 브라우저별 불안정, flex 는 30 년간 안정. grid 는 3+ pane 확장 시 고려 대상.
+2. **percent 를 px 로 즉시 변환 (내부 px-only)**: 사용자 의도를 엄밀히 보존하려면 "percent 단위 유지 + render 시만 px 로 계산" 이 맞지만, 드래그 도중 모든 delta 가 px 단위로 들어오고 결과 commit 도 px 이므로 변환을 드래그 시마다 하는 것은 낭비. 대신 ResizeObserver 로 컨테이너가 변했을 때 "원래 저장값이 percent 였는지" 를 모르면 잘못된 clamp 가 일어난다 — 이 tradeoff 는 v1 에서 **저장값은 px 고정**(persist 도 px)으로 수용. percent 지속 보존은 v1.1.
+3. **단일 snap 지점**: multi-snap (예: 25/50/75) 도 가능하지만 UX 복잡도 ↑. v1 은 하나. `snapSize` 배열로 확장 여지만 남김.
+4. **controlled 에서 storageKey 무시**: owner 의 state 가 진실 근원이므로 이중 persist 가 충돌. dev warn 후 무시. 대안(storageKey 우선) 은 controlled 의미와 어긋남.
+5. **collapse 는 컴포넌트가 아닌 "특정 사이즈"**: 별도 `isCollapsed` state 를 두지 않고 sizePx 파생. 장점: single-source-of-truth + 애니메이션 자연스러움. 단점: collapsedSize ≠ 0 일 때 "collapse 상태" 와 "그냥 작음" 이 헷갈릴 수 있다 → 0.5 px tolerance 로 판정 (§8.3).
+6. **divider 6 px 고정**: 접근성 WCAG 2.5.5(44 px 타겟)과 충돌. 대신 divider 에 `::before` pseudo-element 로 `-3px ~ +3px` 확장 hit area 제공 (총 12 px). 시각은 그대로 6 px, hit 은 12 px. v1 구현:
+   ```css
+   .sp-divider::before {
+     content: ""; position: absolute;
+     inset-inline: -3px; top: 0; bottom: 0;
+   }
+   .sp-divider[data-orientation="horizontal"]::before {
+     inset-block: -3px; left: 0; right: 0; inset-inline: 0;
+   }
+   ```
+7. **persist unit (px vs pct)**: px persist 가 "화면폭 변경 시 같은 크기 유지" 를 의도한 경우 맞지만, "같은 비율 유지" 를 원하는 경우 틀림. v1 은 px. `storageUnit?: "px" | "pct"` 는 v1.1.
+8. **2-pane 만 지원**: `Pane, Divider, Pane, Divider, Pane` 같은 3+ 구성은 divider 간 리사이즈 상호작용(한 divider 움직이면 이웃 pane 만/전체 재분배 정책) 결정이 복잡. VSCode/react-resizable-panels 가 채택한 "greedy vs evenly" 선택 옵션 등 설계 공간이 크므로 별도 마이너 릴리스로 분리.
+9. **React.memo 사용**: Pane/Divider/CollapseButton 에 memo 적용. Context value 변경 시 이들이 재렌더되는 것을 피하기 위해 Divider 의 `aria-valuenow` 는 DOM ref 로 직접 업데이트.
+10. **`useId` 로 ARIA id 생성**: Pane 이 `id` 없이 시작하므로 Root 에서 `useId()` 로 base id 만들고 start/end 에 `-start`/`-end` 접미사.
+
+---
+
+## 17. 후속 작업 (v1.1+)
+
+- **3+ pane (multi-pane)**: `Pane, Divider, Pane, Divider, Pane` 배열 지원. divider 이동 정책 옵션 (`resizeMode: "adjacent" | "distribute"`). 크기 배열 `sizes: SplitPaneSize[]`.
+- **nested API 편의**: `layout: [[30, 70], [70, 30]]` 같은 선언형 레이아웃.
+- **layout presets**: `presets: { name: string; sizes: number[] }[]` + 버튼 UI.
+- **percent persist**: `storageUnit` prop.
+- **multi snap**: `snapSizes: SplitPaneSize[]`.
+- **touch handle affordance**: 큰 drag dot.
+- **drag constraint props**: `resizable: boolean` 동적 차단 외에 `onBeforeResize(sizeDraft) => boolean` 훅.
+- **animation preset**: collapse 애니메이션 duration/easing 커스터마이징.
+- **demo App 의 사이드바 리사이즈를 SplitPane 기반으로 리팩터링**: 현재 `demo/src/App.tsx` 에 동일 로직이 중복. plastic 스스로 자기 데모를 드레싱하는 데에 사용.
+- **PipelineGraphInspector 리팩터링**: `onDividerPointerDown` 제거하고 SplitPane 래퍼로 대체. 이 plan 본 PR 에는 포함하지 않음 (다른 agent 병렬 작업 충돌 회피).
+- **SSR 준비**: `localStorage` 접근 `typeof window` 가드 (v1 에서도 이미 포함).
+
+---
+
+## 18. 관련 파일 인벤토리 (구현 시 참조)
+
+| 용도 | 경로 |
+|---|---|
+| useControllable (dual API) | `/Users/neo/workspace/plastic/src/components/_shared/useControllable.ts` |
+| pointer drag 훅 패턴 (가장 유사) | `/Users/neo/workspace/plastic/src/components/DataTable/useColumnResize.ts` |
+| divider 리사이즈 prior impl (추출 대상) | `/Users/neo/workspace/plastic/src/components/PipelineGraph/PipelineGraphInspector.tsx` (line 315~340) |
+| 데모 App 내부 사이드바 리사이즈 (prior, 중복) | `/Users/neo/workspace/plastic/demo/src/App.tsx` (line 191~296) |
+| 이전 plan 포맷 참고 (템플릿) | `/Users/neo/workspace/plastic/docs/plans/012-pipelinegraph-component.md` |
+| 배럴 등록 | `/Users/neo/workspace/plastic/src/components/index.ts` |
+| 데모 페이지 레이아웃 패턴 | `/Users/neo/workspace/plastic/demo/src/pages/PipelineGraphPage.tsx`, `/Users/neo/workspace/plastic/demo/src/pages/HexViewPage.tsx` |
+| 데모 App 라우팅 / NAV | `/Users/neo/workspace/plastic/demo/src/App.tsx` |
+| tsconfig 제약 | `/Users/neo/workspace/plastic/tsconfig.json` |
+
+---
+
+## 19. 의존성 영향
+
+신규 런타임 의존 없음. React 18.3 (기존) + DOM API (`ResizeObserver`, `PointerEvent`, `localStorage`, `requestAnimationFrame`) 만 사용.
+
+번들 영향:
+- SplitPane 자체 예상 크기: ~3.5 KB (min), ~1.5 KB (min+gzip).
+- plastic 전체 dist 거의 영향 없음.
+
+Browser 지원:
+- ResizeObserver: Chrome 64+, Firefox 69+, Safari 13.1+. 모두 ES2020 라이브러리 타깃과 일관.
+- PointerEvents: 모든 모던 브라우저.
+- `setPointerCapture`: 동일.
+- CSS `touch-action: none`: 동일.
+
+---
+
+## 20. 구현 완료 정의 (Definition of Done)
+
+- [ ] `npm run typecheck` 통과.
+- [ ] `npx tsup` 통과 (타입 선언 포함).
+- [ ] demo 에 `/#/splitpane` 라우트 동작.
+- [ ] §13.2 수동 체크리스트 항목 전부 눈으로 확인.
+- [ ] §13.3 엣지 케이스 항목 전부 눈으로 확인 또는 "v1 범위 밖" 이유 기재.
+- [ ] PipelineGraph / CodeView / HexView / CommandPalette / DataTable / 기타 페이지 리그레션 없음.
+- [ ] `src/components/index.ts` 배럴에 `export * from "./SplitPane";` 추가됨.
+- [ ] `package.json` dependencies 변경 없음 (신규 의존 없음).
+- [ ] Props 문서 섹션이 Props 표로 채워져 있음 (Root/Pane/Divider/CollapseButton 네 개).
+- [ ] Usage 섹션에 최소 4 개 스니펫 (기본 / IDE / controlled+persist / nested 2×2).
+- [ ] 데모 Playground 에서 모든 prop 토글 가능.
+- [ ] Light/Dark 테마 전환 시 시각 이상 없음.
+- [ ] 키보드 단독으로 (마우스 없이) 리사이즈 + collapse toggle 이 가능.
+- [ ] 스크린리더(VoiceOver) 에서 divider 의 value 변경이 읽힘.
+
+---
+
+**끝.**

--- a/docs/plans/018-tree-component.md
+++ b/docs/plans/018-tree-component.md
@@ -1,0 +1,1715 @@
+# Tree 컴포넌트 설계문서
+
+## Context
+
+plastic 라이브러리에 "계층적(재귀적) 트리를 렌더링하고 확장/축소/선택/체크를 관리하는" `Tree` 컴포넌트를 추가한다. 역할 비유: VSCode 의 Explorer(파일 트리), Chrome DevTools 의 JSON 패널, Figma 의 레이어 패널, Finder 의 column/tree 뷰, 조직도(Org chart). 헤드리스 스타일(시각 최소, 상호작용·상태·접근성 코어만 제공) + runtime-zero(DOM + React 만) + VSCode 급 품질(키보드·ARIA·성능) 기조로 구성한다.
+
+참고 (prior art — UX 근거):
+- **Ant Design `Tree`** — checkable, multiple, draggable, async loadData, showLine, virtual. 풍부한 prop 셋은 본 v1 의 주요 참조 모델.
+- **react-arborist** — flatten + fixed-height virtual scroll + keyboard 일등시민. 성능·키보드 모델의 대표 구현.
+- **rc-tree** (antd 내부) — `TreeNode` + key 기반 state (expandedKeys, selectedKeys, checkedKeys) + halfCheckedKeys. Set 기반 모델 원형.
+- **Blueprint `Tree`** — `TreeNode<T>` 재귀 구조 + controlled props. TypeScript generic 타입 디자인 참조.
+- **MUI `TreeView`** (x-tree-view) — ARIA tree pattern 준수. role=tree/treeitem/group 표준.
+- **WAI-ARIA Authoring Practices — Tree View Pattern** — `role`, `aria-expanded`, `aria-selected`, `aria-level`, `aria-posinset`, `aria-setsize` 규약, typeahead 패턴.
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/_shared/useControllable.ts` — controlled/uncontrolled 이중 API 표준 훅. Set 값에도 그대로 사용 가능.
+- `src/components/PipelineGraph/PipelineGraphCluster.tsx` — 계층 구조(cluster > node) 의 expand/collapse 상태를 Set 으로 관리하는 prior 구현. 재귀 flatten 과 expand 토글 패턴 참조.
+- `src/components/DataTable/DataTableRow.tsx`, `DataTable.tsx` — 행 선택, 키보드 포커스 링, rowSelection Set 패턴. Tree 의 selection 구현에 동일 mental model 재사용.
+- `src/components/DataTable/useVirtualList.ts` — flattened row 가상 스크롤 prior. v1.1 virtualization 도입 시 동일 훅을 재사용/이식.
+- `src/components/CommandPalette/*` — typeahead(입력 기반 필터) 구현 및 ARIA focus 이동 패턴. Tree 의 typeahead 로직 참조.
+- `src/components/index.ts` — 배럴 파일. `export * from "./Tree";` 한 줄 추가 지점.
+- `demo/src/App.tsx` — NAV 추가 지점 + 사이드바 라우팅 패턴.
+- `demo/src/pages/CommandPalettePage.tsx` — 최근 데모 페이지 구조 (Basic / Nested / Async / Controlled / Dark / Playground / Props / Usage). 본 문서 §12 가 동일 패턴을 따름.
+- `tsconfig.json` — `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax` 제약 준수 필요.
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+<Tree.Root
+  data={data}                              // TreeNode<T>[] — 루트 배열
+  defaultExpanded={new Set(["src"])}
+  defaultSelected={new Set()}
+  selectionMode="single"                   // "none" | "single" | "multiple"
+  checkable                                 // checkbox 표시
+  defaultChecked={new Set()}
+  onExpandedChange={setExpanded}
+  onSelectedChange={setSelected}
+  onCheckedChange={setChecked}
+  loadChildren={async (node) => fetchChildren(node.id)}
+  theme="light"
+  indent={16}
+  renderNode={({ node, level, isExpanded, isSelected, isChecked }) => (
+    <>
+      <Tree.ExpandToggle />
+      <span>{node.icon}</span>
+      <Tree.Label>{node.label}</Tree.Label>
+    </>
+  )}
+>
+  {/* 또는 JSX 재귀로 직접 기술:
+      <Tree.Node id="src" label="src">
+        <Tree.Node id="src/index.ts" label="index.ts" />
+      </Tree.Node>
+  */}
+</Tree.Root>
+```
+
+렌더 결과 (VSCode 파일 트리 개념):
+```
+▾ src
+  ▸ components
+  ▾ utils
+      format.ts
+      parse.ts
+    index.ts
+▸ public
+  package.json
+```
+
+핵심 설계 원칙:
+- **compound 컴포넌트**. `Tree.Root / Tree.Node / Tree.Label / Tree.Children / Tree.ExpandToggle` 다섯 요소로 Context 상태 공유. 데이터 기반(`data` prop) 과 JSX 기반(`Tree.Node` 재귀) 양쪽 모두 지원.
+- **flatten-based 상태**. 트리 자체는 재귀 구조지만 상태는 `Set<id>` 3 개 (expanded / selected / checked) 로 평탄화 관리. VSCode · react-arborist 와 동일한 모델.
+- **id 는 유일 키**. `TreeNode<T>.id: string` 은 트리 전체에서 유일해야 하며, 중복 시 dev throw. path(경로) 는 자동 유도.
+- **controlled / uncontrolled 이중 API**. `expanded`/`defaultExpanded`, `selected`/`defaultSelected`, `checked`/`defaultChecked` 각 Set. `useControllable` 와 동일 계약.
+- **headless-first 렌더**. 기본 스타일은 얇게 제공하되 `renderNode` 훅 또는 `Tree.Node` children 조합으로 아이콘·라벨·메뉴·뱃지 등 자유 커스터마이즈.
+- **runtime 의존 zero**. React + DOM 만. virtualization/DnD 는 v1.1+ 로 미룸.
+- **접근성 · 키보드 우선**. `role="tree" + treeitem + group`, `aria-expanded/selected/level/posinset/setsize`, Arrow/Home/End/Space/Enter/`*`/typeahead.
+- **async lazy load**. `loadChildren(node)` 한 번만 호출, loading/error/cached 상태 유도.
+- **v1 은 DOM 렌더(비가상화)**. 노드 수 ~500 까지 체감 60 fps 목표. 1k+ 은 v1.1 virtualization.
+- **DnD 는 v1.1**. 본 v1 에서는 hook point(콜백 슬롯·데이터 모델 Set 기반 이동 함수) 만 확보하고 구현은 다음 마이너.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+
+1. 제네릭 `TreeNode<T>` 기반 계층 데이터 렌더 (재귀). `T` 는 사용자 payload.
+2. 확장/축소 상태(Set<id>) controlled/uncontrolled. `defaultExpanded` 또는 `expanded`, `onExpandedChange`.
+3. 선택 상태(Set<id>) 3 모드: `"none" | "single" | "multiple"`.
+4. 체크박스 모드 (`checkable`): 체크 상태 Set + **indeterminate(부분 체크)** 자동 계산 + 부모/자식 cascade.
+5. 비활성 노드 (`disabled: boolean` per node) — expand/selection/check 모두 무시.
+6. 재귀 자식: 데이터 모드(`children?: TreeNode<T>[]`) 및 JSX 모드(`<Tree.Node>` 재귀) 양립.
+7. 지연 로딩 (`loadChildren(node)`): 최초 expand 시점에 1회 호출, loading/error 상태 노출.
+8. 키보드 네비게이션: ↑ ↓ (flatten 기준 prev/next), → (닫혀있으면 열기, 열려있으면 첫 자식으로), ← (열려있으면 닫기, 닫혀있으면 부모로), Home/End (처음/끝), Space (선택 토글 / 체크 토글), Enter (선택), `*` (현재 레벨 전체 확장), 문자열 typeahead.
+9. custom node render: `renderNode` prop 또는 `Tree.Node` children 로 커스터마이즈. 기본 렌더는 `▸/▾ {label}`.
+10. indent guide(얇은 세로선): prop 토글 (`showIndentGuides`).
+11. 아이콘 슬롯: `TreeNode.icon?: React.ReactNode` 또는 `renderNode` 내에서 렌더.
+12. Light / Dark 테마 (`theme="light" | "dark"`).
+13. 완전한 ARIA: `role="tree" / "treeitem" / "group"`, `aria-expanded`, `aria-selected`, `aria-level`, `aria-posinset`, `aria-setsize`, `aria-checked="mixed"` (indeterminate).
+14. 중복 id 감지: 전체 트리를 flatten 하면서 Set 으로 중복 체크. dev 에서 throw.
+15. max depth 제약 (기본 32). 넘으면 dev warn + 렌더 중단.
+16. "전체 펴기/접기" 유틸: `expandAll()`, `collapseAll()` ref API (`Tree.Root` forwardRef).
+17. controlled expanded 가 아닐 때: mount 직후 `defaultExpanded` 에 포함된 id 만 열림. 이후 사용자 토글로 변경.
+
+### Non-goals (v1 제외)
+
+- **Virtualization (가상 스크롤)**: flatten 후 고정 높이 기반 virtual list 는 v1.1. v1 은 DOM 전체 렌더. 500 노드 기준 60 fps 을 목표로 설계.
+- **Drag and Drop**: 노드 이동/복사 UX. v1.1 에서 `onMove(src, dst, position)` + drop indicator + `dragHandle` 로 도입.
+- **멀티 루트(시각적 포레스트) 고급 API**: `data` prop 은 이미 배열이므로 멀티 루트 자체는 v1 지원. 다만 "각 루트 간 교차 선택 범위(shift-click 범위 선택)" 같은 고급 상호작용은 v1 단일 루트 가정으로 단순 구현.
+- **트리 편집 (rename / add / delete)**: 셀 편집 UI. v1 범위 밖. 사용자가 외부에서 data 조작 후 재렌더하는 것은 언제나 가능.
+- **필터/검색 내장 UI**: 검색 박스와 match highlighting. v1 은 매치 API (`filter?: (node) => boolean`) 만 데이터 레벨에서 지원, UI 는 사용자가.
+- **드래그 rubber-band 범위 선택**: v1 은 클릭 + Shift+클릭 + Ctrl/Cmd+클릭 만.
+- **애니메이션**: expand/collapse 의 height 애니메이션은 CSS transition 한 줄로만. 복잡한 stagger 애니메이션 아님.
+- **무한 depth 스크롤 들여쓰기 자동 조정**: level \* indent 가 컨테이너 폭 초과 시 horizontal scroll 로 맡김. 자동 wrap 아님.
+- **contextmenu**: 우클릭 메뉴 본체는 별도 Menu 컴포넌트(후속). v1 은 `onContextMenu` prop 만 forward.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Tree/Tree.types.ts`
+
+```ts
+import type React from "react";
+
+export type TreeTheme = "light" | "dark";
+
+export type TreeSelectionMode = "none" | "single" | "multiple";
+
+/**
+ * 제네릭 트리 노드.
+ * - id: 트리 내 전역 유일. 중복 시 dev throw.
+ * - label: 기본 렌더 텍스트. renderNode 사용 시 무시 가능.
+ * - children: 자식 배열. undefined = "unknown"(loadChildren 사용 가능). [] = "확실히 없음(leaf)".
+ * - hasChildren: lazy load 일 때 children 이 undefined 여도 "확장 가능" 표시용. true/false 명시 가능.
+ * - disabled: 해당 노드 및 하위 상호작용 차단.
+ * - icon: 선택적 아이콘 슬롯.
+ * - data: 사용자 payload (제네릭 T).
+ */
+export interface TreeNode<T = unknown> {
+  id: string;
+  label?: React.ReactNode;
+  children?: TreeNode<T>[];
+  hasChildren?: boolean;
+  disabled?: boolean;
+  icon?: React.ReactNode;
+  data?: T;
+}
+
+export interface TreeRenderNodeArgs<T> {
+  node: TreeNode<T>;
+  level: number;        // 0-based
+  path: string[];       // root → self 의 id 체인 (포함)
+  isExpanded: boolean;
+  isSelected: boolean;
+  isChecked: boolean;
+  isIndeterminate: boolean;
+  isDisabled: boolean;
+  isLoading: boolean;   // async 진행 중
+  hasChildren: boolean; // 확장 가능 여부
+  isFocused: boolean;   // 현재 키보드 포커스
+}
+
+export interface TreeRootProps<T = unknown> {
+  /** 데이터 배열(루트). JSX 모드(`<Tree.Node>` 재귀)로 대체 가능. */
+  data?: TreeNode<T>[];
+
+  /** 확장된 id 집합. controlled. */
+  expanded?: ReadonlySet<string>;
+  defaultExpanded?: ReadonlySet<string>;
+  onExpandedChange?: (next: ReadonlySet<string>) => void;
+
+  /** 선택 모드. 기본 "none". */
+  selectionMode?: TreeSelectionMode;
+  /** 선택된 id 집합. */
+  selected?: ReadonlySet<string>;
+  defaultSelected?: ReadonlySet<string>;
+  onSelectedChange?: (next: ReadonlySet<string>) => void;
+
+  /** 체크박스 모드 활성. 기본 false. */
+  checkable?: boolean;
+  /** 체크된 id 집합. indeterminate 는 제외(자동 유도). */
+  checked?: ReadonlySet<string>;
+  defaultChecked?: ReadonlySet<string>;
+  onCheckedChange?: (next: ReadonlySet<string>) => void;
+  /**
+   * 부모-자식 cascade 정책. 기본 "parent-child".
+   * - "parent-child": 부모 체크 → 자식 전부 체크, 자식 전부 체크 → 부모 체크.
+   * - "self":        cascade 없음 (독립 체크). indeterminate 도 계산 안 함.
+   */
+  checkCascade?: "parent-child" | "self";
+
+  /** async 자식 로더. 최초 expand 시 1회 호출. */
+  loadChildren?: (node: TreeNode<T>) => Promise<TreeNode<T>[]>;
+
+  /** 노드 렌더 커스터마이즈. 미지정 시 기본 렌더. */
+  renderNode?: (args: TreeRenderNodeArgs<T>) => React.ReactNode;
+
+  /** 들여쓰기 픽셀 (level * indent). 기본 16. */
+  indent?: number;
+  /** 얇은 세로 가이드 라인 표시. 기본 false. */
+  showIndentGuides?: boolean;
+
+  /** 최대 depth (재귀 안전장치). 기본 32. */
+  maxDepth?: number;
+
+  /** Light / Dark. 기본 "light". */
+  theme?: TreeTheme;
+
+  /** 전체 비활성. */
+  disabled?: boolean;
+
+  /** ARIA 라벨 (role=tree). 스크린리더용. */
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+
+  /** 이벤트 */
+  onNodeActivate?: (node: TreeNode<T>) => void;   // Enter 또는 더블클릭
+  onNodeContextMenu?: (node: TreeNode<T>, e: React.MouseEvent) => void;
+
+  /** 필터. true 리턴한 노드만 렌더. 부모는 매칭 자식이 있으면 유지. */
+  filter?: (node: TreeNode<T>) => boolean;
+
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;                      // JSX 모드
+}
+
+export interface TreeNodeProps {
+  /** 전역 유일 id. */
+  id: string;
+  label?: React.ReactNode;
+  icon?: React.ReactNode;
+  disabled?: boolean;
+  hasChildren?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+  /** JSX 자식 (다시 Tree.Node 들). 없거나 [] 면 leaf. */
+  children?: React.ReactNode;
+}
+
+export interface TreeLabelProps {
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}
+
+export interface TreeExpandToggleProps {
+  className?: string;
+  style?: React.CSSProperties;
+  /** 커스텀 ▸/▾. 미지정 시 기본 텍스트 triangle. */
+  collapsedIcon?: React.ReactNode;
+  expandedIcon?: React.ReactNode;
+  loadingIcon?: React.ReactNode;
+  /** leaf 에서 공간 예약(alignment) 유지 여부. 기본 true. */
+  reserveSpaceForLeaf?: boolean;
+}
+
+export interface TreeChildrenProps {
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}
+
+/** forwardRef 로 노출되는 imperative API. */
+export interface TreeRootHandle {
+  expandAll(): void;
+  collapseAll(): void;
+  expandTo(id: string): void;   // id 의 모든 조상 확장
+  focus(id?: string): void;     // 특정 노드 포커스 (미지정 시 첫 노드)
+  getExpanded(): ReadonlySet<string>;
+  getSelected(): ReadonlySet<string>;
+  getChecked(): ReadonlySet<string>;
+}
+```
+
+### 2.2 배럴
+
+```ts
+// src/components/Tree/index.ts
+export { Tree } from "./Tree";
+export type {
+  TreeNode,
+  TreeTheme,
+  TreeSelectionMode,
+  TreeRootProps,
+  TreeNodeProps,
+  TreeLabelProps,
+  TreeExpandToggleProps,
+  TreeChildrenProps,
+  TreeRenderNodeArgs,
+  TreeRootHandle,
+} from "./Tree.types";
+```
+
+그리고 `src/components/index.ts` 에 `export * from "./Tree";` 한 줄 추가.
+
+### 2.3 Compound namespace
+
+```ts
+// Tree.tsx
+export const Tree = {
+  Root: TreeRoot,            // forwardRef<TreeRootHandle>
+  Node: TreeNode_,           // JSX 모드에서 사용자 사용
+  Label: TreeLabel,
+  Children: TreeChildren,    // JSX 모드에서 children 슬롯 명시
+  ExpandToggle: TreeExpandToggle,
+};
+```
+
+displayName: `"Tree.Root"`, `"Tree.Node"`, `"Tree.Label"`, `"Tree.Children"`, `"Tree.ExpandToggle"`.
+
+### 2.4 사용 모드 2 가지
+
+**(A) Data-driven (권장)** — 외부에서 `TreeNode<T>[]` 만들어 주입. renderNode 로 커스터마이즈.
+```tsx
+<Tree.Root data={fileTreeData} renderNode={({ node, isExpanded }) => ...} />
+```
+
+**(B) JSX-recursive** — 선언형 스크립트 인라인. 정적·적은 노드에 유리.
+```tsx
+<Tree.Root>
+  <Tree.Node id="src" label="src">
+    <Tree.Node id="src/index.ts" label="index.ts" />
+  </Tree.Node>
+  <Tree.Node id="public" label="public" />
+</Tree.Root>
+```
+JSX 모드는 내부에서 children 을 순회해 `TreeNode<T>[]` 로 변환 후 동일 파이프라인에 투입.
+
+---
+
+## 3. 도메인 모델
+
+### 3.1 id · path · depth
+
+- `id: string` — 트리 전역 유일. 중복 시 dev throw `[Tree] duplicate id: "src/index.ts"` + 해당 노드 렌더 skip.
+- `path: string[]` — root → self 의 id 체인. 예: `["src", "utils", "format.ts"]`. renderNode 에 전달. 내부 breadcrumb/선택 범위 계산 등 다용도.
+- `level: number` — 0-based depth. root 노드는 `level=0`. JSX 모드에서도 중첩 깊이로 계산.
+- `index.ts` 라는 label 이 여러 폴더에 있어도 id 만 다르면 문제 없음.
+
+### 3.2 flatten
+
+렌더 파이프라인은 항상 `flatten(data, expanded)` 으로 평탄화한 뒤 순차 렌더. 평탄화는 pre-order DFS.
+
+```ts
+interface FlatItem<T> {
+  node: TreeNode<T>;
+  level: number;
+  path: string[];
+  parentId: string | null;
+  index: number;          // 부모 내 순서 (posinset)
+  siblingCount: number;   // 부모의 자식 수 (setsize)
+  isExpanded: boolean;
+  hasChildren: boolean;
+  isLeaf: boolean;
+}
+
+function flatten<T>(
+  roots: TreeNode<T>[],
+  expanded: ReadonlySet<string>,
+  maxDepth: number,
+  loadedChildren: Map<string, TreeNode<T>[]>,
+): FlatItem<T>[] {
+  const out: FlatItem<T>[] = [];
+  const seen = new Set<string>();
+  function walk(nodes: TreeNode<T>[], level: number, path: string[], parentId: string | null) {
+    if (level >= maxDepth) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(`[Tree] maxDepth(${maxDepth}) exceeded at ${parentId}`);
+      }
+      return;
+    }
+    nodes.forEach((node, i) => {
+      if (seen.has(node.id)) {
+        if (process.env.NODE_ENV !== "production") {
+          throw new Error(`[Tree] duplicate id: "${node.id}"`);
+        }
+        return;
+      }
+      seen.add(node.id);
+      const loaded = loadedChildren.get(node.id);
+      const children = loaded ?? node.children;
+      const hasChildren = node.hasChildren ?? (children != null && children.length > 0);
+      const isLeaf = !hasChildren;
+      const isExpanded = expanded.has(node.id);
+      const nextPath = [...path, node.id];
+      out.push({
+        node, level, path: nextPath, parentId,
+        index: i, siblingCount: nodes.length,
+        isExpanded, hasChildren, isLeaf,
+      });
+      if (isExpanded && children && children.length > 0) {
+        walk(children, level + 1, nextPath, node.id);
+      }
+    });
+  }
+  walk(roots, 0, [], null);
+  return out;
+}
+```
+
+`flatten` 은 `useMemo` 로 캐싱 (deps: `data`, `expanded`, `loadedChildren`, `maxDepth`).
+
+### 3.3 indexByPath / nodeById
+
+```ts
+const nodeById = useMemo(() => {
+  const m = new Map<string, TreeNode<T>>();
+  function walk(ns: TreeNode<T>[]) {
+    for (const n of ns) {
+      m.set(n.id, n);
+      if (n.children) walk(n.children);
+    }
+  }
+  if (data) walk(data);
+  // loadedChildren 에서 로드된 것도 등록
+  loadedChildren.forEach((cs) => walk(cs));
+  return m;
+}, [data, loadedChildren]);
+```
+
+### 3.4 상태 Set
+
+3 개 독립 Set, 각기 controlled/uncontrolled:
+
+```ts
+const [expanded, setExpanded] = useControllable<ReadonlySet<string>>(
+  props.expanded, props.defaultExpanded ?? EMPTY_SET, props.onExpandedChange,
+);
+const [selected, setSelected] = useControllable<ReadonlySet<string>>(
+  props.selected, props.defaultSelected ?? EMPTY_SET, props.onSelectedChange,
+);
+const [checked, setChecked] = useControllable<ReadonlySet<string>>(
+  props.checked, props.defaultChecked ?? EMPTY_SET, props.onCheckedChange,
+);
+```
+
+`EMPTY_SET = new Set<string>()` 는 모듈 상수 (매 렌더 새 Set 생성 회피).
+
+Set 변경은 항상 **새 Set 생성 후 치환** (immutable). `setExpanded(new Set([...expanded, id]))`.
+
+### 3.5 indeterminate 계산
+
+`checkable + checkCascade === "parent-child"` 일 때:
+
+```ts
+interface CheckViewModel {
+  checked: Set<string>;        // UI 상 "완전 체크"
+  indeterminate: Set<string>;  // UI 상 "부분 체크"
+}
+
+function deriveCheckVM<T>(
+  roots: TreeNode<T>[],
+  rawChecked: ReadonlySet<string>,
+  loadedChildren: Map<string, TreeNode<T>[]>,
+): CheckViewModel {
+  const checked = new Set<string>();
+  const indeterminate = new Set<string>();
+
+  function walk(node: TreeNode<T>): { fully: boolean; any: boolean } {
+    const kids = loadedChildren.get(node.id) ?? node.children ?? [];
+    if (kids.length === 0) {
+      const on = rawChecked.has(node.id);
+      if (on) checked.add(node.id);
+      return { fully: on, any: on };
+    }
+    let allFully = true;
+    let anyOn = false;
+    for (const k of kids) {
+      const r = walk(k);
+      if (!r.fully) allFully = false;
+      if (r.any) anyOn = true;
+    }
+    if (allFully) {
+      checked.add(node.id);
+      return { fully: true, any: true };
+    }
+    if (anyOn) {
+      indeterminate.add(node.id);
+      return { fully: false, any: true };
+    }
+    return { fully: false, any: false };
+  }
+
+  for (const r of roots) walk(r);
+  return { checked, indeterminate };
+}
+```
+
+사용자가 제공하는 `checked` Set 은 "leaf 체크 의도" 로 해석. 내부 렌더 시 위 함수로 부모 checked/indeterminate 를 **유도**. 체크박스 클릭 시:
+- leaf: toggle raw.
+- non-leaf: 모든 하위 leaf 를 대상으로 raw set 에서 추가/제거.
+
+`checkCascade === "self"` 면 이 유도 없이 raw Set 그대로 사용(부모 체크는 자식과 독립).
+
+### 3.6 async loadedChildren
+
+```ts
+const [loadedChildren, setLoadedChildren] = useState<Map<string, TreeNode<T>[]>>(new Map());
+const [loadingIds, setLoadingIds] = useState<Set<string>>(new Set());
+const [errorById, setErrorById] = useState<Map<string, Error>>(new Map());
+```
+
+### 3.7 root Context
+
+```ts
+interface TreeContextValue<T = unknown> {
+  // 데이터
+  nodeById: Map<string, TreeNode<T>>;
+  flatItems: FlatItem<T>[];
+  // 상태
+  expanded: ReadonlySet<string>;
+  selected: ReadonlySet<string>;
+  checkedVM: CheckViewModel;
+  loadingIds: ReadonlySet<string>;
+  errorById: ReadonlyMap<string, Error>;
+  focusedId: string | null;
+  // 설정
+  selectionMode: TreeSelectionMode;
+  checkable: boolean;
+  checkCascade: "parent-child" | "self";
+  indent: number;
+  showIndentGuides: boolean;
+  disabled: boolean;
+  theme: TreeTheme;
+  renderNode: TreeRootProps<T>["renderNode"];
+  // 액션
+  toggleExpand(id: string): void;
+  selectNode(id: string, modifiers: { shift: boolean; meta: boolean }): void;
+  toggleCheck(id: string): void;
+  setFocus(id: string | null): void;
+  onActivate(id: string): void;
+}
+
+const TreeContext = createContext<TreeContextValue<any> | null>(null);
+```
+
+---
+
+## 4. 시각 / 구조
+
+### 4.1 DOM 구조
+
+```html
+<ul role="tree" aria-label="..." class="tr-root" data-theme="light">
+  <li role="treeitem"
+      aria-expanded="true"
+      aria-selected="false"
+      aria-level="1"
+      aria-posinset="1"
+      aria-setsize="3"
+      tabindex="0"
+      data-id="src"
+      class="tr-item"
+      style="--tr-level: 0">
+    <div class="tr-row">
+      <!-- indent 가이드 (level 개수 만큼) -->
+      <span class="tr-indent" aria-hidden="true" />
+      <button class="tr-toggle" aria-hidden="true">▾</button>
+      <span class="tr-icon">📁</span>
+      <span class="tr-label">src</span>
+    </div>
+    <ul role="group">
+      <li role="treeitem" aria-level="2" ...>...</li>
+    </ul>
+  </li>
+</ul>
+```
+
+`<ul><li>` 의미론 + role 로 ARIA Tree 패턴 준수.
+
+**단일 tabindex**: 전체 tree 에서 한 번에 한 노드만 `tabindex="0"`, 나머지는 `tabindex="-1"`. focus 이동 시 동적 업데이트. (roving tabindex)
+
+### 4.2 indent + guide
+
+```css
+.tr-item {
+  padding-inline-start: calc(var(--tr-level) * var(--tr-indent, 16px));
+  position: relative;
+}
+.tr-row {
+  display: flex; align-items: center; gap: 6px;
+  min-height: 24px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  cursor: default;
+}
+.tr-row:hover     { background: var(--tr-row-hover); }
+.tr-item[aria-selected="true"] > .tr-row { background: var(--tr-row-selected); }
+.tr-item[data-focused="true"]  > .tr-row { outline: 2px solid var(--tr-focus); outline-offset: -2px; }
+.tr-item[aria-disabled="true"] > .tr-row { opacity: 0.5; pointer-events: none; }
+
+.tr-root[data-indent-guides="true"] .tr-item::before {
+  content: ""; position: absolute;
+  left: calc(var(--tr-level) * var(--tr-indent, 16px) + 8px);
+  top: 0; bottom: 0; width: 1px;
+  background: var(--tr-guide);
+}
+```
+
+### 4.3 toggle 아이콘
+
+- 기본 collapsed: `▸` (U+25B8)
+- 기본 expanded: `▾` (U+25BE)
+- loading: 작은 스피너 (CSS 애니메이션 `@keyframes tr-spin`) 또는 `…` fallback.
+- leaf: reserveSpaceForLeaf=true (기본) 시 같은 폭의 invisible span 으로 alignment 유지.
+
+크기: 12×12 (사각형 hit area 는 24×24 로 확장 via padding).
+
+### 4.4 palette 토큰
+
+```ts
+// Tree/theme.ts
+export const treePalette = {
+  light: {
+    rowHover:        "rgba(0,0,0,0.04)",
+    rowSelected:     "rgba(37,99,235,0.10)",
+    rowSelectedText: "#1d4ed8",
+    textPrimary:     "#111827",
+    textSecondary:   "#6b7280",
+    focus:           "#2563eb",
+    guide:           "rgba(0,0,0,0.10)",
+    toggleFg:        "#6b7280",
+    checkboxBorder:  "rgba(0,0,0,0.25)",
+    checkboxChecked: "#2563eb",
+    disabledFg:      "rgba(0,0,0,0.40)",
+    loadingFg:       "#9ca3af",
+    errorFg:         "#dc2626",
+  },
+  dark: {
+    rowHover:        "rgba(255,255,255,0.06)",
+    rowSelected:     "rgba(96,165,250,0.18)",
+    rowSelectedText: "#bfdbfe",
+    textPrimary:     "#e5e7eb",
+    textSecondary:   "#9ca3af",
+    focus:           "#60a5fa",
+    guide:           "rgba(255,255,255,0.10)",
+    toggleFg:        "#9ca3af",
+    checkboxBorder:  "rgba(255,255,255,0.25)",
+    checkboxChecked: "#60a5fa",
+    disabledFg:      "rgba(255,255,255,0.40)",
+    loadingFg:       "#6b7280",
+    errorFg:         "#f87171",
+  },
+} as const;
+```
+
+### 4.5 기본 renderNode
+
+```tsx
+function defaultRenderNode<T>(args: TreeRenderNodeArgs<T>) {
+  return (
+    <>
+      <Tree.ExpandToggle />
+      {args.node.icon && <span className="tr-icon">{args.node.icon}</span>}
+      {/* checkable 일 때 내부에서 체크박스 자동 삽입 — Root 레벨 책임이므로
+          여기서는 생략하거나 context 에서 checkable 시 checkbox 노드 반환 */}
+      <Tree.Label>{args.node.label}</Tree.Label>
+    </>
+  );
+}
+```
+
+checkable 인 경우 Root 가 renderNode 호출 직후 checkbox 를 앞에 붙여주는 방식(§5.7).
+
+---
+
+## 5. 핵심 로직
+
+### 5.1 JSX → data 변환
+
+JSX 모드에서 `Tree.Root` 의 children (`<Tree.Node>...</Tree.Node>`) 을 순회하여 `TreeNode<T>[]` 로 변환.
+
+```ts
+function jsxToData(children: React.ReactNode, level = 0, maxDepth = 32): TreeNode<unknown>[] {
+  const arr: TreeNode<unknown>[] = [];
+  React.Children.forEach(children, (child) => {
+    if (!React.isValidElement(child)) return;
+    if ((child.type as any).displayName !== "Tree.Node") return;
+    const props = child.props as TreeNodeProps;
+    if (level >= maxDepth) return;
+    const kids = jsxToData(props.children, level + 1, maxDepth);
+    arr.push({
+      id: props.id,
+      label: props.label,
+      icon: props.icon,
+      disabled: props.disabled,
+      hasChildren: props.hasChildren ?? kids.length > 0,
+      children: kids.length > 0 ? kids : undefined,
+    });
+  });
+  return arr;
+}
+```
+
+`data` prop 이 있으면 data 우선, 없으면 JSX 변환 결과 사용. 둘 다 있으면 dev warn + data 사용.
+
+### 5.2 toggleExpand
+
+```ts
+function toggleExpand(id: string) {
+  const node = nodeById.get(id);
+  if (!node || node.disabled) return;
+
+  const isOpen = expanded.has(id);
+  if (isOpen) {
+    const next = new Set(expanded);
+    next.delete(id);
+    setExpanded(next);
+    return;
+  }
+
+  // 열기 — async load 필요 여부
+  const kids = loadedChildren.get(id) ?? node.children;
+  const needsLoad =
+    loadChildren != null &&
+    kids == null &&
+    (node.hasChildren === true || kids == null);
+
+  if (needsLoad && !loadingIds.has(id) && !loadedChildren.has(id)) {
+    setLoadingIds((s) => new Set(s).add(id));
+    loadChildren(node).then(
+      (result) => {
+        setLoadedChildren((m) => {
+          const next = new Map(m);
+          next.set(id, result);
+          return next;
+        });
+        setLoadingIds((s) => {
+          const n = new Set(s); n.delete(id); return n;
+        });
+        setExpanded((e) => new Set(e).add(id));
+      },
+      (err: Error) => {
+        setErrorById((m) => {
+          const n = new Map(m); n.set(id, err); return n;
+        });
+        setLoadingIds((s) => {
+          const n = new Set(s); n.delete(id); return n;
+        });
+      },
+    );
+    return;
+  }
+
+  setExpanded(new Set(expanded).add(id));
+}
+```
+
+> `loadChildren` 호출은 "한 번만" 이 원칙. 이미 `loadedChildren.has(id)` 면 재호출 금지. 재시도는 사용자가 외부에서 명시(예: `treeRef.current?.collapse(id)` 후 재expand, 또는 future API `reload(id)`).
+
+### 5.3 expandAll / collapseAll
+
+```ts
+function expandAll() {
+  const all = new Set<string>();
+  flatItems.forEach((it) => {
+    if (it.hasChildren) all.add(it.node.id);
+  });
+  setExpanded(all);
+}
+function collapseAll() {
+  setExpanded(new Set());
+}
+function expandTo(id: string) {
+  const path = findPath(data ?? jsxData, id);  // root → id
+  if (!path) return;
+  const next = new Set(expanded);
+  path.slice(0, -1).forEach((p) => next.add(p));
+  setExpanded(next);
+}
+```
+
+### 5.4 selection
+
+```ts
+function selectNode(id: string, mods: { shift: boolean; meta: boolean }) {
+  const node = nodeById.get(id);
+  if (!node || node.disabled) return;
+  if (selectionMode === "none") return;
+  if (selectionMode === "single") {
+    setSelected(new Set([id]));
+    return;
+  }
+  // multiple
+  if (mods.meta) {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    setSelected(next);
+    return;
+  }
+  if (mods.shift && lastAnchorIdRef.current) {
+    // flatten 기준 anchor..id 구간 선택
+    const flat = flatItems.map((it) => it.node.id);
+    const a = flat.indexOf(lastAnchorIdRef.current);
+    const b = flat.indexOf(id);
+    if (a < 0 || b < 0) { setSelected(new Set([id])); return; }
+    const [lo, hi] = a <= b ? [a, b] : [b, a];
+    setSelected(new Set(flat.slice(lo, hi + 1)));
+    return;
+  }
+  lastAnchorIdRef.current = id;
+  setSelected(new Set([id]));
+}
+```
+
+### 5.5 checkbox toggle (parent-child cascade)
+
+```ts
+function toggleCheck(id: string) {
+  const node = nodeById.get(id);
+  if (!node || node.disabled) return;
+  const descendantLeaves = collectLeafIds(node);
+  const isFullyOn = descendantLeaves.every((lid) => checked.has(lid));
+  const next = new Set(checked);
+  if (isFullyOn) {
+    descendantLeaves.forEach((lid) => next.delete(lid));
+  } else {
+    descendantLeaves.forEach((lid) => next.add(lid));
+  }
+  setChecked(next);
+}
+
+function collectLeafIds(node: TreeNode<T>): string[] {
+  const kids = loadedChildren.get(node.id) ?? node.children ?? [];
+  if (kids.length === 0) return [node.id];
+  const out: string[] = [];
+  for (const k of kids) out.push(...collectLeafIds(k));
+  return out;
+}
+```
+
+`checkCascade === "self"` 일 때는 위 대신 단순 toggle:
+```ts
+const next = new Set(checked);
+if (next.has(id)) next.delete(id); else next.add(id);
+setChecked(next);
+```
+
+### 5.6 focused node (roving tabindex)
+
+```ts
+const [focusedId, setFocusedId] = useState<string | null>(null);
+
+useEffect(() => {
+  if (focusedId == null && flatItems.length > 0) {
+    setFocusedId(flatItems[0]!.node.id);
+  }
+}, [flatItems, focusedId]);
+```
+
+컨테이너 focus 시 focusedId 노드의 DOM 에 `focus()` 호출. row 클릭 시 focusedId 업데이트.
+
+### 5.7 row 렌더
+
+```tsx
+function TreeRow({ item }: { item: FlatItem<T> }) {
+  const ctx = useTreeContext();
+  const { node, level, path, isExpanded, hasChildren } = item;
+  const isSelected = ctx.selected.has(node.id);
+  const isChecked = ctx.checkedVM.checked.has(node.id);
+  const isIndeterminate = ctx.checkedVM.indeterminate.has(node.id);
+  const isFocused = ctx.focusedId === node.id;
+  const isDisabled = !!node.disabled || ctx.disabled;
+  const isLoading = ctx.loadingIds.has(node.id);
+  const err = ctx.errorById.get(node.id);
+
+  const content = (ctx.renderNode ?? defaultRenderNode)({
+    node, level, path, isExpanded, isSelected, isChecked,
+    isIndeterminate, isDisabled, isLoading, hasChildren, isFocused,
+  });
+
+  return (
+    <li role="treeitem"
+        aria-expanded={hasChildren ? isExpanded : undefined}
+        aria-selected={ctx.selectionMode !== "none" ? isSelected : undefined}
+        aria-checked={ctx.checkable ? (isIndeterminate ? "mixed" : isChecked) : undefined}
+        aria-level={level + 1}
+        aria-posinset={item.index + 1}
+        aria-setsize={item.siblingCount}
+        aria-disabled={isDisabled || undefined}
+        tabIndex={isFocused ? 0 : -1}
+        data-id={node.id}
+        data-focused={isFocused || undefined}
+        class="tr-item"
+        style={{ "--tr-level": level } as React.CSSProperties}
+        onClick={(e) => ctx.selectNode(node.id, { shift: e.shiftKey, meta: e.metaKey || e.ctrlKey })}
+        onDoubleClick={() => ctx.onActivate(node.id)}
+    >
+      <div class="tr-row">
+        {ctx.checkable && !isDisabled && (
+          <input type="checkbox"
+                 checked={isChecked}
+                 ref={(el) => { if (el) el.indeterminate = isIndeterminate; }}
+                 onChange={() => ctx.toggleCheck(node.id)}
+                 onClick={(e) => e.stopPropagation()}
+                 aria-label={`Check ${node.id}`} />
+        )}
+        {content}
+        {err && <span class="tr-error" title={err.message}>!</span>}
+      </div>
+      {isExpanded && hasChildren && (
+        <ul role="group">
+          {/* 자식 row 들은 flatItems 가 이미 펼친 상태로 상위에서 렌더되므로
+              실제로는 Root 에서 하나의 flat 리스트로 렌더하는 방법도 가능.
+              하지만 ARIA 의 계층 구조를 살리기 위해 재귀 렌더를 권장. */}
+        </ul>
+      )}
+    </li>
+  );
+}
+```
+
+> 설계 결정: ARIA `role="tree"` 의 DOM 구조는 `ul > li > ul > li` 계층이어야 스크린리더가 올바르게 계층을 읽는다. 따라서 **v1 은 재귀 JSX 렌더**(flat list 아님). flatten 배열은 "어느 id 가 현재 보여야 하는지" 계산 + 키보드 탐색용으로만 사용하고, 실제 render 는 데이터 재귀. v1.1 virtualization 도입 시 flat list 로 전환하면서 `aria-owns`/`aria-level` 로 계층을 보조한다 (복잡도 ↑, 별도 설계).
+
+---
+
+## 6. 제약
+
+### 6.1 중복 id
+
+flatten 도중 `Set<string>` 으로 감지. 중복 발견 시 development (`process.env.NODE_ENV !== "production"`) 에서 **throw**:
+```
+[Tree] duplicate id: "src/index.ts"
+```
+production 빌드에서는 첫 번째 노드만 채택, 중복 노드는 skip (crash 회피).
+
+### 6.2 maxDepth
+
+기본 32. `prop maxDepth` 로 조절 가능. 초과 시:
+- development: `console.warn("[Tree] maxDepth(32) exceeded at ...")`
+- 더 이상 재귀 안 함 (해당 서브트리 leaf 처리).
+- 사용자가 명시적으로 큰 값 주면 책임 이전.
+
+### 6.3 빈 children 의 의미
+
+- `children: undefined` — "아직 모른다". `loadChildren` 있으면 async load 가능, toggle 아이콘 보임.
+- `children: []` — "확실히 없다". leaf 처리, toggle 아이콘 숨김 (reserveSpace 는 유지).
+- `hasChildren: true` + `children: undefined` — "있을 텐데 로드 전". 가장 흔한 lazy load 패턴.
+- `hasChildren: false` — "없음" 명시 (children 유무 무시).
+
+### 6.4 filter 적용 시
+
+`filter` prop 이 있으면 flatten 도중 매칭 여부 계산:
+- leaf: `filter(node)` true 면 표시.
+- 내부 노드: `filter(node)` true **or** 하위 중 하나라도 매칭되면 표시.
+- 매칭된 내부 노드는 자동 expand (filter 활성 시 한정).
+
+### 6.5 controlled checked + loadChildren
+
+async 로드 전 자식 id 를 외부에서 미리 알 수 없으므로, 부모 체크 시 "현재 시점에 아는 leaf 만" 업데이트. 이후 자식 로드되면 indeterminate 로 표시되는 위험 존재 — 문서화.
+
+---
+
+## 7. 키보드
+
+root `ul` 에 `onKeyDown` 핸들러. focusedId 기준 동작.
+
+| 키 | 동작 |
+|---|---|
+| `ArrowDown` | flatten 기준 다음 표시 노드로 이동. 마지막이면 유지. |
+| `ArrowUp` | 이전 표시 노드로 이동. 처음이면 유지. |
+| `ArrowRight` | (hasChildren && !expanded) → expand. (expanded) → 첫 자식으로 이동. leaf → noop. |
+| `ArrowLeft` | (expanded) → collapse. (collapsed 또는 leaf) → 부모로 이동. 루트 노드면 유지. |
+| `Home` | 첫 번째 표시 노드로 이동. |
+| `End` | 마지막 표시 노드로 이동. |
+| `Enter` | onActivate 호출. selectionMode!=="none" 이면 함께 select. |
+| `Space` | selectionMode!=="none" 이면 toggle select (multi 에선 meta 처럼). checkable 이면 toggle check (우선). |
+| `*` | 현재 포커스 노드와 **같은 레벨 형제 전체** expand (VSCode 관례). |
+| `a..z / 0..9` | typeahead: 입력 문자열로 시작하는 다음 노드로 포커스. 300 ms 무입력 시 buffer reset. |
+| `Escape` | typeahead buffer reset + focus 는 유지. |
+| `Tab` | 트리 밖으로 빠져나감 (roving tabindex 이므로 자연스럽게). |
+
+```ts
+function onRootKeyDown(e: React.KeyboardEvent) {
+  if (disabled) return;
+  const idx = flatItems.findIndex((it) => it.node.id === focusedId);
+  if (idx < 0) return;
+  const cur = flatItems[idx]!;
+
+  const moveTo = (nextIdx: number) => {
+    const clamped = Math.max(0, Math.min(flatItems.length - 1, nextIdx));
+    setFocusedId(flatItems[clamped]!.node.id);
+    focusDom(flatItems[clamped]!.node.id);
+  };
+
+  switch (e.key) {
+    case "ArrowDown":  e.preventDefault(); moveTo(idx + 1); return;
+    case "ArrowUp":    e.preventDefault(); moveTo(idx - 1); return;
+    case "Home":       e.preventDefault(); moveTo(0); return;
+    case "End":        e.preventDefault(); moveTo(flatItems.length - 1); return;
+    case "ArrowRight":
+      e.preventDefault();
+      if (cur.hasChildren && !cur.isExpanded) { toggleExpand(cur.node.id); return; }
+      if (cur.isExpanded) { moveTo(idx + 1); return; }
+      return;
+    case "ArrowLeft":
+      e.preventDefault();
+      if (cur.isExpanded) { toggleExpand(cur.node.id); return; }
+      if (cur.parentId) {
+        const pIdx = flatItems.findIndex((it) => it.node.id === cur.parentId);
+        if (pIdx >= 0) moveTo(pIdx);
+      }
+      return;
+    case "Enter":
+      e.preventDefault();
+      if (selectionMode !== "none") selectNode(cur.node.id, { shift: e.shiftKey, meta: e.metaKey || e.ctrlKey });
+      onActivate(cur.node.id);
+      return;
+    case " ":
+      e.preventDefault();
+      if (checkable) { toggleCheck(cur.node.id); return; }
+      if (selectionMode === "multiple") selectNode(cur.node.id, { shift: false, meta: true });
+      else if (selectionMode === "single") selectNode(cur.node.id, { shift: false, meta: false });
+      return;
+    case "*":
+      e.preventDefault();
+      expandSiblings(cur);
+      return;
+    case "Escape":
+      typeaheadBufferRef.current = "";
+      return;
+    default:
+      if (e.key.length === 1 && /\S/.test(e.key)) {
+        e.preventDefault();
+        typeahead(e.key, idx);
+      }
+  }
+}
+```
+
+### 7.1 typeahead
+
+```ts
+const typeaheadBufferRef = useRef("");
+const typeaheadTimerRef = useRef<number | null>(null);
+function typeahead(ch: string, fromIdx: number) {
+  typeaheadBufferRef.current += ch.toLowerCase();
+  if (typeaheadTimerRef.current) window.clearTimeout(typeaheadTimerRef.current);
+  typeaheadTimerRef.current = window.setTimeout(() => {
+    typeaheadBufferRef.current = "";
+  }, 500);
+  const buf = typeaheadBufferRef.current;
+  const n = flatItems.length;
+  for (let i = 1; i <= n; i++) {
+    const probe = flatItems[(fromIdx + i) % n]!;
+    const label = typeof probe.node.label === "string" ? probe.node.label : probe.node.id;
+    if (label.toLowerCase().startsWith(buf)) {
+      setFocusedId(probe.node.id);
+      focusDom(probe.node.id);
+      return;
+    }
+  }
+}
+```
+
+### 7.2 expandSiblings (VSCode `*`)
+
+```ts
+function expandSiblings(cur: FlatItem<T>) {
+  const siblings = flatItems.filter((it) => it.parentId === cur.parentId && it.hasChildren);
+  const next = new Set(expanded);
+  siblings.forEach((s) => next.add(s.node.id));
+  setExpanded(next);
+}
+```
+
+---
+
+## 8. 상태 관리 (controlled / uncontrolled)
+
+### 8.1 useControllable 적용
+
+3 개 독립 축 (expanded, selected, checked) 각기 `useControllable<ReadonlySet<string>>` 사용. 기존 훅은 "값 그대로 동기화" 계약이며, Set 타입도 그대로 쓸 수 있다 (참조 비교라 새 Set 을 매번 만들어 치환해야 onChange 가 rebroadcast 됨 — 문서화).
+
+```ts
+const [expanded, setExpanded] = useControllable(
+  props.expanded, props.defaultExpanded ?? EMPTY_SET, props.onExpandedChange,
+);
+```
+
+### 8.2 controlled 규칙
+
+- controlled 상태(예: `props.expanded !== undefined`) 에서는 사용자가 `onExpandedChange` 에 응답해 외부 state 를 갱신해야 변화 반영. 외부에서 응답 없으면 토글이 적용되지 않는 것으로 보인다 (React controlled 관례).
+- `defaultExpanded` / `defaultSelected` / `defaultChecked` 는 mount 이후 변경해도 무시 (표준 uncontrolled 관례).
+
+### 8.3 Set identity 주의
+
+`new Set(expanded)` 처럼 매번 새 Set 반환 — 외부에서 `useState<ReadonlySet<string>>` 으로 받아 그대로 pass 하면 안정적. 부모가 매 렌더 `new Set(...)` 을 만들면 Tree 가 flatten 재계산 → 성능 이슈. `useMemo` 권장 안내를 Usage 섹션에 명시.
+
+### 8.4 loadedChildren / loading / error
+
+이 3 가지는 **항상 internal state**. controlled API 없음. 이유:
+- async 호출 시점/결과는 컴포넌트 본인이 가장 잘 안다.
+- 외부에서 "재시도" 또는 "강제 리로드" 하려면 향후 `treeRef.current?.reload(id)` imperative API 로 해결 (v1.1+).
+
+v1 에서 외부가 꼭 필요하면 `loadChildren` 을 사용자 state 와 얽어 `setXxx` 호출 후 다음 렌더에 반영하는 패턴 문서화.
+
+---
+
+## 9. Async load
+
+### 9.1 계약
+
+```ts
+loadChildren?: (node: TreeNode<T>) => Promise<TreeNode<T>[]>;
+```
+
+- 반환값은 `TreeNode<T>[]` (children). 빈 배열이면 "확인했는데 자식 없음" 으로 저장, 이후 toggle 시 다시 호출하지 않음.
+- reject 되면 `errorById` 에 저장, 행 옆에 `!` 표시 + title 에 메시지. 재시도는 사용자가 페이지 refresh 또는 (v1.1) `treeRef.reload(id)`.
+
+### 9.2 라이프사이클
+
+```
+click toggle (collapsed, needs load)
+ → loadingIds.add(id)
+ → loadChildren(node)
+    ├─ resolved  → loadedChildren.set(id, kids); loadingIds.delete(id); expanded.add(id)
+    └─ rejected  → errorById.set(id, err);      loadingIds.delete(id); (expanded 변화 없음)
+```
+
+### 9.3 취소 (cancel)
+
+v1 은 AbortController 내장 없음. 사용자가 `loadChildren` 내부에서 own Promise 관리. 컴포넌트 unmount / 동일 id 재호출 방지만 담당:
+```ts
+const mountedRef = useRef(true);
+useEffect(() => () => { mountedRef.current = false; }, []);
+// then 콜백에서 if (!mountedRef.current) return;
+```
+
+§13.3 에 "unmount 중 resolve 했을 때 setState 경고 없음" 검증 항목 추가.
+
+### 9.4 에러 표시
+
+행 우측에 빨간 `!` 표시, `title=err.message`. renderNode 사용자는 `args.node` 와 `ctx.errorById` 에 접근해 맞춤 표시 가능 (renderNode 인자에 포함되어 있지 않으므로, 필요 시 Context hook `useTreeNodeState(id)` 제공 예정 — v1 에서는 단순화 위해 error 도 renderNode args 에 추가):
+
+```ts
+// v1 최종: renderNode args 에 error?: Error 추가
+export interface TreeRenderNodeArgs<T> {
+  // ...기존
+  error?: Error;
+}
+```
+
+---
+
+## 10. 파일 구조
+
+```
+src/components/Tree/
+├── Tree.tsx                 # Root + Node + Label + Children + ExpandToggle + context 조립
+├── Tree.types.ts            # 공개 타입
+├── Tree.utils.ts            # flatten, jsxToData, deriveCheckVM, collectLeafIds, findPath
+├── TreeContext.ts           # Context + useTreeContext
+├── useTreeKeyboard.ts       # keydown 핸들러 + typeahead
+├── useTreeAsync.ts          # loadedChildren / loadingIds / errorById 상태 + loader
+├── theme.ts                 # treePalette
+├── tree.css (or inline)     # 기본 스타일 (인라인 style 로 병합 권장)
+└── index.ts                 # 배럴
+```
+
+각 파일 책임:
+
+- **Tree.tsx**
+  - `TreeRoot` (forwardRef) — data/JSX 양립, useControllable 3 축, flatten memo, Context provide.
+  - `TreeRow` — 재귀 렌더 단위.
+  - `TreeNode_` — JSX 모드 마커 컴포넌트 (실제 렌더 하지 않음, displayName 기반 변환).
+  - `TreeLabel` — 단순 `<span>`.
+  - `TreeExpandToggle` — context 에서 현재 노드 상태 조회, 클릭 시 toggleExpand.
+  - `TreeChildren` — JSX 모드의 명시적 children 슬롯.
+  - `Tree` namespace export.
+
+- **Tree.utils.ts**
+  - `flatten`, `jsxToData`, `deriveCheckVM`, `collectLeafIds`, `findPath`, `EMPTY_SET`.
+  - `assertUniqueIds` (dev-only).
+
+- **TreeContext.ts**
+  - `createContext<TreeContextValue | null>(null)`.
+  - `useTreeContext()` — null 이면 throw `"must be used within Tree.Root"`.
+  - `useTreeCurrentNode()` — 현재 `TreeRow` 가 자기 context 를 얻기 위한 서브 context (option). 간단화: props drilling 대신 renderNode args 로 전부 제공.
+
+- **useTreeKeyboard.ts**
+  - `onRootKeyDown` 핸들러 생성 훅. typeahead buffer, expandSiblings 포함.
+
+- **useTreeAsync.ts**
+  - loadedChildren/loadingIds/errorById state + `requestLoad(node)` 함수.
+
+- **theme.ts**
+  - `treePalette` light/dark.
+
+- **index.ts**
+  - `export { Tree } from "./Tree"` + 타입 재노출.
+
+---
+
+## 11. 구현 단계 (후속 agent 순차 실행)
+
+각 단계 독립 커밋 권장. 매 커밋 `npm run typecheck` + `npx tsup` 통과.
+
+### Step 1 — 타입 + 배럴 + 테마 스켈레톤
+1. `Tree.types.ts` 작성 (§2.1 전부).
+2. `theme.ts` 작성 (`treePalette`).
+3. `Tree.utils.ts` 에 `EMPTY_SET`, `flatten` skeleton (expand 상태 미반영, 단순 DFS 만), `assertUniqueIds`.
+4. `index.ts` 배럴.
+5. `src/components/index.ts` 에 `export * from "./Tree";`.
+6. `Tree.tsx` placeholder: `export const Tree = { Root: () => null, Node: () => null, Label: () => null, Children: () => null, ExpandToggle: () => null };`.
+7. `npm run typecheck` 통과.
+8. 커밋: `feat(Tree): 타입 + 테마 + 배럴`.
+
+### Step 2 — 데이터 파이프라인 + 기본 렌더
+1. `TreeContext.ts` + `useTreeContext`.
+2. `flatten` 에 expanded Set 반영.
+3. `TreeRoot` 가 `data` prop 을 받아 `flatten` 후 **재귀 렌더** (expand 는 아직 고정 값).
+4. 기본 `defaultRenderNode` (toggle ▸/▾ + label).
+5. JSX 변환은 아직 생략 (data 전용).
+6. 커밋: `feat(Tree): 기본 데이터 렌더`.
+
+### Step 3 — expand/collapse 상태 + toggle
+1. `useControllable` 로 expanded state.
+2. `toggleExpand` 구현.
+3. `Tree.ExpandToggle` 컴포넌트 연결 (context 의 현재 노드 id 를 얻기 위해 `TreeRow` 가 `TreeItemContext` 를 별도로 제공 — 서브 context).
+4. 클릭으로 열고 닫기 동작.
+5. 커밋: `feat(Tree): expand/collapse 토글`.
+
+### Step 4 — JSX 재귀 모드
+1. `Tree.Node`, `Tree.Children` 마커 + `jsxToData` 구현.
+2. `data` 없고 children 있으면 JSX 변환 사용.
+3. data + JSX 동시 존재 시 dev warn.
+4. 커밋: `feat(Tree): JSX 모드 지원`.
+
+### Step 5 — selection (single/multiple)
+1. `useControllable` 로 selected state.
+2. `selectNode(id, mods)` — single/multi/none + shift 범위 + meta 토글.
+3. 클릭 시 selection, aria-selected 반영.
+4. 커밋: `feat(Tree): 선택 모드`.
+
+### Step 6 — checkable + indeterminate
+1. `useControllable` 로 checked state.
+2. `deriveCheckVM` 구현 + 렌더에 반영.
+3. checkbox 렌더 + indeterminate DOM 동기화 (ref).
+4. `toggleCheck` 구현 (parent-child cascade).
+5. `checkCascade="self"` 경로 분기.
+6. 커밋: `feat(Tree): 체크박스 + indeterminate`.
+
+### Step 7 — async loadChildren
+1. `useTreeAsync` 훅.
+2. toggleExpand 가 필요 시 load 를 먼저 호출.
+3. loadingIds/errorById 상태 노출.
+4. 에러 `!` 표시.
+5. unmount 가드.
+6. 커밋: `feat(Tree): async lazy load`.
+
+### Step 8 — 키보드 + ARIA
+1. `useTreeKeyboard` 훅 (Arrow/Home/End/Space/Enter/`*`/typeahead/Escape).
+2. roving tabindex: focusedId 변화 시 해당 DOM 에 focus.
+3. `role="tree"/"treeitem"/"group"` + `aria-expanded/selected/level/posinset/setsize/checked(mixed)/disabled`.
+4. `aria-label`/`aria-labelledby` 지원.
+5. 커밋: `feat(Tree): 키보드 + ARIA`.
+
+### Step 9 — maxDepth / 중복 id / filter
+1. flatten 에 maxDepth 제한.
+2. 중복 id dev throw.
+3. `filter` prop 반영 (매칭 노드 + 조상 유지, 자동 expand).
+4. 커밋: `feat(Tree): 제약 + 필터`.
+
+### Step 10 — imperative ref + Dark 테마
+1. `TreeRootHandle` forwardRef 로 노출.
+2. `expandAll`/`collapseAll`/`expandTo`/`focus`.
+3. Dark 테마 palette 전파.
+4. 커밋: `feat(Tree): imperative API + Dark`.
+
+### Step 11 — 데모 페이지
+1. `demo/src/pages/TreePage.tsx` (§12).
+2. `demo/src/App.tsx` NAV 추가.
+3. 3 개 샘플 데이터 (FileTree, JsonTree, OrgChart) 작성.
+4. 커밋: `feat(Tree): 데모 페이지`.
+
+### Step 12 — 마감
+1. Props 표 + Usage 예제 (§12.10).
+2. §20 DoD 전부 체크.
+3. 커밋: `feat(Tree): 데모 props 표 + usage`.
+
+---
+
+## 12. 데모 페이지
+
+`demo/src/pages/TreePage.tsx`. 구조는 CommandPalettePage 와 동일: `<section id="...">` + 좌측 NAV 연동.
+
+### 12.1 NAV 추가 (App.tsx)
+
+```ts
+{ id: "tree", label: "Tree", description: "계층 트리 / 체크 / async", sections: [
+  { label: "Basic",            id: "basic" },
+  { label: "Checkable",        id: "checkable" },
+  { label: "Async load",       id: "async" },
+  { label: "Custom render",    id: "custom" },
+  { label: "Disabled",         id: "disabled" },
+  { label: "Dark",             id: "dark" },
+  { label: "Controlled",       id: "controlled" },
+  { label: "Playground",       id: "playground" },
+  { label: "Props",            id: "props" },
+  { label: "Usage",            id: "usage" },
+]},
+```
+
+`Page` 타입에 `"tree"` 추가 + 하단 `{current === "tree" && <TreePage />}`.
+
+### 12.2 샘플 데이터 — FileTree
+
+```ts
+const fileTree: TreeNode[] = [
+  { id: "src", label: "src", icon: "📁", children: [
+    { id: "src/components", label: "components", icon: "📁", children: [
+      { id: "src/components/Tree.tsx", label: "Tree.tsx", icon: "📄" },
+      { id: "src/components/Button.tsx", label: "Button.tsx", icon: "📄" },
+    ]},
+    { id: "src/utils", label: "utils", icon: "📁", children: [
+      { id: "src/utils/format.ts", label: "format.ts", icon: "📄" },
+    ]},
+    { id: "src/index.ts", label: "index.ts", icon: "📄" },
+  ]},
+  { id: "public", label: "public", icon: "📁", children: [
+    { id: "public/favicon.ico", label: "favicon.ico", icon: "🖼" },
+  ]},
+  { id: "package.json", label: "package.json", icon: "📄" },
+];
+```
+
+### 12.3 샘플 데이터 — JsonTree
+
+임의 JSON 객체를 재귀적으로 TreeNode 변환:
+
+```ts
+function jsonToTree(value: unknown, path = "$"): TreeNode {
+  if (Array.isArray(value)) {
+    return {
+      id: path, label: `Array(${value.length})`,
+      children: value.map((v, i) => jsonToTree(v, `${path}[${i}]`)),
+    };
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value);
+    return {
+      id: path, label: `Object(${entries.length})`,
+      children: entries.map(([k, v]) => jsonToTree(v, `${path}.${k}`)),
+    };
+  }
+  return { id: path + ":" + String(value), label: `${JSON.stringify(value)}` };
+}
+```
+
+### 12.4 샘플 데이터 — OrgChart
+
+```ts
+const orgChart: TreeNode[] = [
+  { id: "ceo", label: "Alice (CEO)", icon: "👤", children: [
+    { id: "cto", label: "Bob (CTO)", icon: "👤", children: [
+      { id: "eng1", label: "Carol (Engineer)", icon: "👤" },
+      { id: "eng2", label: "Dave (Engineer)", icon: "👤" },
+    ]},
+    { id: "cfo", label: "Eve (CFO)", icon: "👤", children: [
+      { id: "fin1", label: "Frank (Finance)", icon: "👤" },
+    ]},
+  ]},
+];
+```
+
+### 12.5 섹션 — Basic
+
+```tsx
+<Tree.Root
+  data={fileTree}
+  defaultExpanded={new Set(["src", "src/components"])}
+  selectionMode="single"
+  style={{ width: 320, border: "1px solid #e5e7eb", borderRadius: 8, padding: 8 }}
+/>
+```
+
+세 샘플 각각 전시 (탭 또는 나란히).
+
+### 12.6 섹션 — Checkable
+
+```tsx
+const [checked, setChecked] = useState<ReadonlySet<string>>(new Set());
+<Tree.Root
+  data={fileTree}
+  defaultExpanded={new Set(["src", "src/components"])}
+  checkable
+  checked={checked}
+  onCheckedChange={setChecked}
+/>
+<div>Checked: {Array.from(checked).join(", ") || "(none)"}</div>
+```
+
+별도로 `checkCascade="self"` 비교 샘플.
+
+### 12.7 섹션 — Async load
+
+```tsx
+async function fakeLoad(node: TreeNode) {
+  await new Promise((r) => setTimeout(r, 600));
+  if (node.id === "slow") throw new Error("Load failed");
+  return [
+    { id: node.id + "/a", label: "a.ts", hasChildren: false },
+    { id: node.id + "/b", label: "b.ts", hasChildren: false },
+  ];
+}
+<Tree.Root
+  data={[
+    { id: "remote-1", label: "remote folder 1", hasChildren: true },
+    { id: "remote-2", label: "remote folder 2", hasChildren: true },
+    { id: "slow", label: "broken (reject)", hasChildren: true },
+  ]}
+  loadChildren={fakeLoad}
+/>
+```
+
+### 12.8 섹션 — Custom render
+
+파일 크기 뱃지, 수정일, 상태 dot 등 복잡 renderNode 예제.
+
+```tsx
+<Tree.Root
+  data={files}
+  renderNode={({ node, level, isExpanded, isSelected, hasChildren }) => (
+    <>
+      <Tree.ExpandToggle />
+      <span>{hasChildren ? (isExpanded ? "📂" : "📁") : "📄"}</span>
+      <Tree.Label>{node.label}</Tree.Label>
+      <span style={{ marginLeft: "auto", color: "#9ca3af", fontSize: 11 }}>
+        {(node.data as any)?.size ?? ""}
+      </span>
+      {(node.data as any)?.modified && (
+        <span style={{ color: "#2563eb", fontSize: 11 }}>
+          M
+        </span>
+      )}
+    </>
+  )}
+/>
+```
+
+### 12.9 섹션 — Disabled / Dark / Controlled / Playground
+
+**Disabled** — 일부 노드에 `disabled: true` + root `disabled` prop 동시 비교.
+
+**Dark** — `<div style={{ background: "#0f172a" }}><Tree.Root theme="dark" ... /></div>`.
+
+**Controlled** — 외부 버튼으로 "Expand all", "Collapse all", "Select src/*" 제공.
+```tsx
+const ref = useRef<TreeRootHandle>(null);
+<button onClick={() => ref.current?.expandAll()}>Expand all</button>
+<button onClick={() => ref.current?.collapseAll()}>Collapse all</button>
+<Tree.Root ref={ref} data={fileTree} />
+```
+
+**Playground** — 컨트롤:
+- data source (FileTree / JsonTree / OrgChart)
+- selectionMode (none/single/multiple)
+- checkable (on/off) + checkCascade (parent-child/self)
+- showIndentGuides (on/off)
+- indent (8/16/24 px)
+- theme (light/dark)
+- disabled (on/off)
+- async 토글 (루트 일부 자식을 lazy 로 교체)
+
+하단에 현재 expanded/selected/checked Set 상태를 `<pre>` 로 실시간 표시.
+
+### 12.10 Props 표
+
+`Tree.Root` 의 모든 prop × 타입 × 기본값 × 설명 (기존 페이지 관례 동일). `TreeNode<T>` 타입 필드도 별도 표.
+
+### 12.11 Usage (4 개 스니펫)
+
+1. **기본 파일 트리**: data + defaultExpanded + single select.
+2. **체크박스 + indeterminate**: checkable + onCheckedChange.
+3. **Async 파일 탐색기**: loadChildren + hasChildren flag.
+4. **커스텀 렌더**: 아이콘/뱃지/메타 칩 복합 행.
+
+---
+
+## 13. 검증 계획
+
+### 13.1 자동화
+```bash
+cd /Users/neo/workspace/plastic
+npm run typecheck
+npx tsup
+```
+주의: `exactOptionalPropertyTypes` — `ReadonlySet<string> | undefined` 구분, `noUncheckedIndexedAccess` — `flatItems[i]` 는 `FlatItem<T> | undefined` → `!` non-null assertion 신중 사용, `verbatimModuleSyntax` — 타입은 `import type`.
+
+### 13.2 수동 (demo dev server)
+```bash
+cd demo && npm run dev
+```
+
+체크리스트:
+- [ ] Basic FileTree: `src` 펼치면 components/utils/index.ts 보임. 클릭 시 선택 하이라이트.
+- [ ] JsonTree: 중첩 Object/Array 재귀 표시, 깊이 10+ 도 동작.
+- [ ] OrgChart: 3 depth 조직도 렌더, 선택.
+- [ ] ArrowDown/Up 네비, ArrowRight/Left 가 expand/collapse + 자식/부모 이동.
+- [ ] Home/End 가 flatten 의 맨 처음/끝으로.
+- [ ] `*` 키로 현재 레벨 전체 펼침.
+- [ ] Typeahead: `co` 입력 시 "components" 로 포커스, 500 ms 후 버퍼 초기화.
+- [ ] selectionMode="multiple": Shift+클릭 범위, Ctrl/Cmd+클릭 토글.
+- [ ] Checkable parent-child: 부모 체크 → 모든 leaf 체크, 일부 leaf 해제 → 부모 indeterminate, 모든 leaf 해제 → 부모 해제.
+- [ ] Checkable self: cascade 없이 각자 토글.
+- [ ] Async: `remote folder 1` 클릭 → spinner 600 ms → children 펼침. 같은 노드 재 collapse/expand 시 재로드 안 함.
+- [ ] Async error: `broken (reject)` 클릭 → 에러 `!` 표시, collapse 유지.
+- [ ] Disabled 노드: 클릭/키보드 무시, 자식 expand 도 불가.
+- [ ] Dark 테마: row hover/selected/toggle 색 모두 전환.
+- [ ] Controlled + expandAll/collapseAll ref API.
+- [ ] showIndentGuides on/off 시각 차이.
+- [ ] 다른 페이지 리그레션 없음.
+
+### 13.3 엣지 케이스
+- [ ] **중복 id**: dev 모드에서 두 노드 id 같게 주면 throw. prod 는 두 번째 skip.
+- [ ] **깊이 32 초과**: maxDepth 에서 warn + leaf 처리.
+- [ ] **hasChildren=true + children=undefined + loadChildren 없음**: toggle 클릭 시 아무 것도 일어나지 않음 (spinner 도 안 뜸). dev warn `loadChildren missing`.
+- [ ] **loadChildren resolve 가 []**: "빈 폴더" 로 저장, 이후 같은 노드 재 expand 에도 재호출 없음.
+- [ ] **loadChildren reject**: error 저장, 재시도 API 없음 (v1.1 예정).
+- [ ] **unmount 중 loadChildren resolve**: mountedRef 가드로 setState 경고 없음.
+- [ ] **매 렌더 새 `data` 참조**: flatten useMemo 재계산 → 성능 degradation. 부모에게 `useMemo` 권장 문서화.
+- [ ] **controlled checked 에 없는 id 포함**: 무시 (경고 없음, 그냥 매칭 안 됨).
+- [ ] **filter 가 전부 false**: 빈 트리 렌더 + `role="tree"` 여전 + tabindex 없음.
+- [ ] **RTL**: Arrow 방향 반전은 **하지 않음**. VSCode/Finder 동일 정책 (Right=expand, Left=collapse). RTL 에서도 동일 (논리적 방향).
+  > 만약 "물리 방향" 을 원하면 v1.1 `arrowDirection: "logical" | "physical"` prop 도입 고려.
+- [ ] **IME 입력 중 typeahead**: `e.isComposing` 체크 후 버퍼에 안 넣음.
+- [ ] **매우 긴 label**: overflow 처리는 사용자 스타일 책임. 기본은 white-space:nowrap 없이 natural wrap (VSCode 와 차별).
+- [ ] **data가 비어있음([])**: 아무 것도 렌더되지 않고 tree role 도 빈 `<ul>` 로 유지, focus 불가능.
+
+---
+
+## 14. 성능
+
+### 14.1 목표
+- 초기 마운트 (200 노드): < 10 ms
+- 300 노드 트리 전체 expand + 재 flatten: < 5 ms
+- 키보드 Arrow 연타 (10 회/s): 드롭 프레임 없음
+- 500 노드 기준 60 fps
+- 1000+ 노드는 v1.1 virtualization 전제
+
+### 14.2 병목 가설 + 완화
+
+1. **flatten 의 O(N)**: 매번 새 배열. 상태 변경(예: expanded 토글) 시 전체 재계산. N 이 1k 이상이면 체감 가능. 완화: `useMemo(() => flatten(...), [data, expanded, loadedChildren, maxDepth])`. `data` 참조 안정성 요구.
+2. **Set identity**: 부모가 매 렌더 새 Set 주면 memo miss. 문서화 + controlled 일 때 `useMemo(() => expanded, [expanded])` 권장.
+3. **deriveCheckVM 의 O(N)**: checkable 일 때 매 렌더 전체 subtree 순회. Memo (`[data, checked, loadedChildren]`). 1k 노드에 <3 ms 예상.
+4. **재귀 렌더의 React reconciliation**: 깊은 트리에서 `React.Children.map` 대신 `.map()` 사용, key 는 `node.id` 로 안정화. reconcile 비용은 N 에 비례, 1k 까진 허용.
+5. **checkbox indeterminate DOM 동기화**: `ref={(el) => { if (el) el.indeterminate = ... }}` 는 매 렌더 실행 → 변화 없으면 no-op 이지만 ref 콜백 잦은 호출 우려. `useEffect` 로 변경 시에만 적용하는 변형도 가능 (측정 후 결정).
+6. **키보드 typeahead 의 string scan**: `flatItems` 를 `label` 기준 선형 scan. 1k 노드여도 < 1 ms. OK.
+7. **roving focus DOM 이동**: `document.querySelector('[data-id="..."]')` 는 O(N) 이지만 탐색 결과를 `flatItems` index 기반 DOM ref array 로 캐시. 매 렌더 `useLayoutEffect` 에서 ref array 갱신.
+
+### 14.3 측정
+- DevTools Performance 로 1k 노드 전체 펼치기 → 한 프레임 < 16 ms 확인.
+- React Profiler 로 toggleExpand 시 렌더 대상이 트리 전체인지 확인. Context value 변경은 Provider 아래 모든 subscriber 를 재렌더 시키므로, 일부 컴포넌트는 `React.memo + useMemo` 로 stable props 유지.
+
+### 14.4 큰 트리 한계
+
+- 500 노드 이하: v1 그대로 사용 권장.
+- 500~1500: 약간의 랙 허용 가능. showIndentGuides=false, 얕은 renderNode 로 완화.
+- 1500 초과: v1.1 virtualization 기다리거나, 사용자가 직접 가상 스크롤 래퍼 작성.
+
+이 가이드라인은 README/Props 문서에 명시.
+
+---
+
+## 15. 접근성
+
+### 15.1 role / aria
+
+- 컨테이너: `role="tree"` + `aria-label`/`aria-labelledby` (사용자 provide 또는 기본 "Tree").
+- 각 노드: `role="treeitem"`.
+- 자식 `<ul>`: `role="group"`.
+- `aria-expanded`: hasChildren 인 노드에만 true/false. leaf 는 미설정.
+- `aria-selected`: selectionMode!=="none" 일 때만 설정.
+- `aria-checked`: checkable 일 때만 설정. indeterminate → `"mixed"`.
+- `aria-level`: 1-based (level + 1).
+- `aria-posinset`: 1-based (index + 1).
+- `aria-setsize`: 부모의 자식 수.
+- `aria-disabled`: disabled 노드에 true.
+
+### 15.2 roving tabindex
+
+트리 전체에서 한 노드만 `tabindex="0"`, 나머지 `-1`. focus 이동은 키보드 핸들러가 직접 DOM focus 이동.
+
+### 15.3 스크린리더 기대 동작 (VoiceOver 기준)
+
+- 트리 진입: "Tree, src, 1 of 3, expanded, level 1".
+- ArrowDown: "components, 1 of 3, collapsed, level 2".
+- Space (checkable): "checked" / "unchecked" / "mixed".
+- expand 시: 상태 변화 announce.
+
+### 15.4 Focus visible
+
+CSS:
+```css
+.tr-item:focus { outline: none; }
+.tr-item:focus-visible > .tr-row {
+  outline: 2px solid var(--tr-focus);
+  outline-offset: -2px;
+}
+```
+data-focused 와 `:focus-visible` 이중 경로. data-focused 는 JS 로 제어(키보드 탐색이 DOM focus 이동을 수반), `:focus-visible` 은 브라우저가 결정.
+
+### 15.5 추가 권장
+
+- `aria-label` 은 사용자 필수 권장. 미지정 시 기본 "Tree" (dev 콘솔 info).
+- async loading 중 `aria-busy="true"` 를 treeitem 에 부여.
+- error 있는 treeitem 에 `aria-invalid="true"` + description id 로 에러 메시지 연결.
+
+---
+
+## 16. 알려진 트레이드오프 · 결정
+
+1. **재귀 DOM vs flat DOM**: ARIA tree 패턴은 계층 DOM 요구. v1 은 재귀 유지. virtualization(v1.1) 은 flat + `aria-owns` 보조로 전환 — 설계 변경 수반.
+2. **Set 불변성 요구**: 외부가 매 렌더 새 Set 을 만들면 memo miss. 가이드 문서화로 해소. 대안(deep equality 비교) 은 비용이 큼.
+3. **indeterminate 자동 유도**: controlled checked 는 "leaf 의도" 만 받고 부모 상태는 유도. 장점: 단일 진실 원천. 단점: 사용자가 "서버에서 받은 부모 체크 상태" 를 직접 표시하기 어려움. 그 경우 `checkCascade="self"` 로 우회.
+4. **async 재시도 없음**: v1 은 단순성 위주. `reload(id)` 는 v1.1 imperative API.
+5. **RTL Arrow 방향**: 논리 방향 고정(Right=expand, VSCode 관례). 물리 방향은 v1.1 옵션.
+6. **lastAnchor ref**: shift 범위 선택의 anchor 는 내부 ref. 첫 클릭에 설정, 이후 shift+클릭 시 anchor~target 구간 선택. 일반 클릭 시 anchor 갱신. 포커스 이동만으로는 anchor 변화 없음 (DataTable 과 동일 모델).
+7. **Context value fat**: Context 1 개에 많은 필드. 성능 민감하면 "데이터 context" + "상태 context" 분리 가능. v1 은 단일 context.
+8. **toggle 아이콘 UTF-8**: ▸/▾ 글꼴 렌더 차이. 필요 시 사용자가 `collapsedIcon`/`expandedIcon` 로 SVG 주입.
+9. **checkbox onClick stopPropagation**: row 의 select 이벤트와 분리. checkbox 클릭은 오직 check toggle (row select 안 일어남). 디자인 선택.
+10. **onActivate 시점**: Enter 키 + 더블클릭. single selection 은 Click 으로 선택 + Enter/더블클릭으로 activate (파일 열기) 패턴. VSCode 관례.
+11. **빈 children vs undefined children**: leaf vs unknown 구분 명시. hasChildren flag 로 override 가능. 문서화 필수.
+12. **filter 시 자동 expand**: 매칭 된 노드의 모든 조상을 자동 expand. controlled 상태에 충돌 가능 — filter 활성 시에는 임시 expand 를 "view-only" 로 적용하고 expanded state 는 변경 안 함 (내부 effective-expanded 계산). 복잡도 있으나 사용자 혼란 최소화.
+
+---
+
+## 17. 후속 작업 (v1.1+)
+
+- **Virtualization**: flat list + fixed item height + `useVirtualList` 재사용. `aria-owns` 로 계층 보조. ~10k 노드까지 60 fps 목표.
+- **Drag and Drop**: `draggable` + `onDragStart/Over/Drop` + drop indicator (`data-drop="before" | "inside" | "after"`) + `onMove(srcIds, dstId, position)` 콜백. drag handle 렌더 슬롯.
+- **Multi-root 고급**: 루트 간 shift-click 범위, 루트 간 이동 제약.
+- **reload API**: `treeRef.current?.reload(id)` — errorById 삭제 + loadedChildren 재실행.
+- **편집 모드**: inline rename / add / delete. renderNode 로도 가능하지만 표준 컴포넌트 제공.
+- **검색 UI 내장**: `<Tree.Search />` 하위 컴포넌트 + highlight 유틸.
+- **persist expanded**: `storageKey` prop → localStorage.
+- **drag 범위 선택 (rubber band)**.
+- **Context menu**: `<Tree.ContextMenu />` 하위 + items prop.
+- **물리 RTL Arrow**: `arrowDirection` prop.
+- **애니메이션**: `transition: max-height` 기반 expand/collapse.
+- **단축키 커스터마이징**: shortcut 매핑 prop.
+- **SSR / React Server Components 호환 재점검**.
+- **i18n**: 기본 aria-label 텍스트 locale override.
+
+---
+
+## 18. 관련 파일 인벤토리 (구현 시 참조)
+
+| 용도 | 경로 |
+|---|---|
+| useControllable (dual API, 3 축) | `/Users/neo/workspace/plastic/src/components/_shared/useControllable.ts` |
+| 계층 상태 Set / expand 토글 prior (cluster) | `/Users/neo/workspace/plastic/src/components/PipelineGraph/PipelineGraphCluster.tsx` |
+| PipelineGraph 배럴 (참조) | `/Users/neo/workspace/plastic/src/components/PipelineGraph/index.ts` |
+| 행 선택 / focused row / 키보드 prior | `/Users/neo/workspace/plastic/src/components/DataTable/DataTableRow.tsx` |
+| rowSelection Set 패턴 | `/Users/neo/workspace/plastic/src/components/DataTable/DataTable.tsx` |
+| 가상 스크롤 훅 (v1.1 재사용) | `/Users/neo/workspace/plastic/src/components/DataTable/useVirtualList.ts` |
+| 입력 기반 typeahead/ARIA 패턴 | `/Users/neo/workspace/plastic/src/components/CommandPalette/` |
+| 배럴 등록 | `/Users/neo/workspace/plastic/src/components/index.ts` |
+| 데모 페이지 레이아웃 (섹션 + 사이드바) | `/Users/neo/workspace/plastic/demo/src/pages/CommandPalettePage.tsx` |
+| 데모 App 라우팅 / NAV | `/Users/neo/workspace/plastic/demo/src/App.tsx` |
+| tsconfig 제약 | `/Users/neo/workspace/plastic/tsconfig.json` |
+| 이전 plan 템플릿 참고 | `/Users/neo/workspace/plastic/docs/plans/017-splitpane-component.md` |
+
+---
+
+## 19. 의존성 영향
+
+신규 런타임 의존 없음. React 18.3 (기존) + DOM API 만 사용.
+
+번들 영향:
+- Tree 자체 예상 크기: ~6.5 KB (min), ~2.5 KB (min+gzip).
+  - 핵심 로직 (flatten/deriveCheckVM/keyboard): ~3 KB
+  - 타입/palette/util: ~0.5 KB
+  - 렌더 컴포넌트들: ~3 KB
+- plastic 전체 dist 영향 미미.
+
+Browser 지원:
+- ES2020 (optional chaining, nullish coalescing).
+- `Set<string>` / `Map` 기본.
+- focus/ARIA: 모든 모던 브라우저.
+- `compositionstart/end` (IME typeahead 가드): 모두 지원.
+
+---
+
+## 20. 구현 완료 정의 (Definition of Done)
+
+- [ ] `npm run typecheck` 통과.
+- [ ] `npx tsup` 통과 (타입 선언 포함).
+- [ ] demo 에 `/#/tree` 라우트 동작.
+- [ ] §13.2 수동 체크리스트 항목 전부 눈으로 확인.
+- [ ] §13.3 엣지 케이스 항목 전부 눈으로 확인 또는 "v1 범위 밖" 이유 기재.
+- [ ] PipelineGraph / CodeView / HexView / CommandPalette / DataTable / SplitPane / 기타 페이지 리그레션 없음.
+- [ ] `src/components/index.ts` 배럴에 `export * from "./Tree";` 추가됨.
+- [ ] `package.json` dependencies 변경 없음 (신규 의존 없음).
+- [ ] Props 문서 섹션이 Props 표로 채워져 있음 (Root/Node/Label/Children/ExpandToggle + TreeNode 타입).
+- [ ] Usage 섹션에 최소 4 개 스니펫 (기본 / checkable / async / custom render).
+- [ ] 데모 Playground 에서 모든 주요 prop 토글 가능.
+- [ ] Light/Dark 테마 전환 시 시각 이상 없음.
+- [ ] 키보드 단독으로 (마우스 없이) expand/collapse/select/check/typeahead 가능.
+- [ ] 스크린리더(VoiceOver) 에서 role=tree/treeitem, aria-expanded/selected/checked(mixed)/level/posinset/setsize 올바르게 읽힘.
+- [ ] 500 노드 샘플에서 expand/collapse 드롭 프레임 없음.
+- [ ] 중복 id 주입 시 dev throw 확인.
+- [ ] async loadChildren 한 번만 호출되고 error/success 경로 모두 동작 확인.
+- [ ] JSX 모드 (`<Tree.Node>` 재귀) 와 data 모드 결과 동일 확인.
+- [ ] imperative API (`expandAll`/`collapseAll`/`expandTo`/`focus`) 동작 확인.
+
+---
+
+**끝.**

--- a/docs/plans/019-contextmenu-component.md
+++ b/docs/plans/019-contextmenu-component.md
@@ -1,0 +1,1653 @@
+# ContextMenu 컴포넌트 설계문서
+
+## Context
+
+plastic 라이브러리에 "오른쪽 버튼 클릭(또는 모바일 long-press) 시 포인터 근처에 떠오르는 맥락 메뉴" `ContextMenu` 컴포넌트를 추가한다. 역할 비유: VSCode 에디터/트리뷰 우클릭, Figma 캔버스 우클릭, macOS Finder 컨트롤-클릭, IntelliJ 의 "Show Intention Actions". 이 컴포넌트는 IDE 스타일 UI 에서 "선택된 대상에 대한 맥락적 행동 모음" 을 노출하는 표준 블록이며, plastic 상위에서 `DataTable` / `PipelineGraph` / `FileTree` 같은 컨테이너들이 장차 자체적으로 컨텍스트 메뉴를 달고 싶어할 때 공용 프리미티브로 재사용할 수 있도록 먼저 일반화한다.
+
+참고 (prior art — UX/접근성 근거):
+- **Radix `ContextMenu`** — compound API (`Root/Trigger/Portal/Content/Item/Sub/...`), `contextmenu` 이벤트 기반, 포털 포지셔닝 + collision, 키보드 nav 완비. 사실상 모던 React 표준. 본 설계의 1차 참조.
+- **Ant Design `Dropdown` (`trigger: ['contextMenu']`)** — trigger 에 contextMenu 모드가 있어 우클릭으로 드롭다운 메뉴 띄우는 방식. 다만 ContextMenu 전용 컴포넌트는 분리되어 있지 않음.
+- **Electron/VSCode `Menu`/`ContextMenu` (chromium)** — 네이티브 OS 메뉴를 합성. 본 설계는 브라우저-only 이므로 OS 메뉴는 기본 `contextmenu` preventDefault 로 차단하고 커스텀 레이어로 덮는다.
+- **Blueprint `ContextMenu` / `<ContextMenuTarget>`** — render-prop 기반. 고전 패턴, 참고만.
+- **Headless UI / react-aria `useMenuTrigger` + `useMenu`** — 접근성/roving tabindex 로직 구현 레퍼런스.
+- **native `<menu type="context">`** — HTML 스펙에서 폐지(deprecated) 되어 현실적으로 쓰이지 않음. 본 컴포넌트가 polyfill 역할.
+
+역할 비유 (UX):
+- **우클릭 맥락 메뉴** — "이 요소 위에서 가능한 행동". 평소에는 숨고 요청 시에만 등장. `Dropdown` 과 달리 "버튼" 이 아니라 "임의 영역" 에 붙는다.
+- **long-press 터치** — 모바일/태블릿에서 동등한 진입. 550 ms 유지 후 진동 피드백(지원 시) + 메뉴 오픈.
+- **키보드 메뉴 키** — 물리 키보드의 `Menu` 키(혹은 `Shift+F10`) 도 contextmenu 이벤트를 발생시킴. 본 컴포넌트는 이를 그대로 수용하며, 발생 위치가 포인터가 아닌 "포커스된 요소의 좌측 하단" 으로 대체된다.
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/Popover/` — portal 마운트 + viewport 기반 포지셔닝의 prior art. `PopoverContent` 의 `position: "fixed"` + `getBoundingClientRect` 기반 collision flip 로직을 **참조하되 이식하지 않고 자체 구현**(팝오버는 anchor 요소 기준, ContextMenu 는 포인터 좌표 기준이라 계산 입력값이 다름).
+- `src/components/CommandPalette/` — 키보드 전용 리스트 네비게이션(`useKbdNav`), roving activeIndex, `Enter` activate, typeahead 등의 패턴을 직접 참조.
+- `src/components/_shared/useControllable.ts` — controlled/uncontrolled 이중 API 표준 훅. `open`/`defaultOpen`/`onOpenChange` 에서 사용.
+- `src/components/index.ts` — 배럴 등록 지점.
+- `demo/src/App.tsx` — NAV 라우팅에 `"contextmenu"` 추가.
+- `demo/src/pages/CommandPalettePage.tsx` — 키보드 네비게이션이 돋보이는 데모 페이지 레이아웃 관례.
+- `tsconfig.json` — `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax` 제약.
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+<ContextMenu.Root>
+  <ContextMenu.Trigger asChild>
+    <div className="file-item">README.md</div>
+  </ContextMenu.Trigger>
+
+  <ContextMenu.Content theme="dark">
+    <ContextMenu.Label>README.md</ContextMenu.Label>
+    <ContextMenu.Separator />
+
+    <ContextMenu.Item onSelect={open}>
+      Open
+      <ContextMenu.Shortcut>⌘O</ContextMenu.Shortcut>
+    </ContextMenu.Item>
+
+    <ContextMenu.Item onSelect={rename}>
+      Rename
+      <ContextMenu.Shortcut>F2</ContextMenu.Shortcut>
+    </ContextMenu.Item>
+
+    <ContextMenu.Sub>
+      <ContextMenu.SubTrigger>Copy as…</ContextMenu.SubTrigger>
+      <ContextMenu.SubContent>
+        <ContextMenu.Item>Path</ContextMenu.Item>
+        <ContextMenu.Item>Relative path</ContextMenu.Item>
+        <ContextMenu.Item>Content</ContextMenu.Item>
+      </ContextMenu.SubContent>
+    </ContextMenu.Sub>
+
+    <ContextMenu.Separator />
+
+    <ContextMenu.CheckboxItem
+      checked={wordWrap}
+      onCheckedChange={setWordWrap}
+    >
+      Word Wrap
+    </ContextMenu.CheckboxItem>
+
+    <ContextMenu.RadioGroup value={theme} onValueChange={setTheme}>
+      <ContextMenu.RadioItem value="light">Light</ContextMenu.RadioItem>
+      <ContextMenu.RadioItem value="dark">Dark</ContextMenu.RadioItem>
+    </ContextMenu.RadioGroup>
+
+    <ContextMenu.Separator />
+
+    <ContextMenu.Item disabled>Move to…</ContextMenu.Item>
+    <ContextMenu.Item onSelect={trash} data-danger>
+      Delete
+      <ContextMenu.Shortcut>⌫</ContextMenu.Shortcut>
+    </ContextMenu.Item>
+  </ContextMenu.Content>
+</ContextMenu.Root>
+```
+
+렌더 결과 (개념):
+```
+┌─────────────────────────┐
+│ README.md               │  ← Label (dim)
+├─────────────────────────┤
+│ Open              ⌘O    │
+│ Rename            F2    │
+│ Copy as…            ▸   │ ──► ┌─────────────────┐
+├─────────────────────────┤     │ Path            │
+│ ✓ Word Wrap             │     │ Relative path   │
+│ ● Light                 │     │ Content         │
+│ ○ Dark                  │     └─────────────────┘
+├─────────────────────────┤
+│ Move to…        (dim)   │  ← disabled
+│ Delete            ⌫     │
+└─────────────────────────┘
+```
+
+핵심 설계 원칙:
+- **compound 컴포넌트**. `Root`/`Trigger`/`Content` + 아이템 계열(`Item`/`CheckboxItem`/`RadioGroup`/`RadioItem`/`Sub`/`SubTrigger`/`SubContent`/`Separator`/`Label`/`Shortcut`). Context 통해 상태·포커스·dispatch 공유. JSX 선언 자체가 메뉴 구조이며 별도 `items: MenuItem[]` 배열을 인자로 받는 "데이터형 API" 는 v1 범위 밖(§16).
+- **trigger 는 임의 DOM**. `<ContextMenu.Trigger asChild>` 로 기존 요소를 래핑만 하고 `contextmenu` / `touchstart`(long-press) / `keydown`(Shift+F10, Menu) 핸들러를 attach. `asChild` 없으면 `<span>` 기본 래퍼.
+- **포인터 좌표 기준 포지셔닝**. 팝오버가 "anchor rect 기준" 인 것과 달리 ContextMenu 는 "발생 포인트 `(x, y)` 기준" 으로 메뉴의 top-left 를 정렬하되, viewport 경계에 닿으면 **flip/shift** 하여 잘리지 않게 한다. 서브메뉴는 "부모 아이템 rect 의 우측 상단" 기준.
+- **포털(Portal) 마운트**. `document.body` 아래 `<div data-plastic-portal="context-menu">` 에 `createPortal` 로 렌더. `z-index: 9999`. 같은 페이지에 여러 ContextMenu 가 있어도 포털은 공유(싱글톤 노드).
+- **한 번에 하나만**. 전역적으로 동시에 열린 ContextMenu 는 1 개(기본). 새 `contextmenu` 이벤트가 오면 기존 메뉴는 닫히고 새 위치에서 다시 연다.
+- **`DropdownMenu` 와 내부 공유**. 동일한 `useMenuNavigation` 훅, 동일 CSS 토큰, 동일 `Item/CheckboxItem/RadioItem/Sub/SubTrigger/SubContent/Separator/Label/Shortcut` 구현을 재사용한다. 두 컴포넌트 차이는 오직 "어떻게 여는가(trigger)" 와 "어디에 정렬하는가(anchor: 포인터 vs 버튼)" 둘 뿐. 본 PR 은 ContextMenu 만 공개 export 하지만, 내부 디렉터리 구조는 `_Menu/` 공용 레이어 + `ContextMenu/` 얇은 래퍼 + 장차 `DropdownMenu/` 얇은 래퍼 형태로 나눈다(§10).
+- **런타임 의존 zero**. React + DOM API 만. portal, `createPortal`, `pointerEvents`, `getBoundingClientRect`, `requestAnimationFrame` 뿐.
+- **접근성 우선**. `role="menu"` / `role="menuitem"` / `role="menuitemcheckbox"` / `role="menuitemradio"` / `aria-haspopup="menu"` / `aria-expanded` / `aria-checked` / 각 `aria-disabled`. 키보드 네비게이션 + typeahead 지원.
+- **v1 은 다중 depth submenu 허용**. UX 관례(2~3 depth) 내에서 동작. 단 v1 에서 iframe 안쪽/바깥쪽으로 퍼지는 상호작용(iframe 좌표 보정)은 제외.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. `ContextMenu.Trigger` 내부 영역에서 브라우저 `contextmenu` 이벤트 발생 시 기본 동작(OS 메뉴) preventDefault 후 커스텀 메뉴 오픈.
+2. 터치 환경 long-press(기본 550 ms) 로 동일 진입. `touchmove` 임계(8 px) 초과 시 취소.
+3. 키보드 `Shift+F10` 및 `ContextMenu` 키로도 오픈(trigger 내부에 포커스가 있을 때). 오픈 좌표는 포커스된 요소의 bounding rect 의 좌측 하단.
+4. 메뉴 아이템: 일반 `Item`, 비활성 `Item` (`disabled`), `CheckboxItem`, `RadioGroup` + `RadioItem`, `Separator`, `Label`, 우측 단축키 힌트 `Shortcut`.
+5. **다중 depth 서브메뉴** (`Sub` / `SubTrigger` / `SubContent`). 호버 시 150 ms 지연 열림, 포인터 이동 의도(pointer-safe triangle) 로직으로 서브메뉴로 이동하는 대각 경로 유지 시 부모가 조기 닫히지 않도록 보장.
+6. 키보드 네비게이션: `ArrowDown`/`ArrowUp` 이동(roving `activeIndex`), `ArrowRight` 서브메뉴 열고 첫 아이템 포커스, `ArrowLeft` 서브메뉴 닫고 부모로, `Enter`/`Space` 선택, `Escape` 닫기, `Home`/`End` 양 끝, typeahead (연속 타이핑 200 ms 버퍼 → 시작문자 일치).
+7. 포인터 이동: `mouseenter` 시 `activeIndex` 업데이트, disabled 는 건너뜀.
+8. 포털 기반 viewport 클램프 + flip. 우측/하단 경계 초과 시 좌측/상단으로 반전. 여전히 초과면 내부 스크롤(`max-height: calc(100vh - 16px)`, `overflow-y: auto`).
+9. 외부 클릭(`pointerdown`, target 이 포털 밖) / `Escape` / 창 블러 / 스크롤 / resize 시 닫기.
+10. controlled/uncontrolled 이중 API: `open`/`defaultOpen`/`onOpenChange`. 프로그래매틱 오픈/닫기 수단 제공 (`ContextMenu.Root` 가 `open` 을 받으면 해당 값 그대로 표시, `x`/`y` 를 동시에 받으면 그 좌표에).
+11. `onSelect` 콜백이 `event.preventDefault()` 하면 메뉴가 닫히지 않음(선택 → 서브액션 연속 시나리오). 기본은 선택 즉시 닫힘.
+12. Light / Dark 테마.
+13. `DropdownMenu` 와 내부(훅, 공용 아이템 컴포넌트, CSS 토큰) 공유. v1 본 PR 은 ContextMenu 만 export. DropdownMenu 는 후속(§17).
+
+### Non-goals (v1 제외)
+- **iframe 교차 좌표 보정**: `contextmenu` 가 iframe 내부에서 발생해 iframe 바깥의 부모 문서 위에 메뉴를 띄우는 use case. 좌표계 변환 + `postMessage` 필요. v1.1.
+- **중첩 Root 제한 해제**: 같은 트리거 내부에 또다른 Trigger 를 둔 케이스는 가장 깊은 Trigger 가 우선(DOM 이벤트 버블 순), 바깥 Trigger 는 무시되도록만 보장. "동시에 두 개 열기" 는 지원하지 않는다.
+- **커스텀 포지셔닝 전략** (예: `align: "center" | "right-edge"`): v1 은 포인터 기준 top-left 정렬 + viewport 경계 flip 만. 커스텀은 v1.1.
+- **드래그로 메뉴 내 선택** (press-drag-release): macOS 네이티브 메뉴의 "눌러서 드래그, 뗀 위치에서 선택" 패턴. UX 복잡도 ↑. v1 은 클릭/키보드만.
+- **아이콘 슬롯 전용 prop**: `icon?: ReactNode` 같은 prop 은 두지 않고, 사용자는 children 에 자유롭게 아이콘 요소를 넣는다(예: `<Item><Icon /> Open</Item>`). `Shortcut` 은 예외적으로 정렬 관례(`margin-left: auto`) 때문에 전용 컴포넌트.
+- **async 아이템(동적 로딩)**: 서브메뉴 열 때 데이터를 fetch 하는 패턴. v1 은 정적 JSX 만. `Sub` 안에서 사용자가 `useEffect` 로 로딩하는 것은 당연히 가능하지만, 공식 `loading` 슬롯/skeleton 은 없음.
+- **MenuBar** (`File Edit View ...` 상단 고정 메뉴 바): 트리거 모델이 다르고 focus policy 도 다름. 별도 컴포넌트로 §17.
+- **macOS 앱처럼 메뉴 자체에 포커스 링 없음**: activeIndex 의 시각적 표시는 background highlight + optional focus ring(키보드 열림일 때만 외곽선). "보이지 않는 포커스" 금지.
+- **right-to-left 미러링 (서브메뉴 방향 자동 반전)**: 서브메뉴가 기본 우측으로 펼쳐지는 것을 RTL 에서 좌측으로 자동 반전하는 것은 v1 범위. 단 최상위 메뉴의 좌표 정렬 자체는 포인터 기준이므로 RTL 영향 없음. (포인터 좌표는 물리 좌표.)
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/ContextMenu/ContextMenu.types.ts`
+
+```ts
+export type ContextMenuTheme = "light" | "dark";
+
+export interface ContextMenuRootProps {
+  /** open 제어값. 지정 시 controlled. */
+  open?: boolean;
+  /** 초기 open. uncontrolled. 기본 false. */
+  defaultOpen?: boolean;
+  /** open 변경 콜백. user interaction 및 외부 dismiss 모두. */
+  onOpenChange?: (open: boolean) => void;
+
+  /**
+   * 프로그래매틱 오픈 시 좌표(viewport 기준 px).
+   * controlled open=true 이면 필수. uncontrolled 는 contextmenu 이벤트 좌표 사용.
+   */
+  position?: { x: number; y: number };
+
+  /** 비활성화. trigger 영역에서 contextmenu 이벤트를 완전히 무시(OS 메뉴가 뜸). */
+  disabled?: boolean;
+
+  /**
+   * long-press(touch) 지속 임계 ms. 기본 550.
+   * 0 이면 long-press 비활성.
+   */
+  longPressMs?: number;
+
+  /** long-press 판정 시 허용 이동 임계 px. 초과 시 취소. 기본 8. */
+  longPressTolerance?: number;
+
+  /** 자식: Trigger + Content (+ 기타). */
+  children: React.ReactNode;
+}
+
+export interface ContextMenuTriggerProps {
+  /** true 면 자식 하나를 감싸지 않고 이벤트만 inject(cloneElement). */
+  asChild?: boolean;
+  /** 비활성화 (ContextMenuRootProps.disabled 와 독립적으로 trigger 만 끄고 싶을 때). */
+  disabled?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}
+
+export interface ContextMenuContentProps {
+  /** 라이트/다크. 기본 "light". (Root 에서 내려받지 않고 개별 Content 가 가짐.) */
+  theme?: ContextMenuTheme;
+  /** 메뉴 container 추가 클래스/스타일. */
+  className?: string;
+  style?: React.CSSProperties;
+  /** 한 줄 최소 폭 (px). 기본 180. */
+  minWidth?: number;
+  /** 최대 폭 (px). 기본 320. 초과 시 줄바꿈 없이 ellipsis. */
+  maxWidth?: number;
+  /** 접근성 라벨(선택). 기본 "Context menu". */
+  "aria-label"?: string;
+  children: React.ReactNode;
+}
+
+export interface ContextMenuItemProps {
+  /** 선택 콜백. event.preventDefault() 시 메뉴 닫히지 않음. */
+  onSelect?: (event: ContextMenuItemEvent) => void;
+  disabled?: boolean;
+  /** typeahead 및 스크린리더용 텍스트 라벨 override. 기본 children 의 textContent. */
+  textValue?: string;
+  className?: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}
+
+/** onSelect 에 전달되는 synthetic-like event. preventDefault 시 close 억제. */
+export interface ContextMenuItemEvent {
+  preventDefault: () => void;
+  defaultPrevented: boolean;
+}
+
+export interface ContextMenuCheckboxItemProps
+  extends Omit<ContextMenuItemProps, "onSelect"> {
+  checked?: boolean;
+  defaultChecked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+  /** 선택 시 추가 부작용. 기본은 toggle 만. */
+  onSelect?: (event: ContextMenuItemEvent) => void;
+}
+
+export interface ContextMenuRadioGroupProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  children: React.ReactNode;
+}
+
+export interface ContextMenuRadioItemProps
+  extends Omit<ContextMenuItemProps, "onSelect"> {
+  value: string;
+  onSelect?: (event: ContextMenuItemEvent) => void;
+}
+
+export interface ContextMenuSubProps {
+  /** open 제어. */
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+export interface ContextMenuSubTriggerProps {
+  disabled?: boolean;
+  textValue?: string;
+  className?: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}
+
+export interface ContextMenuSubContentProps {
+  className?: string;
+  style?: React.CSSProperties;
+  minWidth?: number;
+  maxWidth?: number;
+  children: React.ReactNode;
+}
+
+export interface ContextMenuSeparatorProps {
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export interface ContextMenuLabelProps {
+  className?: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}
+
+export interface ContextMenuShortcutProps {
+  className?: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}
+```
+
+### 2.2 배럴
+
+```ts
+// src/components/ContextMenu/index.ts
+export { ContextMenu } from "./ContextMenu";
+export type {
+  ContextMenuTheme,
+  ContextMenuRootProps,
+  ContextMenuTriggerProps,
+  ContextMenuContentProps,
+  ContextMenuItemProps,
+  ContextMenuItemEvent,
+  ContextMenuCheckboxItemProps,
+  ContextMenuRadioGroupProps,
+  ContextMenuRadioItemProps,
+  ContextMenuSubProps,
+  ContextMenuSubTriggerProps,
+  ContextMenuSubContentProps,
+  ContextMenuSeparatorProps,
+  ContextMenuLabelProps,
+  ContextMenuShortcutProps,
+} from "./ContextMenu.types";
+```
+
+그리고 `src/components/index.ts` 에 `export * from "./ContextMenu";` 한 줄 추가.
+
+### 2.3 Compound namespace
+
+```ts
+// ContextMenu.tsx
+export const ContextMenu = {
+  Root: ContextMenuRoot,
+  Trigger: ContextMenuTrigger,
+  Content: ContextMenuContent,
+  Item: ContextMenuItem,
+  CheckboxItem: ContextMenuCheckboxItem,
+  RadioGroup: ContextMenuRadioGroup,
+  RadioItem: ContextMenuRadioItem,
+  Sub: ContextMenuSub,
+  SubTrigger: ContextMenuSubTrigger,
+  SubContent: ContextMenuSubContent,
+  Separator: ContextMenuSeparator,
+  Label: ContextMenuLabel,
+  Shortcut: ContextMenuShortcut,
+};
+```
+
+각 subcomponent 의 `displayName` 은 `"ContextMenu.Root"`, `"ContextMenu.Trigger"`, ... 으로 명명하여 DevTools 가독성 확보.
+
+---
+
+## 3. 도메인 모델
+
+### 3.1 메뉴 트리 모델 (선언형 JSX)
+
+v1 의 메뉴 구조는 사용자 JSX 가 곧 데이터다. 별도 `items: MenuItem[]` 을 만들지 않는다.
+
+```
+ContextMenu.Content
+ ├─ Label                ("README.md")
+ ├─ Separator
+ ├─ Item                 (Open)
+ ├─ Item                 (Rename)
+ ├─ Sub
+ │   ├─ SubTrigger       (Copy as…)
+ │   └─ SubContent
+ │       ├─ Item         (Path)
+ │       ├─ Item         (Relative path)
+ │       └─ Item         (Content)
+ ├─ Separator
+ ├─ CheckboxItem         (Word Wrap, checked)
+ ├─ RadioGroup
+ │   ├─ RadioItem        (light)
+ │   └─ RadioItem        (dark)
+ ├─ Separator
+ ├─ Item (disabled)      (Move to…)
+ └─ Item                 (Delete)
+```
+
+런타임에는 `Content`/`SubContent` 가 자식을 `React.Children.toArray` 하여 "선택 가능(focusable) 아이템 인덱스 배열" 을 만든다(`Label`/`Separator`/`disabled Item` 은 제외). `activeIndex` 는 이 focusable 배열 안에서 움직이는 정수. 이로써 `ArrowDown` 이 disabled 위로 뛰어 건너뛴다.
+
+### 3.2 내부 아이템 디스크립터
+
+```ts
+type MenuItemKind =
+  | "item"
+  | "checkbox"
+  | "radio"
+  | "sub-trigger"
+  | "separator"
+  | "label";
+
+interface MenuItemDescriptor {
+  kind: MenuItemKind;
+  disabled: boolean;
+  textValue: string;      // typeahead + aria
+  element: React.ReactElement;
+}
+```
+
+`Content` 가 `useLayoutEffect` 로 children 을 스캔해 `descriptorsRef.current` 채운다. `Item/CheckboxItem/RadioItem/SubTrigger` 는 `useMenuItem()` 훅을 호출해 자신의 `textValue` 와 `disabled` 를 Context 에 등록. separator/label 은 "건너뛰기 대상" 표시.
+
+### 3.3 checkbox / radio 상태
+
+- `CheckboxItem` 은 `useControllable<boolean>` 로 checked 를 보유 (controlled 가능).
+- `RadioGroup` 은 내부 Context 로 `value` + `onValueChange` 를 자식 `RadioItem` 에 내려보낸다. `RadioItem` 이 `onSelect` 시 자신의 `value` 로 그룹의 `onValueChange` 호출. 시각적으로는 현재 value 와 일치하는 radio 만 `●`.
+
+### 3.4 서브메뉴 트리
+
+`Sub` 는 독립적 `open` state 를 가진다 (Root 의 open 과 별개). 서브메뉴 depth 가 깊어지면 `Sub` 안에 `Sub` 를 또 넣는다. 최상위 Root 가 닫히면 모든 `Sub.open` 도 false 로 강제 리셋(`useEffect` 로 전파).
+
+### 3.5 Root Context
+
+```ts
+interface ContextMenuContextValue {
+  open: boolean;
+  position: { x: number; y: number } | null;
+  setOpen: (open: boolean, atPosition?: { x: number; y: number }) => void;
+  disabled: boolean;
+  longPressMs: number;
+  longPressTolerance: number;
+
+  /** 최상위 content 의 rootNodeId (포털 내부 식별용). */
+  rootId: string;
+
+  /** 열림 방식 (키보드 vs 포인터). 포커스 링 표시 정책용. */
+  openMode: "pointer" | "keyboard" | null;
+
+  /** typeahead 버퍼 (Content 가 공유). */
+  typeaheadRef: React.MutableRefObject<{ buf: string; timer: number | null }>;
+}
+```
+
+`Content` 수준 Context 는 별도:
+
+```ts
+interface ContextMenuContentContextValue {
+  /** 현재 Content 의 activeIndex (focusable 배열 내 index). */
+  activeIndex: number;
+  setActiveIndex: (i: number) => void;
+  /** 현재 Content 에 속한 focusable items ref 리스트. */
+  itemsRef: React.MutableRefObject<HTMLElement[]>;
+  descriptorsRef: React.MutableRefObject<MenuItemDescriptor[]>;
+  /** 선택 시 close 전파. */
+  onItemSelect: (ev: ContextMenuItemEvent) => void;
+  /** 서브 ↔ 부모 포커스 상호작용. */
+  closeSelf: () => void;
+}
+```
+
+### 3.6 dispatcher
+
+라이브러리 외부 API 없는 내부 헬퍼:
+
+```ts
+// Root 가 소유하는 open 액션
+type OpenAction =
+  | { type: "open-pointer"; x: number; y: number }
+  | { type: "open-keyboard"; x: number; y: number }
+  | { type: "close" };
+```
+
+---
+
+## 4. 시각 / 구조 설계
+
+### 4.1 DOM 구조 (열린 상태 기준)
+
+```
+<body>
+  <!-- 원래 Trigger 가 있던 문서 트리 -->
+  <div data-plastic-context-menu-trigger="ok" oncontextmenu="...">
+    … 사용자 콘텐츠 …
+  </div>
+
+  <!-- 포털: Content -->
+  <div data-plastic-portal="context-menu">
+    <div
+      role="menu"
+      aria-label="Context menu"
+      tabindex="-1"
+      class="cm-content cm-theme-light"
+      style="position:fixed; top:120px; left:240px; min-width:180px; max-width:320px; z-index:9999;"
+    >
+      <div role="presentation" class="cm-label">README.md</div>
+      <div role="separator" class="cm-separator" />
+      <div role="menuitem" tabindex="-1" data-active="true" class="cm-item">
+        <span class="cm-item-label">Open</span>
+        <span class="cm-shortcut">⌘O</span>
+      </div>
+      <div role="menuitem" tabindex="-1" class="cm-item">
+        <span class="cm-item-label">Rename</span>
+        <span class="cm-shortcut">F2</span>
+      </div>
+
+      <div role="menuitem" tabindex="-1"
+           aria-haspopup="menu" aria-expanded="false"
+           class="cm-item cm-sub-trigger">
+        <span class="cm-item-label">Copy as…</span>
+        <span class="cm-sub-indicator">▸</span>
+      </div>
+
+      <div role="separator" class="cm-separator" />
+
+      <div role="menuitemcheckbox" aria-checked="true" tabindex="-1" class="cm-item">
+        <span class="cm-check">✓</span>
+        <span class="cm-item-label">Word Wrap</span>
+      </div>
+
+      <div role="group" class="cm-radio-group">
+        <div role="menuitemradio" aria-checked="true" tabindex="-1" class="cm-item">
+          <span class="cm-radio">●</span>
+          <span class="cm-item-label">Light</span>
+        </div>
+        <div role="menuitemradio" aria-checked="false" tabindex="-1" class="cm-item">
+          <span class="cm-radio"></span>
+          <span class="cm-item-label">Dark</span>
+        </div>
+      </div>
+
+      <div role="separator" class="cm-separator" />
+
+      <div role="menuitem" aria-disabled="true" class="cm-item cm-item-disabled">
+        Move to…
+      </div>
+      <div role="menuitem" tabindex="-1" class="cm-item cm-item-danger">
+        Delete
+        <span class="cm-shortcut">⌫</span>
+      </div>
+    </div>
+
+    <!-- 서브메뉴가 열린 경우(별도 floating container) -->
+    <div role="menu" class="cm-content" style="position:fixed; top:180px; left:460px; ...">
+      …
+    </div>
+  </div>
+</body>
+```
+
+### 4.2 포지셔닝 알고리즘 (pointer 기준 flip/shift)
+
+사용자가 `contextmenu` 이벤트 좌표 `(cx, cy)` 를 건넸다고 하자. Content 마운트 직후 `useLayoutEffect` 에서:
+
+1. Content DOM 의 `getBoundingClientRect()` 로 `w` (width), `h` (height) 측정.
+2. viewport 크기 `vw = window.innerWidth`, `vh = window.innerHeight`.
+3. 바깥 padding `PAD = 8 px` (viewport 가장자리와 Content 사이 최소 여백).
+4. 계산:
+   ```
+   left = cx
+   top  = cy
+   // 우측 overflow → flip
+   if (left + w + PAD > vw)  left = Math.max(PAD, cx - w)
+   // 좌측 underflow
+   if (left < PAD)           left = PAD
+   // 하단 overflow → flip
+   if (top + h + PAD > vh)   top  = Math.max(PAD, cy - h)
+   // 상단 underflow
+   if (top < PAD)            top  = PAD
+   ```
+5. 여전히 `h > vh - 2*PAD` 인(메뉴가 뷰포트보다 큰) 경우: `top = PAD`, Content 에 `max-height: calc(100vh - 16px); overflow-y: auto` 적용.
+
+### 4.3 서브메뉴 포지셔닝 (anchor 기준)
+
+서브메뉴는 부모 `SubTrigger` 요소의 rect `r = trigger.getBoundingClientRect()` 를 기준:
+
+1. 이상적 위치: `left = r.right + 2`, `top = r.top - 4` (살짝 위로 보정해 첫 아이템이 trigger 선과 맞도록).
+2. 우측 overflow (`left + w + PAD > vw`) 이면 **좌측 플립**: `left = r.left - w - 2`.
+3. 아직도 좌측 underflow 면 `left = PAD`.
+4. 하단 overflow 면 `top = Math.max(PAD, r.bottom - h)` (bottom align).
+5. 높이 과대면 §4.2 와 동일 max-height 적용.
+
+### 4.4 이유 — fixed vs absolute vs body-relative
+
+- `position: fixed` 선택. viewport 기준 좌표(`contextmenu` event 의 `clientX/Y`) 와 직결되어 스크롤/스크롤 위치 변동과 독립. 스크롤 발생 시에는 **메뉴 자체를 닫는다**(§5.x dismiss) — 팔로우 로직 불필요.
+- `absolute` 에 `offsetParent` 기준이면 포털이 body 직하여 좌표 변환이 `pageX/Y` 로 달라지고 스크롤 이슈.
+- iframe 내부 이벤트는 v1 에서 취급하지 않으므로 단일 문서 `clientX/Y` 로 충분.
+
+### 4.5 palette 토큰
+
+```ts
+// ContextMenu/theme.ts
+export const contextMenuPalette = {
+  light: {
+    contentBg:        "#ffffff",
+    contentFg:        "#111827",
+    contentBorder:    "rgba(0,0,0,0.08)",
+    contentShadow:    "0 12px 32px rgba(0,0,0,0.14), 0 2px 6px rgba(0,0,0,0.08)",
+    itemHoverBg:      "rgba(37,99,235,0.08)",
+    itemActiveBg:     "rgba(37,99,235,0.14)",
+    itemDisabledFg:   "rgba(17,24,39,0.35)",
+    itemDangerFg:     "#dc2626",
+    itemDangerBg:     "rgba(220,38,38,0.08)",
+    separatorBg:      "rgba(0,0,0,0.08)",
+    labelFg:          "rgba(17,24,39,0.55)",
+    shortcutFg:       "rgba(17,24,39,0.50)",
+    checkFg:          "#2563eb",
+    radioFg:          "#2563eb",
+    focusRing:        "#2563eb",
+  },
+  dark: {
+    contentBg:        "#1f2937",
+    contentFg:        "#e5e7eb",
+    contentBorder:    "rgba(255,255,255,0.08)",
+    contentShadow:    "0 12px 32px rgba(0,0,0,0.45), 0 2px 6px rgba(0,0,0,0.25)",
+    itemHoverBg:      "rgba(96,165,250,0.12)",
+    itemActiveBg:     "rgba(96,165,250,0.20)",
+    itemDisabledFg:   "rgba(229,231,235,0.40)",
+    itemDangerFg:     "#f87171",
+    itemDangerBg:     "rgba(248,113,113,0.15)",
+    separatorBg:      "rgba(255,255,255,0.08)",
+    labelFg:          "rgba(229,231,235,0.55)",
+    shortcutFg:       "rgba(229,231,235,0.50)",
+    checkFg:          "#60a5fa",
+    radioFg:          "#60a5fa",
+    focusRing:        "#60a5fa",
+  },
+} as const;
+```
+
+### 4.6 치수 / 타이포
+
+- Content padding: `4px 0`.
+- Item: `padding: 6px 10px`, `height: 28px`, `font-size: 13px`, `line-height: 16px`.
+- Shortcut: 우측 정렬, `margin-left: auto`, `font-variant-numeric: tabular-nums`, `color: var(--shortcutFg)`.
+- Separator: `height: 1px`, `margin: 4px 6px`, `background: var(--separatorBg)`.
+- Label: `padding: 4px 10px`, `font-size: 11px`, `text-transform: uppercase`, `letter-spacing: 0.04em`, `color: var(--labelFg)`.
+- Sub indicator(`▸`): `margin-left: 6px`, `opacity: 0.7`.
+- Radius: 6px (content) / 3px (item hover box-inset).
+- Content shadow : §4.5 팔레트.
+
+---
+
+## 5. 핵심 로직
+
+### 5.1 trigger 이벤트 attach
+
+`ContextMenu.Trigger` 는 자식을 감싸는 얇은 wrapper. `asChild` 이면 `React.cloneElement(child, injectedProps)` 로 이벤트만 내려보낸다(Radix 방식). 그렇지 않으면 `<span data-cm-trigger>` 로 감싼다.
+
+```ts
+function useTriggerHandlers(ctx: ContextMenuContextValue) {
+  const onContextMenu = (e: React.MouseEvent) => {
+    if (ctx.disabled) return;
+    e.preventDefault();
+    e.stopPropagation();
+    ctx.setOpen(true, { x: e.clientX, y: e.clientY });
+  };
+
+  // long-press (touch)
+  const touchStateRef = useRef<{ tid: number; sx: number; sy: number } | null>(null);
+  const onTouchStart = (e: React.TouchEvent) => {
+    if (ctx.disabled || ctx.longPressMs <= 0) return;
+    const t0 = e.touches[0];
+    if (!t0) return;
+    const tid = window.setTimeout(() => {
+      ctx.setOpen(true, { x: t0.clientX, y: t0.clientY });
+      // 진동 (지원 시)
+      if (typeof navigator.vibrate === "function") navigator.vibrate(8);
+    }, ctx.longPressMs);
+    touchStateRef.current = { tid, sx: t0.clientX, sy: t0.clientY };
+  };
+  const cancel = () => {
+    if (touchStateRef.current) {
+      clearTimeout(touchStateRef.current.tid);
+      touchStateRef.current = null;
+    }
+  };
+  const onTouchMove = (e: React.TouchEvent) => {
+    const s = touchStateRef.current;
+    const t = e.touches[0];
+    if (!s || !t) return;
+    const d = Math.hypot(t.clientX - s.sx, t.clientY - s.sy);
+    if (d > ctx.longPressTolerance) cancel();
+  };
+  const onTouchEnd = cancel;
+  const onTouchCancel = cancel;
+
+  // 키보드: Shift+F10, ContextMenu 키
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (ctx.disabled) return;
+    const isCtxKey =
+      e.key === "ContextMenu" || (e.shiftKey && e.key === "F10");
+    if (!isCtxKey) return;
+    e.preventDefault();
+    const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    ctx.setOpen(true, { x: r.left, y: r.bottom });
+    // openMode = "keyboard" 로 마킹 → activeIndex=0 자동
+  };
+
+  return { onContextMenu, onTouchStart, onTouchMove, onTouchEnd, onTouchCancel, onKeyDown };
+}
+```
+
+주의점:
+- `onContextMenu` 에 `preventDefault` 는 필수 — OS 메뉴 띄우는 브라우저 기본 차단.
+- `stopPropagation` 도 호출하여, 중첩된 상위 Trigger 가 같은 이벤트에 반응해 중복 오픈하지 않도록. (최내부 Trigger 가 이김.)
+- `disabled` 이면 이벤트 무시 → OS 기본 메뉴가 그대로 뜸. (테스트/디버깅 편의.)
+
+### 5.2 Root 상태 머신
+
+```ts
+function ContextMenuRoot(props: ContextMenuRootProps) {
+  const [openUnc, setOpenUnc] = useState(props.defaultOpen ?? false);
+  const [positionUnc, setPositionUnc] = useState<{ x: number; y: number } | null>(null);
+  const [openMode, setOpenMode] = useState<"pointer" | "keyboard" | null>(null);
+
+  const isControlled = props.open !== undefined;
+  const open = isControlled ? props.open! : openUnc;
+  const position = isControlled ? (props.position ?? null) : positionUnc;
+
+  const setOpen = useEvent((next: boolean, atPosition?: { x: number; y: number }, mode: "pointer" | "keyboard" = "pointer") => {
+    if (!isControlled) {
+      setOpenUnc(next);
+      if (atPosition) setPositionUnc(atPosition);
+      else if (!next) setPositionUnc(null);
+    }
+    setOpenMode(next ? mode : null);
+    props.onOpenChange?.(next);
+  });
+
+  // dev warn: controlled open=true 인데 position 미지정
+  useEffect(() => {
+    if (isControlled && open && !props.position) {
+      console.warn("[ContextMenu] controlled `open=true` requires `position={{x,y}}`");
+    }
+  }, [isControlled, open, props.position]);
+
+  // ... Context.Provider + children 렌더
+}
+```
+
+`useEvent` 는 `useCallback` 가 deps 로 인한 stale handler 를 피하기 위한 ref 기반 헬퍼(내부). `CommandPalette` 에서 쓰던 패턴 재사용.
+
+### 5.3 Content 마운트 & 포지셔닝
+
+```tsx
+function ContextMenuContent({ children, theme = "light", minWidth = 180, maxWidth = 320, ...rest }: ContextMenuContentProps) {
+  const ctx = useContextMenuContext();
+  const ref = useRef<HTMLDivElement>(null);
+  const [placement, setPlacement] = useState<{ left: number; top: number; maxH?: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!ctx.open || !ctx.position || !ref.current) { setPlacement(null); return; }
+    const el = ref.current;
+    const w = el.offsetWidth, h = el.offsetHeight;
+    const vw = window.innerWidth, vh = window.innerHeight;
+    const PAD = 8;
+    let { x: left, y: top } = ctx.position;
+    if (left + w + PAD > vw) left = Math.max(PAD, ctx.position.x - w);
+    if (left < PAD) left = PAD;
+    if (top + h + PAD > vh) top  = Math.max(PAD, ctx.position.y - h);
+    if (top  < PAD) top  = PAD;
+    const maxH = h > vh - 2 * PAD ? vh - 2 * PAD : undefined;
+    setPlacement({ left, top, ...(maxH ? { maxH } : {}) });
+  }, [ctx.open, ctx.position?.x, ctx.position?.y]);
+
+  // keyboard/pointer focus mgmt + dismissers + arrow nav (자세한 로직은 §7)
+  useMenuDismisser(ref, ctx);
+  const contentCtx = useMenuContentStateMachine(ref, ctx, { openMode: ctx.openMode });
+
+  if (!ctx.open) return null;
+  return createPortal(
+    <div
+      ref={ref}
+      role="menu"
+      aria-label={rest["aria-label"] ?? "Context menu"}
+      tabIndex={-1}
+      className={clsx("cm-content", `cm-theme-${theme}`, rest.className)}
+      style={{
+        position: "fixed",
+        left: placement?.left ?? -9999,
+        top: placement?.top ?? -9999,
+        minWidth, maxWidth,
+        maxHeight: placement?.maxH,
+        overflowY: placement?.maxH ? "auto" : undefined,
+        opacity: placement ? 1 : 0,  // 측정 전에는 숨김 (FOUC 방지)
+        zIndex: 9999,
+        ...rest.style,
+      }}
+      onKeyDown={contentCtx.onKeyDown}
+      onMouseMoveCapture={contentCtx.onMouseMoveCapture}
+    >
+      <ContextMenuContentContext.Provider value={contentCtx.value}>
+        {children}
+      </ContextMenuContentContext.Provider>
+    </div>,
+    getPortalNode()
+  );
+}
+```
+
+`getPortalNode()` 은 `document.body` 에 `data-plastic-portal="context-menu"` 를 한번만 만들어 재사용 (싱글톤, `useSyncExternalStore` 필요 없음). Popover 의 것과 **분리** — 다른 z-index 와 cleanup lifecycle.
+
+### 5.4 서브메뉴 hover-open 지연 + pointer-safe triangle
+
+서브메뉴는 `SubTrigger` 에 포인터가 들어오면 150 ms 후 열고, 나가면 150 ms 후 닫는다. 단 "닫힘 타이머" 동작 중 포인터가 이미 열려있는 `SubContent` 의 첫 visible rect 쪽으로 "대각 이동 중" 이라면 타이머를 연장한다(사용자가 서브메뉴로 이동하는 의도).
+
+알고리즘 (safe triangle):
+1. `SubContent` 가 열려있고 위치가 확정되었을 때, 그 좌측 세로변(왼쪽 플립이면 우측 세로변)의 두 끝점을 `P1 = (subLeft, subTop)`, `P2 = (subLeft, subBottom)` 로 기록.
+2. 포인터가 `SubTrigger` 에서 벗어나는 순간 커서 좌표 `P0 = (px, py)` 를 기준점으로 삼고, 이후 `mousemove` 를 Content 레벨에서 감지.
+3. 이후 매 이동 좌표 `Pn` 에 대해 **삼각형 `P0-P1-P2` 내부** 에 있는지 판정. 내부면 사용자는 서브메뉴 쪽으로 "향하는 중" 으로 해석 → 닫힘 타이머 리셋(또 150 ms 연장).
+4. 삼각형 밖으로 벗어나거나 250 ms 지연 누적 시 타이머 만료 → 서브메뉴 닫기.
+
+```ts
+// pointer-safe triangle 내부 판정 (barycentric)
+function isInsideTriangle(p: XY, a: XY, b: XY, c: XY): boolean {
+  const d1 = sign(p, a, b);
+  const d2 = sign(p, b, c);
+  const d3 = sign(p, c, a);
+  const neg = d1 < 0 || d2 < 0 || d3 < 0;
+  const pos = d1 > 0 || d2 > 0 || d3 > 0;
+  return !(neg && pos);
+}
+function sign(p: XY, a: XY, b: XY): number {
+  return (p.x - b.x) * (a.y - b.y) - (a.x - b.x) * (p.y - b.y);
+}
+```
+
+UX 영향: 사용자가 "Copy as…" 위에서 우측 서브메뉴의 "Relative path" 로 대각 이동할 때 중간에 다른 Item 위를 스쳐도 서브메뉴가 닫히지 않는다. 이 부분은 Radix/Chromium native 메뉴의 사실상 표준 UX.
+
+구현 위치: `useMenuSub` 훅이 부모 Content 의 `onMouseMoveCapture` 를 구독하여 좌표를 받는다. `P0/P1/P2` 는 `SubTrigger` 를 떠날 때 계산해 저장.
+
+### 5.5 외부 dismiss
+
+`Content` 마운트 시 document-level 리스너:
+- `pointerdown` (capture): target 이 `data-plastic-portal="context-menu"` 의 descendant 가 아니면 `setOpen(false)`.
+- `keydown` Escape: 활성 Content 가 서브면 자기만 close, 아니면 최상위 close.
+- `blur` on window: `setOpen(false)` (창을 떠나면 메뉴 닫힘).
+- `scroll` (capture, passive): 컨테이너가 스크롤될 때 좌표 신뢰도 잃으므로 닫음. 단 Content 자체의 내부 스크롤은 무시(리스너 target 검사).
+- `resize`: 동일 이유로 닫음.
+- `contextmenu` (capture): 다른 위치에서 또 우클릭이 오면, Root 의 setOpen 로직이 새 좌표로 다시 열기 — Content 는 재계산으로 움직인다. 즉 "이전 메뉴 close + 새 메뉴 open" 이 자연스럽게 흐른다.
+
+모두 `useEffect` 내 `addEventListener` + cleanup.
+
+### 5.6 Item 선택 & close 전파
+
+`Item.onClick` 및 `Enter/Space` 키 처리에서:
+```ts
+function selectItem(userOnSelect?: (e: ContextMenuItemEvent) => void) {
+  const ev: ContextMenuItemEvent = {
+    defaultPrevented: false,
+    preventDefault() { this.defaultPrevented = true; },
+  };
+  userOnSelect?.(ev);
+  if (!ev.defaultPrevented) ctx.setOpen(false);
+}
+```
+
+`CheckboxItem` 은 선택 시 내부 toggle + `onCheckedChange` 후 `userOnSelect` 호출. `RadioItem` 은 그룹의 `onValueChange(value)` 호출 후 close.
+
+---
+
+## 6. 제약 (viewport clamp, 최대 높이, 아이템 수, 길이)
+
+### 6.1 viewport clamp 정책
+- **clamp 우선**: §4.2 의 flip 로직으로 우/하단 경계를 건드리지 않는 한 원래 좌표 유지. 건드릴 때만 플립.
+- **양쪽 동시 overflow**: width > vw - 2*PAD 인 극단 케이스는 left=PAD, maxWidth=vw-2*PAD. height 동일.
+- **PAD=8px 이유**: OS 스타일 드롭 섀도(대략 12~16 px blur) 절반이 들여다보이도록 최소 여백.
+
+### 6.2 max-height 와 내부 스크롤
+- 아이템 수가 많아 Content 가 `vh - 16px` 보다 크면 내부 `overflow-y: auto`.
+- 스크롤 컨테이너 자체가 키보드 네비로 자동 `scrollIntoView({ block: "nearest" })` 되어야 함 → `useMenuNavigation` 이 activeIndex 변경 시 해당 item DOM 을 `scrollIntoView`.
+- 외부 스크롤(윈도우/부모 컨테이너)이 감지되면 Content 는 닫는다(§5.5). 그러나 **Content 내부 스크롤**은 닫지 않는다(리스너 capture 에서 `e.target` 이 Content descendant 인지 검사).
+
+### 6.3 item width 제약
+- 라벨이 길면 `white-space: nowrap; overflow: hidden; text-overflow: ellipsis`. 최대 폭 `maxWidth - padding - shortcut` 선에서 잘림. tooltip 은 v1 없음 (사용자가 필요시 `Tooltip` 으로 감싸면 됨).
+
+### 6.4 동시 오픈 제한
+- 하나의 Root 는 동시 1 개 메뉴 트리(최상위 Content + 열린 서브들)만 유지. 다른 Root 도 `document` pointerdown 이 dismiss 역할을 하므로 자연스럽게 하나만 표시된다.
+- 여러 Root 가 같은 영역에 대해 `contextmenu` 를 받는다면, DOM 이벤트 버블 순서대로 최내부 Trigger 가 `stopPropagation` 호출해 이김.
+
+### 6.5 서브메뉴 깊이
+- 기술적 제한 없음. 다만 UX 관례상 3 depth 이상은 ineffective — 데모 페이지에서도 2~3 depth 예시만.
+
+### 6.6 아이템 DOM 수
+- 1000 개 이상의 Item 은 성능 경고 대상(§14). v1 은 단순 렌더, 가상화 없음. 1000 개 이상이 필요한 유스케이스는 "메뉴" 가 아니라 `CommandPalette` 로 유도.
+
+---
+
+## 7. 키보드
+
+메뉴 오픈 후 포커스는 Content DOM (`tabindex=-1`, 실제 포커스는 `activeIndex` 에 해당하는 item 의 DOM 이 `ref.focus()`).
+
+| 키 | 위치 | 동작 |
+|---|---|---|
+| `ArrowDown` | Content/SubContent | 다음 focusable item 으로. 끝이면 처음으로 wrap. disabled/separator/label 건너뜀. |
+| `ArrowUp` | Content/SubContent | 이전 focusable item. 처음이면 끝으로 wrap. |
+| `ArrowRight` | SubTrigger 에 활성일 때 | 서브메뉴 열고 첫 item 에 포커스. 일반 item 에선 무시. |
+| `ArrowLeft` | SubContent 내부 | 서브메뉴 닫고 부모 Content 로 포커스 복귀(부모의 SubTrigger 가 active). Content(최상위) 에선 무시. |
+| `Enter` / `Space` | item 활성 | 선택. onSelect preventDefault 면 유지, 아니면 최상위까지 close. |
+| `Escape` | 임의 Content | 현재 Content 가 SubContent 면 자기만 close, 최상위면 Root close. |
+| `Home` | Content | 첫 focusable item. |
+| `End` | Content | 마지막 focusable item. |
+| `Tab` | Content | preventDefault — Tab 포커스 순환이 메뉴 바깥으로 빠져나가지 못하게. (Radix 정책 준수.) |
+| `a-z 0-9` + symbol | Content | typeahead: 200 ms 버퍼 유지, 버퍼로 `startsWith` (case-insensitive) 일치 첫 item 포커스. 같은 문자 반복 시 동일 prefix 그룹 내 순환 (`jj` 는 "j" 시작 두 번째). |
+
+typeahead 구현:
+```ts
+const ta = ctx.typeaheadRef.current;
+if (ta.timer) clearTimeout(ta.timer);
+ta.buf += e.key.toLowerCase();
+ta.timer = window.setTimeout(() => { ta.buf = ""; ta.timer = null; }, 200);
+
+const descs = contentCtx.descriptorsRef.current.filter(d =>
+  !d.disabled && (d.kind === "item" || d.kind === "checkbox" || d.kind === "radio" || d.kind === "sub-trigger")
+);
+// 현재 activeIndex 이후부터 순회
+const start = contentCtx.activeIndex + 1;
+const N = descs.length;
+for (let i = 0; i < N; i++) {
+  const d = descs[(start + i) % N];
+  if (d && d.textValue.toLowerCase().startsWith(ta.buf)) {
+    contentCtx.setActiveIndex((start + i) % N);
+    break;
+  }
+}
+```
+
+### 7.1 첫 포커스 위치 (openMode 분기)
+
+- `openMode === "pointer"`: 포커스 링 숨김, `activeIndex = -1` (아직 아무것도 highlight 안 됨). 이후 포인터 hover 가 activeIndex 를 정한다.
+- `openMode === "keyboard"` (Shift+F10, Menu 키): `activeIndex = 0` 즉시 highlight, 포커스 링 보임.
+
+`data-open-mode="pointer"|"keyboard"` 를 Content 에 걸고 CSS 에서 `[data-open-mode="keyboard"] .cm-item[data-active="true"] { outline: 2px solid var(--focusRing); }` 으로 분기.
+
+### 7.2 포커스 트랩
+
+Content 가 열리면 직전 포커스 `document.activeElement` 를 저장. 닫힐 때 저장 요소로 복원. Tab/Shift+Tab 은 preventDefault 되어 메뉴 밖으로 못 나간다.
+
+---
+
+## 8. 상태 관리 (open, openSub, activeIndex, controlled)
+
+### 8.1 Root 레벨
+
+```ts
+const [openUnc, setOpenUnc] = useState(defaultOpen ?? false);
+const [positionUnc, setPositionUnc] = useState<{x:number;y:number} | null>(null);
+const isControlled = props.open !== undefined;
+```
+
+controlled 이면 `open`/`position` 은 props 에서 읽고, user interaction 은 `onOpenChange` 만 호출. uncontrolled 이면 내부 setState 도 함께.
+
+controlled + `open=true` 인데 `position` 없으면 dev warn + 이전 position 재사용 (없으면 `{x:0,y:0}` fallback).
+
+### 8.2 Content 레벨
+
+```ts
+const [activeIndex, setActiveIndex] = useState(openMode === "keyboard" ? 0 : -1);
+```
+
+포인터 mouseenter 시:
+```ts
+function onItemMouseEnter(index: number) {
+  setActiveIndex(index);
+}
+```
+
+activeIndex 가 변경되면 해당 item DOM 을 `focus()` 하여 실제 포커스 트랩을 유지 (screen reader 에서 읽힘).
+
+### 8.3 Sub 레벨
+
+```ts
+function ContextMenuSub({ open, defaultOpen, onOpenChange, children }: ContextMenuSubProps) {
+  const [openUnc, setOpenUnc] = useState(defaultOpen ?? false);
+  const isControlled = open !== undefined;
+  const subOpen = isControlled ? open! : openUnc;
+  const setSubOpen = (next: boolean) => {
+    if (!isControlled) setOpenUnc(next);
+    onOpenChange?.(next);
+  };
+  // 최상위 Root 닫힘 → 모든 Sub close
+  const rootCtx = useContextMenuContext();
+  useEffect(() => {
+    if (!rootCtx.open && subOpen) setSubOpen(false);
+  }, [rootCtx.open]);
+
+  return <ContextMenuSubContext.Provider value={{ open: subOpen, setOpen: setSubOpen }}>{children}</ContextMenuSubContext.Provider>;
+}
+```
+
+### 8.4 프로그래매틱 오픈 예시
+
+```tsx
+const [open, setOpen] = useState(false);
+const [pos, setPos] = useState({x:0, y:0});
+// 외부 버튼으로 임의 좌표에 메뉴 띄우기
+<button onClick={(e) => { setPos({x: e.clientX, y: e.clientY}); setOpen(true); }}>
+  Show menu at cursor
+</button>
+<ContextMenu.Root open={open} onOpenChange={setOpen} position={pos}>
+  <ContextMenu.Trigger asChild><div /></ContextMenu.Trigger>{/* no-op trigger */}
+  <ContextMenu.Content>…</ContextMenu.Content>
+</ContextMenu.Root>
+```
+
+Trigger 가 실제로는 사용되지 않아도 compound 구조상 존재해야 한다. v1 정책: Trigger 가 없거나 children 이 비면 dev warn 후 렌더만 수행. v1.1 에서 `<ContextMenu.Root>` 내부 Trigger 생략 허용 리팩터링.
+
+---
+
+## 9. 고유 기능
+
+### 9.1 CheckboxItem / RadioGroup
+
+- 시각적 prefix: Checkbox 는 `✓` (24 × 24 icon slot), Radio 는 `●`. 미체크 시 공백이지만 **동일 너비** 차지(메뉴 정렬 일관성).
+- `RadioGroup` 은 `value` / `defaultValue` / `onValueChange` 를 받아 Context 로 자식에 전달. `RadioItem` 은 내부 Context 에서 현재 value 와 자신의 value 비교 → `aria-checked`.
+- 선택 시 toggle/값변경 후 기본 close. `onSelect` 에서 `preventDefault` 시 열림 유지(연속 토글 시나리오).
+
+### 9.2 Shortcut 표시
+
+- `<ContextMenu.Shortcut>` 는 children 을 그대로 렌더. 내부 CSS 가 `margin-left: auto` + 색상/크기. 문자열(⌘O, Ctrl+S, F2 등) 또는 JSX 자유롭게.
+- 실제 단축키 **바인딩 책임은 사용자** (주변 앱에서 전역 keydown 으로 처리). 메뉴는 표시만.
+- v1 후보 확장: `shortcut="Mod+S"` 문자열 prop 으로 OS 감지 포맷팅(⌘ vs Ctrl) — v1.1(§17).
+
+### 9.3 Sub / SubTrigger / SubContent
+
+- `Sub` 는 독립 상태. hover 지연 open/close (§5.4).
+- `SubTrigger` 는 `Item` 형태지만 `aria-haspopup="menu"`, `aria-expanded`, 우측 `▸` indicator 포함. `Enter/Space/ArrowRight` 로 open.
+- `SubContent` 는 `SubTrigger` rect 기준 포지셔닝 (§4.3).
+- 서브메뉴 열릴 때 부모 `activeIndex` 는 그대로(SubTrigger 에 고정), SubContent 의 `activeIndex=0` 으로 시작.
+
+### 9.4 disabled
+
+- `Item.disabled=true` 이면 `aria-disabled="true"`, 포커스 안 받음, 클릭/Enter 무시, typeahead/arrow nav 에서도 skip, 시각적 dim.
+- focusable 배열에서 제외되므로 `ArrowDown` 이 건너뛴다.
+
+### 9.5 safe triangle hover-intent
+
+§5.4 에서 상술. 구현 난이도는 중간(기하 판정 + timer coordination), 그러나 서브메뉴 UX 품질의 핵심. Radix 와 동일 접근.
+
+### 9.6 danger item
+
+- 관례적 `data-danger` attribute. CSS 에서 `.cm-item[data-danger]` 색상 (#dc2626 / #f87171). 사용자가 `<Item data-danger onSelect={trash}>Delete</Item>` 식으로 표시.
+- 별도 prop 은 두지 않음 (attribute 로 충분, 커스텀 변형 여지 열어둠).
+
+### 9.7 label
+
+- `<Label>` 은 `role="presentation"` (메뉴 구조에서 제외). 스크린리더는 `<menu>` 의 `aria-label` 로 맥락을 받고 Label 은 시각적 section 구분 역할.
+- 대안: `role="heading" aria-level="3"` — v1 은 presentation (VoiceOver 가 메뉴 항목으로 오해하지 않도록).
+
+---
+
+## 10. 파일 구조
+
+```
+src/components/ContextMenu/
+├── ContextMenu.tsx                    # compound 조립 + namespace
+├── ContextMenu.types.ts               # 공개 타입
+├── ContextMenuRoot.tsx                # Root 상태머신
+├── ContextMenuTrigger.tsx             # contextmenu/long-press/키보드 핸들러
+├── ContextMenuContent.tsx             # 포털 + 포지셔닝 + 디스미스 + 포커스 트랩
+├── ContextMenuItem.tsx                # Item (일반/disabled/danger)
+├── ContextMenuCheckboxItem.tsx        # CheckboxItem
+├── ContextMenuRadioGroup.tsx          # RadioGroup + context
+├── ContextMenuRadioItem.tsx           # RadioItem
+├── ContextMenuSub.tsx                 # Sub (상태만)
+├── ContextMenuSubTrigger.tsx          # SubTrigger (item + haspopup)
+├── ContextMenuSubContent.tsx          # SubContent (anchor 기준 포지셔닝)
+├── ContextMenuSeparator.tsx           # Separator
+├── ContextMenuLabel.tsx               # Label
+├── ContextMenuShortcut.tsx            # Shortcut
+├── ContextMenuContext.ts              # Root/Content/Sub/RadioGroup Context
+├── useMenuNavigation.ts               # activeIndex + arrow/home/end/typeahead (공용)
+├── useMenuDismisser.ts                # pointerdown/escape/blur/scroll/resize (공용)
+├── useLongPress.ts                    # touch long-press (Trigger 전용)
+├── useSafeTriangle.ts                 # pointer-safe triangle (Sub 전용)
+├── portal.ts                          # getPortalNode() 싱글톤
+├── geometry.ts                        # isInsideTriangle, clamp, flip 계산
+├── theme.ts                           # contextMenuPalette
+└── index.ts                           # 배럴
+```
+
+파일 책임:
+
+- **ContextMenu.tsx** — namespace 조립. `export const ContextMenu = { Root, Trigger, Content, ... }`. 구현은 분할 파일들.
+- **ContextMenuRoot.tsx** — open/position state, openMode, Context.Provider 설정. `children` 그대로 렌더 (Trigger/Content 는 자식으로).
+- **ContextMenuTrigger.tsx** — `useTriggerHandlers` 로 이벤트 attach. `asChild` 이면 `cloneElement`, 아니면 `<span>` wrap.
+- **ContextMenuContent.tsx** — 포털 마운트, 포지셔닝 `useLayoutEffect`, `useMenuDismisser`, `useMenuNavigation` 조립, Content Context.Provider.
+- **ContextMenuItem.tsx** — 단일 item. `useMenuItem()` 훅으로 자신의 ref 를 Content Context 에 등록(descriptorsRef 에 push). onClick/키보드는 Content 수준의 `activeIndex` 를 본다.
+- **ContextMenuCheckboxItem.tsx / RadioItem.tsx** — Item 재사용 + prefix slot + aria-checked. controlled state.
+- **ContextMenuSub.tsx** — 독립 open state. Context.Provider.
+- **ContextMenuSubTrigger.tsx** — Item + onMouseEnter → hover-open timer + ArrowRight → open. `useSafeTriangle` 결과를 구독해 hover-leave timer 연장/취소.
+- **ContextMenuSubContent.tsx** — 포털 마운트 + anchor 기준 포지셔닝. 자체 `useMenuNavigation`. `ArrowLeft` / `Escape` 는 자기만 close.
+- **portal.ts** — `document.body` 에 `[data-plastic-portal="context-menu"]` 노드 한 번만 생성. HMR/언마운트 고려해 reference count. Popover portal 과 **분리**.
+- **geometry.ts** — `clampToViewport`, `flipHorizontal`, `flipVertical`, `isInsideTriangle`. 순수 함수.
+- **theme.ts** — palette. CSS 변수 문자열 생성기 `buildThemeVars(theme)`.
+- **useMenuNavigation.ts** — focusable 배열 구축(`descriptorsRef` + MutationObserver 대신 `useSyncExternalStore`/re-register 패턴), activeIndex 관리, `onKeyDown` (Arrow/Home/End/Enter/Space/typeahead) 반환. **ContextMenu 와 DropdownMenu 가 공유**(§16).
+- **useMenuDismisser.ts** — document-level 리스너 attach/cleanup. 공유.
+- **useLongPress.ts** — touch timer + tolerance. Trigger 전용이지만 장차 재사용 가능.
+- **useSafeTriangle.ts** — Sub 전용이지만 로직 자체는 순수. `geometry.ts` 의 `isInsideTriangle` 에 얹은 ref state-machine.
+
+### 10.1 공용 레이어 (DropdownMenu 와의 공유)
+
+v1 본 PR 에서는 ContextMenu 디렉터리 내부에 모든 파일을 둔다. DropdownMenu 도입(§17) 시점에 아래와 같이 `_menu/` 공용 디렉터리로 추출할 것:
+
+```
+src/components/_menu/            # 장래
+├── useMenuNavigation.ts
+├── useMenuDismisser.ts
+├── useSafeTriangle.ts
+├── portal.ts
+├── geometry.ts
+├── theme.ts
+├── Item.tsx, CheckboxItem.tsx, RadioGroup.tsx, RadioItem.tsx,
+│   Sub.tsx, SubTrigger.tsx, SubContent.tsx, Separator.tsx,
+│   Label.tsx, Shortcut.tsx     # 공용 subcomponent
+```
+
+v1 당시 추출하지 않는 이유는, 공용 레이어의 shape 는 두 번째 consumer (DropdownMenu) 가 존재할 때에야 정확히 판단 가능하기 때문(premature abstraction 회피). 대신 본 PR 에서 파일 분할을 "공용화 가능" 단위로 미리 끊어두어 추후 단순 이동만으로 추출되게 한다.
+
+---
+
+## 11. 구현 단계 (후속 agent 가 순차 실행)
+
+각 단계 독립 커밋 권장. 각 커밋이 `npm run typecheck` + `npx tsup` 통과.
+
+### Step 1 — 타입 + 배럴 + 테마 스켈레톤
+1. `ContextMenu.types.ts` 전부 작성 (§2.1).
+2. `theme.ts` — palette.
+3. `geometry.ts` — `clamp`, `isInsideTriangle`, 좌표/직사각형 헬퍼.
+4. `portal.ts` — singleton portal node.
+5. `index.ts` 배럴.
+6. `ContextMenu.tsx` placeholder namespace.
+7. `src/components/index.ts` 에 추가.
+8. 커밋: `feat(ContextMenu): 타입 + 테마 + 배럴`.
+
+### Step 2 — Root + Trigger (열고 닫기만, Content 비어있음)
+1. `ContextMenuContext.ts`, `ContextMenuRoot.tsx`.
+2. `ContextMenuTrigger.tsx` — `contextmenu` 이벤트 처리(long-press/키보드는 나중). `asChild` 지원.
+3. `ContextMenuContent.tsx` — 포털 + 고정 position (좌표 flip 은 없음). 단순 `<div role="menu">` 에 children.
+4. dev-only smoke 테스트 페이지에서 "우클릭하면 박스 뜸" 확인.
+5. 커밋: `feat(ContextMenu): Root/Trigger/Content 기본 오픈`.
+
+### Step 3 — 포지셔닝 (viewport flip/shift + max-height)
+1. `useLayoutEffect` 에서 rect 측정 + §4.2 알고리즘.
+2. `opacity: 0 → 1` FOUC 방지.
+3. 커밋: `feat(ContextMenu): viewport 기반 포지셔닝`.
+
+### Step 4 — 디스미스 (외부 클릭/Escape/scroll/resize/blur)
+1. `useMenuDismisser.ts`.
+2. Content 에서 구독.
+3. 커밋: `feat(ContextMenu): dismiss 리스너`.
+
+### Step 5 — Item + Separator + Label + Shortcut
+1. 각 컴포넌트 구현.
+2. `useMenuItem()` 훅으로 descriptorsRef 등록.
+3. onClick → `selectItem`.
+4. 시각 스타일(palette 연결).
+5. 커밋: `feat(ContextMenu): Item/Separator/Label/Shortcut`.
+
+### Step 6 — 키보드 네비게이션 + typeahead + 포커스 트랩
+1. `useMenuNavigation.ts`.
+2. `ArrowUp/Down/Home/End`, `Enter/Space`, `Escape`, `Tab` preventDefault, typeahead 200 ms.
+3. `openMode` 분기 (포인터 vs 키보드 첫 포커스).
+4. activeIndex 변경 시 item DOM focus + `scrollIntoView({ block: "nearest" })`.
+5. 커밋: `feat(ContextMenu): 키보드 네비 + typeahead + 포커스 트랩`.
+
+### Step 7 — disabled + danger
+1. `ContextMenuItem` `disabled` prop 반영 (aria-disabled, skip from focusable).
+2. `data-danger` 시각 분기.
+3. 커밋: `feat(ContextMenu): disabled + danger`.
+
+### Step 8 — CheckboxItem / RadioGroup / RadioItem
+1. prefix slot (✓ / ●), aria-checked.
+2. RadioGroup Context.
+3. controlled/uncontrolled.
+4. 커밋: `feat(ContextMenu): checkbox + radio`.
+
+### Step 9 — Sub / SubTrigger / SubContent + safe triangle
+1. `ContextMenuSub` state + Context.
+2. `SubTrigger` hover-open 150 ms + `ArrowRight` open.
+3. `SubContent` anchor 기준 포지셔닝 (§4.3).
+4. `useSafeTriangle` — hover-leave 시 대각 이동 감지.
+5. `ArrowLeft` / `Escape` 로 서브 close.
+6. 다중 depth 테스트 (3 depth).
+7. 커밋: `feat(ContextMenu): submenu + safe triangle`.
+
+### Step 10 — long-press (touch) + 키보드 오픈(Shift+F10, Menu 키)
+1. `useLongPress.ts`.
+2. Trigger 에 touchstart/move/end/cancel 핸들러.
+3. `onKeyDown` 에서 Shift+F10 / ContextMenu 키 처리.
+4. 터치 디바이스(Chrome DevTools device mode) 검증.
+5. 커밋: `feat(ContextMenu): touch long-press + keyboard open`.
+
+### Step 11 — controlled API + 프로그래매틱 오픈 + dev warn
+1. `open`/`position` controlled 지원.
+2. dev warn (controlled open=true 인데 position 없음, Trigger 없음 등).
+3. 커밋: `feat(ContextMenu): controlled API`.
+
+### Step 12 — Dark 테마
+1. `contextMenuPalette.dark` 통합.
+2. `Content theme="dark"` 전파.
+3. 커밋: `feat(ContextMenu): dark 테마`.
+
+### Step 13 — 데모 페이지
+1. `demo/src/pages/ContextMenuPage.tsx` (§12).
+2. `demo/src/App.tsx` NAV 추가.
+3. 커밋: `feat(ContextMenu): 데모 페이지`.
+
+### Step 14 — 마감
+1. Props 표 + Usage 4 예시.
+2. §20 DoD 전부 체크.
+3. 커밋: `feat(ContextMenu): 데모 props 표 + usage`.
+
+---
+
+## 12. 데모 페이지
+
+`demo/src/pages/ContextMenuPage.tsx`. 기존 페이지(CommandPalettePage, HexViewPage) 구조 복제. 섹션별 `<section id="...">` + 우측 사이드바 nav 연동.
+
+### 12.1 NAV 추가 (App.tsx)
+
+```ts
+{ id: "contextmenu", label: "ContextMenu", description: "우클릭 맥락 메뉴", sections: [
+  { label: "Basic",                id: "basic" },
+  { label: "Submenu",              id: "submenu" },
+  { label: "Checkbox items",       id: "checkbox" },
+  { label: "Radio group",          id: "radio" },
+  { label: "Shortcuts",            id: "shortcuts" },
+  { label: "Disabled / Danger",    id: "disabled" },
+  { label: "Long-press (touch)",   id: "longpress" },
+  { label: "Dark",                 id: "dark" },
+  { label: "Programmatic open",    id: "programmatic" },
+  { label: "Playground",           id: "playground" },
+  { label: "Props",                id: "props" },
+  { label: "Usage",                id: "usage" },
+]},
+```
+
+`Page` 타입에 `"contextmenu"` 추가 + 하단 `{current === "contextmenu" && <ContextMenuPage />}`.
+
+### 12.2 섹션 구성
+
+**Basic**
+```tsx
+<ContextMenu.Root>
+  <ContextMenu.Trigger asChild>
+    <div className="w-80 h-32 border rounded grid place-items-center select-none">
+      Right-click me
+    </div>
+  </ContextMenu.Trigger>
+  <ContextMenu.Content>
+    <ContextMenu.Item onSelect={() => alert("Open")}>Open</ContextMenu.Item>
+    <ContextMenu.Item onSelect={() => alert("Rename")}>Rename</ContextMenu.Item>
+    <ContextMenu.Separator />
+    <ContextMenu.Item onSelect={() => alert("Delete")} data-danger>
+      Delete
+    </ContextMenu.Item>
+  </ContextMenu.Content>
+</ContextMenu.Root>
+```
+
+**Submenu** — 2 depth 예시.
+```tsx
+<ContextMenu.Root>
+  <ContextMenu.Trigger asChild><Box>Right-click</Box></ContextMenu.Trigger>
+  <ContextMenu.Content>
+    <ContextMenu.Item>Open</ContextMenu.Item>
+    <ContextMenu.Sub>
+      <ContextMenu.SubTrigger>Copy as…</ContextMenu.SubTrigger>
+      <ContextMenu.SubContent>
+        <ContextMenu.Item>Path</ContextMenu.Item>
+        <ContextMenu.Item>Relative path</ContextMenu.Item>
+        <ContextMenu.Sub>
+          <ContextMenu.SubTrigger>Content…</ContextMenu.SubTrigger>
+          <ContextMenu.SubContent>
+            <ContextMenu.Item>As plain text</ContextMenu.Item>
+            <ContextMenu.Item>As markdown</ContextMenu.Item>
+          </ContextMenu.SubContent>
+        </ContextMenu.Sub>
+      </ContextMenu.SubContent>
+    </ContextMenu.Sub>
+  </ContextMenu.Content>
+</ContextMenu.Root>
+```
+
+**Checkbox items**
+```tsx
+const [wordWrap, setWordWrap] = useState(true);
+const [minimap, setMinimap] = useState(false);
+<ContextMenu.Content>
+  <ContextMenu.CheckboxItem checked={wordWrap} onCheckedChange={setWordWrap}>
+    Word Wrap
+  </ContextMenu.CheckboxItem>
+  <ContextMenu.CheckboxItem checked={minimap} onCheckedChange={setMinimap}>
+    Minimap
+  </ContextMenu.CheckboxItem>
+</ContextMenu.Content>
+```
+
+**Radio group**
+```tsx
+const [theme, setTheme] = useState("system");
+<ContextMenu.Content>
+  <ContextMenu.Label>Appearance</ContextMenu.Label>
+  <ContextMenu.RadioGroup value={theme} onValueChange={setTheme}>
+    <ContextMenu.RadioItem value="light">Light</ContextMenu.RadioItem>
+    <ContextMenu.RadioItem value="dark">Dark</ContextMenu.RadioItem>
+    <ContextMenu.RadioItem value="system">System</ContextMenu.RadioItem>
+  </ContextMenu.RadioGroup>
+</ContextMenu.Content>
+```
+
+**Shortcuts**
+```tsx
+<ContextMenu.Content>
+  <ContextMenu.Item>Cut <ContextMenu.Shortcut>⌘X</ContextMenu.Shortcut></ContextMenu.Item>
+  <ContextMenu.Item>Copy <ContextMenu.Shortcut>⌘C</ContextMenu.Shortcut></ContextMenu.Item>
+  <ContextMenu.Item>Paste <ContextMenu.Shortcut>⌘V</ContextMenu.Shortcut></ContextMenu.Item>
+  <ContextMenu.Separator />
+  <ContextMenu.Item>Select All <ContextMenu.Shortcut>⌘A</ContextMenu.Shortcut></ContextMenu.Item>
+</ContextMenu.Content>
+```
+
+**Disabled / Danger**
+```tsx
+<ContextMenu.Content>
+  <ContextMenu.Item>Open</ContextMenu.Item>
+  <ContextMenu.Item disabled>Move to… (disabled)</ContextMenu.Item>
+  <ContextMenu.Separator />
+  <ContextMenu.Item data-danger>Delete</ContextMenu.Item>
+</ContextMenu.Content>
+```
+
+**Long-press (touch)** — 설명 문구 + "이 박스를 550 ms 누르고 있으세요". Chrome DevTools device mode 를 열어 터치로 확인.
+
+**Dark**
+```tsx
+<div style={{ background: "#0f172a", padding: 24, borderRadius: 8 }}>
+  <ContextMenu.Root>
+    <ContextMenu.Trigger asChild>
+      <div className="w-80 h-32 border border-slate-700 rounded grid place-items-center text-slate-200">
+        Right-click (dark)
+      </div>
+    </ContextMenu.Trigger>
+    <ContextMenu.Content theme="dark">
+      <ContextMenu.Item>Open</ContextMenu.Item>
+      <ContextMenu.Item>Rename</ContextMenu.Item>
+      <ContextMenu.Separator />
+      <ContextMenu.Item data-danger>Delete</ContextMenu.Item>
+    </ContextMenu.Content>
+  </ContextMenu.Root>
+</div>
+```
+
+**Programmatic open**
+```tsx
+const [open, setOpen] = useState(false);
+const [pos, setPos] = useState({x: 200, y: 200});
+return (
+  <div className="flex gap-2">
+    <button onClick={(e) => { setPos({x: e.clientX, y: e.clientY}); setOpen(true); }}>
+      Open at cursor
+    </button>
+    <button onClick={() => { setPos({x: 40, y: 40}); setOpen(true); }}>
+      Open at (40, 40)
+    </button>
+    <ContextMenu.Root open={open} onOpenChange={setOpen} position={pos}>
+      <ContextMenu.Trigger asChild><span /></ContextMenu.Trigger>
+      <ContextMenu.Content>
+        <ContextMenu.Item>Item A</ContextMenu.Item>
+        <ContextMenu.Item>Item B</ContextMenu.Item>
+      </ContextMenu.Content>
+    </ContextMenu.Root>
+  </div>
+);
+```
+
+**Playground** — 상단 컨트롤 바:
+- `theme` 토글 (light / dark)
+- `disabled` 체크박스 (Root 레벨)
+- `longPressMs` slider (0~2000)
+- `minWidth` / `maxWidth` number input
+- `danger flag` 체크박스 (마지막 아이템 danger 여부)
+- "Add 20 items" / "Reset" 버튼 (긴 메뉴 테스트)
+- submenu on/off 토글
+
+아래에 큰 Trigger 박스 + 현재 설정을 반영한 `ContextMenu.Content`.
+
+**Props 표** — `Root` / `Trigger` / `Content` / `Item` / `CheckboxItem` / `RadioGroup` / `RadioItem` / `Sub` / `SubTrigger` / `SubContent` / `Separator` / `Label` / `Shortcut` 각각 prop × 타입 × 기본값 × 설명.
+
+**Usage (4개)**
+1. 파일 매니저: open/rename/delete + 2 depth Copy as 서브메뉴.
+2. 에디터: checkbox (word wrap, minimap) + radio (theme).
+3. 테이블 셀 우클릭: dynamic items (선택된 셀 수에 따라 Copy/Paste 활성화 변경).
+4. 프로그래매틱: 외부 버튼으로 특정 좌표에 열기.
+
+**샘플 코드 — 파일 매니저**:
+```tsx
+function FileItem({ file }: { file: FileNode }) {
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger asChild>
+        <div className="file-row">{file.name}</div>
+      </ContextMenu.Trigger>
+      <ContextMenu.Content>
+        <ContextMenu.Label>{file.name}</ContextMenu.Label>
+        <ContextMenu.Separator />
+        <ContextMenu.Item onSelect={() => open(file)}>
+          Open <ContextMenu.Shortcut>Enter</ContextMenu.Shortcut>
+        </ContextMenu.Item>
+        <ContextMenu.Item onSelect={() => rename(file)}>
+          Rename <ContextMenu.Shortcut>F2</ContextMenu.Shortcut>
+        </ContextMenu.Item>
+        <ContextMenu.Sub>
+          <ContextMenu.SubTrigger>Copy as…</ContextMenu.SubTrigger>
+          <ContextMenu.SubContent>
+            <ContextMenu.Item onSelect={() => copyPath(file, "abs")}>Absolute path</ContextMenu.Item>
+            <ContextMenu.Item onSelect={() => copyPath(file, "rel")}>Relative path</ContextMenu.Item>
+            <ContextMenu.Item onSelect={() => copyPath(file, "url")}>URL</ContextMenu.Item>
+          </ContextMenu.SubContent>
+        </ContextMenu.Sub>
+        <ContextMenu.Separator />
+        <ContextMenu.Item disabled>Move to…</ContextMenu.Item>
+        <ContextMenu.Item onSelect={() => trash(file)} data-danger>
+          Delete <ContextMenu.Shortcut>⌫</ContextMenu.Shortcut>
+        </ContextMenu.Item>
+      </ContextMenu.Content>
+    </ContextMenu.Root>
+  );
+}
+```
+
+---
+
+## 13. 검증 계획
+
+### 13.1 자동화
+```bash
+cd /Users/neo/workspace/plastic
+npm run typecheck
+npx tsup
+```
+
+주의:
+- `exactOptionalPropertyTypes: true` — optional prop 은 `?:` + default merge 분기 시 `undefined` 가능성 주의.
+- `noUncheckedIndexedAccess: true` — `React.Children.toArray()[i]` 는 `ReactNode | undefined`. descriptor array indexing 시 가드 필수.
+- `verbatimModuleSyntax: true` — 타입 import 는 `import type`.
+
+### 13.2 수동 (demo dev server)
+```bash
+cd demo && npm run dev
+```
+
+체크리스트:
+- [ ] Basic: 박스 위 우클릭 → 메뉴 오픈, 좌측 상단 기준 포인터 좌표. 외부 클릭/Escape 로 닫힘.
+- [ ] 포인터 우측/하단 경계: 박스를 viewport 우하단에 배치 → 메뉴가 좌/상으로 flip.
+- [ ] 극단 케이스: 박스가 viewport 경계에서 20 px → 메뉴가 경계 PAD=8 안에 정렬.
+- [ ] 긴 메뉴: 40 개 Item 렌더 → 내부 스크롤, 키보드 ArrowDown 누를 때 스크롤 따라감.
+- [ ] Submenu: `Copy as…` hover → 150 ms 후 오픈. `Copy as…` 에서 서브메뉴 아이템으로 "대각선" 이동 시 중간 형제 위를 스쳐도 부모가 닫히지 않음(safe triangle).
+- [ ] Submenu 3 depth: 정상 오픈/닫기.
+- [ ] 서브메뉴 우측 overflow: 부모 메뉴가 이미 우측 경계 근처면 서브가 좌측으로 flip.
+- [ ] Checkbox: 클릭 → 토글 + 메뉴 닫힘. controlled 외부 state 도 동기화.
+- [ ] Radio: 선택 → value 변경 + 닫힘. 같은 값 재선택도 동일.
+- [ ] Shortcuts: 라벨 우측 정렬. tabular-nums 로 수직 정렬.
+- [ ] Disabled: 포인터 hover 시 highlight 없음, 클릭 무효, ArrowDown 건너뜀.
+- [ ] Danger: 색상 다름, 나머지 동작 일반 item 과 동일.
+- [ ] Long-press: Chrome DevTools device mode 에서 터치로 550 ms → 메뉴 뜸. 8 px 이상 이동 시 취소.
+- [ ] 키보드 오픈: Trigger 박스 tabindex=0 지정 후 포커스 → `Shift+F10` / `ContextMenu` 키 → 박스 좌하단에 메뉴 오픈, `activeIndex=0` 즉시 highlight.
+- [ ] 키보드 네비: ArrowUp/Down wrap, Home/End, Enter/Space 선택, Escape 닫힘.
+- [ ] Typeahead: "c" → "Copy as…" 로 이동. "co" → 동일. 200 ms 후 리셋.
+- [ ] Tab: 메뉴 안에서 Tab 눌러도 포커스가 메뉴 밖으로 이탈하지 않음.
+- [ ] 외부 dismiss: pointerdown / Escape / window blur / 페이지 스크롤 / resize 모두 닫힘.
+- [ ] Dark 테마: 색상 전환, contrast 확보.
+- [ ] Programmatic: 외부 버튼에서 setOpen + position 으로 오픈, onOpenChange 콜백 수신.
+- [ ] 다른 페이지 리그레션 없음 (CommandPalette/Popover/DataTable 정상 동작).
+
+### 13.3 엣지 케이스
+- [ ] **viewport 4 모서리**: 박스를 4 corners (top-left, top-right, bottom-left, bottom-right) 에 배치하고 각각 우클릭 — 메뉴가 보이는 영역 안에 완전히 표시.
+- [ ] **메뉴 > viewport**: 60 개 item 을 넣고 우클릭 → 내부 스크롤, top=PAD.
+- [ ] **중첩 Trigger**: `<Root A><Trigger A><div><Root B><Trigger B><div /></Trigger></Root></div></Trigger></Root>` 형태. 내부 div 위에서 우클릭 → B 만 열림(stopPropagation).
+- [ ] **disabled Root**: `<Root disabled>` → 우클릭 시 OS 기본 메뉴가 뜸(커스텀 안 뜸).
+- [ ] **controlled open=true with no position**: dev warn + {x:0,y:0} fallback.
+- [ ] **touchstart → touchmove(10px) → 550ms 경과**: 메뉴 뜨지 않음.
+- [ ] **모바일 OS 기본 long-press selection 방해**: `touch-action: none` / `user-select: none` 으로 Trigger 의 텍스트 선택이 안 일어남.
+- [ ] **iframe 내부 Trigger**: 메뉴가 iframe 내부에만 렌더(포털이 iframe document.body 에). 좌표 정상. (iframe 바깥으로 퍼지는 건 v1 제외.)
+- [ ] **portal 재사용**: 여러 Root 인스턴스 공존 시 같은 portal 노드를 공유, 언마운트 시 ref count 가 0 이 되면 portal 제거.
+- [ ] **hot-reload (Vite HMR)**: portal 노드 중복 생성 방지.
+- [ ] **SSR / 초기 렌더**: `typeof window === "undefined"` 가드 — portal 생성 useEffect 에서만 시도.
+- [ ] **drag 중 우클릭**: 드래그 중(pointerdown 유지)인 상태에서 contextmenu 이벤트는 자연스럽게 억제되는 브라우저 동작에 의존. 예외 시 콘솔 경고 없이 무시.
+- [ ] **RadioGroup value 변경 속도**: 빠르게 여러 번 radio 클릭 → 각 클릭마다 onValueChange 호출, 마지막이 최종 상태.
+- [ ] **submenu 가 부모와 다른 theme**: v1 은 부모 theme 을 상속(SubContent theme prop 있으면 override). 시각 일관성.
+- [ ] **매우 낮은 viewport (vh < 200)**: 메뉴 max-height 잘림, 정상 스크롤.
+
+---
+
+## 14. 성능
+
+### 14.1 목표
+- 오픈 시 첫 페인트 < 16 ms (60 fps 프레임 안에 완료).
+- 언마운트 시 < 4 ms.
+- 60 Hz 포인터 이동 중 activeIndex 갱신 드롭프레임 없음.
+
+### 14.2 병목 가설 + 완화
+1. **포털 재생성 비용**: Root 가 여러 개 있으면 각각 portal 노드 생성할 경우 DOM thrash. 완화: `getPortalNode()` 싱글톤 + ref count (`incRef()/decRef()`).
+2. **descriptorsRef 재구축**: children 이 변할 때마다 descriptor 배열을 재구축. React key 가 안정적이면 대부분 캐시 히트. 완화: 각 Item 의 `useLayoutEffect` 내에서 자신의 index 를 등록/해제하는 방식(mount/unmount 기준).
+3. **mousemove 빈도(safe triangle)**: Content 전역 onMouseMoveCapture 는 SubContent 가 열려있을 때만 active. 닫혀있으면 리스너 attach 안 함.
+4. **Context value 매 렌더**: Root 의 Context value 는 `useMemo` + dispatch-style (setOpen 은 ref 기반) 로 재사용. Content 의 activeIndex Context 는 별도 Provider 이므로 Root 리렌더가 Item 까지 내려가지 않도록 분리.
+5. **포지셔닝 `getBoundingClientRect` 연속 호출**: useLayoutEffect 한 번만. ResizeObserver 는 연결하지 않음(스크롤/resize 가 오면 닫기 정책이므로 재계산 불필요).
+
+### 14.3 측정 방법
+- DevTools Performance 탭: 우클릭 1 회 기록 → paint 마커 확인.
+- 1000 item 스트레스 테스트: 자체 성능 경고 트리거하는 dev 모드 `console.warn` 을 Content 가 마운트 시 descriptor 수 > 500 이면 1 회 출력.
+
+---
+
+## 15. 접근성
+
+### 15.1 역할
+
+- Content root: `role="menu"`, `aria-label` (기본 "Context menu", 사용자 override 가능), `tabindex="-1"`.
+- SubContent: `role="menu"` + `aria-labelledby="{subTrigger id}"`.
+- Item: `role="menuitem"`, `tabindex="-1"` (실제 포커스는 JS 로 이동), `aria-disabled="true"` 시 `tabindex` 제거.
+- CheckboxItem: `role="menuitemcheckbox"` + `aria-checked`.
+- RadioItem: `role="menuitemradio"` + `aria-checked`.
+- RadioGroup wrapper: `role="group"` + 선택적 `aria-label`.
+- SubTrigger: `role="menuitem"` + `aria-haspopup="menu"` + `aria-expanded={subOpen}`.
+- Separator: `role="separator"` + `aria-orientation="horizontal"`.
+- Label: `role="presentation"` (의미 없이 시각 구분). 대안: `aria-label` 을 Content 로 올리고 Label 은 presentation 유지 — 현재 방식.
+- Shortcut: `role="presentation"` + `aria-hidden="true"` (스크린리더가 "⌘O" 같은 문자열을 메뉴명 뒤에 엉뚱하게 읽지 않도록). 대신 `textValue` 에 shortcut 설명을 포함하는 건 사용자 책임.
+
+### 15.2 포커스 관리
+
+- Content 오픈 → 직전 `document.activeElement` 저장.
+- `openMode==="keyboard"` → activeIndex=0 item.focus().
+- `openMode==="pointer"` → 포커스 이동 안함 (activeIndex=-1). 단 Content root 자체는 `tabindex=-1` 이므로 screen reader 는 메뉴 라벨 announce.
+- Content 닫힘 → 저장된 이전 요소로 `focus()` 복원.
+- 서브메뉴 오픈 → 부모의 activeIndex 는 SubTrigger 에 유지, 포커스는 SubContent 의 첫 item. 닫힘 시 SubTrigger 로 복귀.
+
+### 15.3 라이브 리전 (불필요)
+
+메뉴 상호작용은 focus 기반이므로 별도 `aria-live` 불필요.
+
+### 15.4 터치 스크린 리더 (TalkBack/VoiceOver Touch)
+
+- long-press 는 TalkBack/VoiceOver 의 제스처와 충돌 가능. 대부분 SR 은 double-tap-and-hold 가 long-press 를 emit 하므로 기본 동작 유지. 추가 핸들링 없음.
+
+### 15.5 대비
+
+- Light: text fg vs bg ≥ 7:1 (Gray 900 on white).
+- Dark: Gray 200 on #1f2937 ≈ 11:1.
+- disabled: contrast 최소 3:1 확보(`rgba(0,0,0,0.35)` = 4.5:1 대략).
+
+---
+
+## 16. 알려진 트레이드오프 · 결정
+
+1. **DropdownMenu 와 공유 vs 분리**:
+   - ContextMenu 와 DropdownMenu 의 내부 90% 는 동일(아이템 렌더, 키보드 네비, 서브메뉴, 디스미스). 차이는 "어떻게 여는가" 뿐.
+   - 선택지 A: 처음부터 `_menu/` 공용 레이어로 분리하고 두 컴포넌트를 얇은 래퍼로 만든다.
+   - 선택지 B (본 설계): v1 은 ContextMenu 단독으로 먼저 완성. 파일 분할은 공용 가능한 단위로 미리 끊어두고, DropdownMenu 도입 시 `_menu/` 로 **이동**만 한다.
+   - A 는 depth-first 완전함, B 는 YAGNI/premature abstraction 회피. DropdownMenu 의 독자 요구(예: anchor element rect 계산, placement prop)가 Content 포지셔닝 API 를 어떻게 틀어놓을지 v1 단계에선 정확히 예측 어려우므로 B 선택.
+2. **safe triangle 난이도**:
+   - 순수 기하는 단순(삼각형 내부 판정 3줄). 어려운 부분은 "언제 `P0` 을 갱신하나" (hover-leave 순간 한 번만), "timer 리셋 규칙" (in-triangle 이동 감지 시 단발성 extend), "3 depth 이상의 chained submenu" 에서 각 Sub 의 safe triangle 이 독립적으로 동작하도록 state 분리.
+   - v1 은 Sub 당 하나의 safe-triangle 세션만 유지(동시 여러 Sub 의 hover-leave 가 겹치는 경우 drop). 대부분 메뉴 트리에서 발생하지 않음.
+3. **포지셔닝 라이브러리 미사용 (Floating UI 등)**:
+   - Floating UI 를 쓰면 collision 로직이 세밀하지만 ~10 KB 추가. 본 케이스는 "포인터 좌표 flip" 이라는 단순 수식이면 충분.
+   - v1 자체 구현. 복잡 요구(예: shift+arrow+flip+virtual padding) 생기면 후속에서 Floating UI 고려.
+4. **portal 싱글톤 vs Root 별 개별**:
+   - 싱글톤은 DOM 하나만 유지, z-index 충돌 단일 지점에서 관리. 단 cleanup 복잡(ref count).
+   - 개별은 단순하나 페이지 당 Root 수만큼 `<div>` 가 body 하위에 깔린다.
+   - v1 싱글톤. ref count 구현은 ~20 lines.
+5. **아이템에 별도 icon prop 없음**:
+   - `icon?: ReactNode` 는 가독성 좋지만 "shortcut 과 icon 을 각각 fixed slot" 으로 강제하면 커스터마이즈 감소. children 자유 + `Shortcut` 만 전용 컴포넌트로.
+6. **Label 의 role=presentation vs heading**:
+   - heading 은 스크린리더가 H3 로 읽어 section 구조를 선언. presentation 은 시각 label 로만 기능.
+   - v1 은 presentation — 메뉴는 선형 구조가 맞고, heading 은 과도.
+7. **typeahead prefix vs substring**:
+   - prefix (startsWith) 선택. 일반 OS 메뉴 관례.
+   - substring 은 검색 필드 메탈 모델이 강해 ContextMenu 본질(빠른 행동 선택)과 어긋남.
+8. **controlled open 에서 Trigger 의미**:
+   - 프로그래매틱 오픈 유스케이스에서 Trigger 는 사실상 no-op. compound 구조를 지키기 위해 현재는 필수.
+   - 대안: `<ContextMenu.Root>` 안에 Trigger 없어도 허용 + position 만으로 열기. v1.1 리팩터링.
+9. **Shortcut 의 실제 키 바인딩**:
+   - 컴포넌트 책임 범위 밖. 앱 전역 keyboard handler 와 중복 구현을 피하기 위해 v1 은 표시만.
+   - 단축키 바인딩 + 메뉴 표시 동기화가 필요한 상위 앱은 자체 mapping 테이블 유지.
+10. **"우클릭 허용 Trigger" 영역의 시각 피드백**:
+    - 일부 디자인 시스템은 Trigger 위에서 마우스 hover 시 우클릭 가능 hint(커서 변경 등) 를 준다.
+    - plastic v1 은 일반 커서 유지. 사용자 측 CSS 로 자유롭게.
+
+---
+
+## 17. 후속 작업 (v1.1+)
+
+- **DropdownMenu export**: `_menu/` 공용 레이어로 리팩터링 후 `src/components/DropdownMenu/` 를 얇은 래퍼로 구성하여 공개. 차이: `Trigger` 가 `<button>` 으로 변환, placement(start/center/end × above/below) 추가, anchor element rect 기반 포지셔닝.
+- **MenuBar**: 상단 고정 메뉴 바(`File Edit View`). roving tabindex, 좌우 arrow 로 top-level 이동, 아래 arrow 로 드롭, 각 드롭이 DropdownMenu 재사용.
+- **iframe 교차 좌표**: contextmenu 가 iframe 내부에서 발생 + 메뉴를 부모 문서에 띄우고 싶을 때 postMessage + 좌표 변환.
+- **custom position API**: `position: { x, y } | "pointer"` + `align: "start" | "end"` + `offset: [x, y]`.
+- **shortcut prop 포맷터**: `shortcut="Mod+S"` → OS 감지(Mac: ⌘S, Others: Ctrl+S) 자동 포맷. `kbd` 요소 렌더.
+- **virtualized items**: 100+ 아이템에서 내부 스크롤만 있는 v1 은 충분하나, 500+ 에서 가상화 도입.
+- **theme override API**: `contextMenuPalette` 를 runtime 에 커스텀 토큰으로 덮어쓰는 PlasticProvider 레벨 API.
+- **keyboard key ContextMenu 미지원 키보드**: Menu 키 없는 키보드 대안(`Shift+F10` 만 통용).
+- **실제 short-key 바인딩 helper**: `useMenuShortcuts({ "Mod+C": copy })` 로 trigger 외부 전역 키 리스너 제공(옵션).
+- **press-drag-release 선택**: macOS 네이티브 스타일(드래그 중 release 로 선택).
+- **CommandPalette 와 통합**: 메뉴 아이템이 많을 때 검색을 시작하면 CommandPalette 로 전환.
+- **animation preset**: fade/scale enter/exit (80 ms). 현재는 순간 표시.
+
+---
+
+## 18. 관련 파일 인벤토리 (구현 시 참조)
+
+| 용도 | 경로 |
+|---|---|
+| portal + 포지셔닝 prior art | `/Users/neo/workspace/plastic/src/components/Popover/` |
+| 키보드 네비 / roving index / typeahead prior art | `/Users/neo/workspace/plastic/src/components/CommandPalette/` |
+| controlled/uncontrolled dual API | `/Users/neo/workspace/plastic/src/components/_shared/useControllable.ts` |
+| 배럴 등록 | `/Users/neo/workspace/plastic/src/components/index.ts` |
+| 데모 App 라우팅 / NAV | `/Users/neo/workspace/plastic/demo/src/App.tsx` |
+| 데모 페이지 레이아웃 관례 | `/Users/neo/workspace/plastic/demo/src/pages/CommandPalettePage.tsx` |
+| tsconfig 제약 | `/Users/neo/workspace/plastic/tsconfig.json` |
+
+Popover 로부터 얻을 레슨:
+- `position: fixed` + `getBoundingClientRect` + `useLayoutEffect` 순서.
+- portal 싱글톤 node 생성 패턴.
+- Escape/outside-click cleanup 의 시점 일관성.
+
+CommandPalette 로부터 얻을 레슨:
+- activeIndex + ArrowUp/Down + typeahead 의 간결한 구현.
+- `useEvent` (ref-backed stable callback) 패턴.
+- `Enter/Space` 활성 시 preventDefault → close → 선택 콜백 순서.
+
+---
+
+## 19. 의존성 영향
+
+신규 런타임 의존 없음. React 18.3 (기존) + DOM API (`createPortal`, `PointerEvent`, `TouchEvent`, `getBoundingClientRect`, `document`, `navigator.vibrate` (optional)) 만 사용.
+
+번들 영향:
+- ContextMenu 자체 예상 크기: ~5.5 KB (min), ~2 KB (min+gzip). 공용 레이어가 장차 DropdownMenu 에도 쓰이면 1 인당 비용은 낮아짐.
+- plastic 전체 dist 에 미치는 영향 경미.
+
+Browser 지원:
+- `createPortal`: React 16+.
+- `PointerEvent`: 모던 브라우저 전체.
+- `TouchEvent`: iOS Safari/Android Chrome.
+- `navigator.vibrate`: Android / 일부 데스크톱. 없으면 조용히 skip.
+- `Shift+F10`, `ContextMenu` key: 키 이름은 `KeyboardEvent.key === "ContextMenu"` (Windows), `e.shiftKey && e.key === "F10"` 둘 다 처리.
+
+---
+
+## 20. 구현 완료 정의 (Definition of Done)
+
+- [ ] `npm run typecheck` 통과.
+- [ ] `npx tsup` 통과 (타입 선언 포함).
+- [ ] demo 에 `/#/contextmenu` 라우트 동작.
+- [ ] §13.2 수동 체크리스트 항목 전부 확인.
+- [ ] §13.3 엣지 케이스 항목 전부 확인 또는 "v1 범위 밖" 사유 명시.
+- [ ] Popover / CommandPalette / DataTable / PipelineGraph / 기타 페이지 리그레션 없음.
+- [ ] `src/components/index.ts` 배럴에 `export * from "./ContextMenu";` 추가됨.
+- [ ] `package.json` dependencies 변경 없음 (신규 의존 없음).
+- [ ] Props 문서 섹션이 13 개 subcomponent (Root/Trigger/Content/Item/CheckboxItem/RadioGroup/RadioItem/Sub/SubTrigger/SubContent/Separator/Label/Shortcut) 별 표로 채워져 있음.
+- [ ] Usage 섹션에 최소 4 개 스니펫 (파일 매니저 / 에디터 / 테이블 셀 / 프로그래매틱).
+- [ ] 데모 Playground 에서 모든 주요 prop 토글 가능.
+- [ ] Light/Dark 테마 전환 시 시각 이상 없음.
+- [ ] 키보드 단독으로 오픈/네비/선택/닫기 전 과정 수행 가능.
+- [ ] 터치(Chrome DevTools device mode) 에서 long-press 오픈 확인.
+- [ ] VoiceOver/NVDA 에서 메뉴 라벨 + menuitem/checkbox/radio 상태 정상 발음.
+- [ ] 1000 아이템 스트레스 케이스에서 dev 경고 1 회 출력 + 렌더/스크롤 이상 없음.
+- [ ] portal 노드 singleton: 여러 Root 공존 시 body 하위 `[data-plastic-portal="context-menu"]` 가 1 개만 존재.
+- [ ] 모든 cleanup 확인 (dismiss 리스너, timers, portal ref count). React StrictMode double-mount 에도 leak 없음.
+
+---
+
+**끝.**

--- a/docs/plans/020-progress-component.md
+++ b/docs/plans/020-progress-component.md
@@ -1,0 +1,1483 @@
+# Progress 컴포넌트 설계문서
+
+## Context
+
+plastic 라이브러리에 "진행 상태(진척도)를 시각화하는 프리미티브" `Progress` 를 추가한다. 역할 비유: VSCode 의 하단 상태바 업로드 진행바, IntelliJ 의 인덱싱 진행, macOS Finder 의 복사 다이얼로그, npm install 의 로딩 바, Chrome 의 탭 로딩 인디케이터. `Progress` 는 "시간이 걸리는 연산의 경과/남음을 가시화" 라는 단일 책임을 가진 **runtime-zero, headless-style** 컴포넌트이며, 선형(linear bar) · 원형(circular SVG) 두 가지 shape 를 하나의 API 로 지원한다.
+
+참고 (prior art — UX·API 근거):
+- **Radix UI `Progress`** — `Root` + `Indicator` compound, `value`/`max` 이중 제어, indeterminate 상태 데이터 속성.
+- **Ant Design `Progress`** — `type="line"|"circle"|"dashboard"`, `status` (success/exception/active), `steps` (segmented stepper bar), `strokeLinecap`, gradient stroke.
+- **MUI `LinearProgress` + `CircularProgress`** — 두 개 분리 API. determinate/indeterminate/buffer 3 가지 variant. indeterminate 키프레임 정의가 표준 레퍼런스.
+- **Chakra UI `Progress`** — striped + animated(`hasStripe` + `isAnimated`) 조합이 plastic 스타일과 유사.
+- **Material Web `md-linear-progress` / `md-circular-progress`** — Web Components 표준. 접근성 속성 기준.
+- **HTML `<progress>` element** — `role="progressbar"` + `aria-valuenow/min/max` 베이스라인.
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/Stepper/` — **유사/경계 컴포넌트**. "단계 기반" 진행은 Stepper 가 담당 (`StepperStep`, `StepperSeparator`, completed/active/pending 상태). Progress 의 `segments` prop 과 역할이 겹치므로 §16 에서 경계 문서화.
+- `src/components/_shared/useControllable.ts` — controlled/uncontrolled 이중 API 표준 훅 (단일 값 버전).
+- `src/components/index.ts` — 컴포넌트 배럴. `export * from "./Progress";` 추가 위치.
+- `demo/src/App.tsx` — NAV 배열 + `Page` 유니온 타입 + 라우팅. `"progress"` 항목 추가 위치.
+- `demo/src/pages/CommandPalettePage.tsx` — 최신 데모 페이지 레이아웃/Props·Usage·Playground 섹션 구조 템플릿.
+- `tsconfig.json` — `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax` 제약.
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+// 1) 기본 Linear determinate
+<Progress value={42} />
+
+// 2) Compound — 라벨·트랙·인디케이터를 직접 배치
+<Progress.Root value={42} max={100} shape="linear" size="md" variant="default">
+  <Progress.Label placement="outside">업로드 중…</Progress.Label>
+  <Progress.Track>
+    <Progress.Indicator />
+    <Progress.Indicator kind="buffer" value={68} />
+  </Progress.Track>
+  <Progress.ValueText />
+</Progress.Root>
+
+// 3) Indeterminate Linear (값 미정)
+<Progress shape="linear" indeterminate />
+
+// 4) Circular determinate (원형)
+<Progress shape="circular" value={72} size="lg" strokeLinecap="round">
+  72%
+</Progress>
+
+// 5) Segmented (단계형 막대)
+<Progress shape="linear" segments={5} value={3} variant="success" />
+
+// 6) Striped + Animated
+<Progress shape="linear" value={60} striped animated />
+```
+
+렌더 결과 (개념):
+```
+Linear determinate 42%
+┌────────────────────────────────────────────────────┐
+│████████████████████                                │
+└────────────────────────────────────────────────────┘
+
+Linear buffer (primary 42%, buffer 68%)
+┌────────────────────────────────────────────────────┐
+│██████████████████████░░░░░░░░░░░░                  │
+└────────────────────────────────────────────────────┘
+ ↑primary (value)       ↑buffer (secondary)
+
+Linear indeterminate (슬라이딩 스트라이프)
+┌────────────────────────────────────────────────────┐
+│        ▓▓▓▓▓▓▓▓▓         ▓▓▓▓▓▓▓▓▓                  │  ← 좌→우 왕복
+└────────────────────────────────────────────────────┘
+
+Linear segmented (5 steps, value=3)
+┌─────┐ ┌─────┐ ┌─────┐ ┌─────┐ ┌─────┐
+│█████│ │█████│ │█████│ │     │ │     │
+└─────┘ └─────┘ └─────┘ └─────┘ └─────┘
+
+Circular determinate 72%
+       ╱─╲
+      ╱   ╲
+     │  72%│   ← SVG stroke-dasharray 로 호 길이 제어
+      ╲___╱
+
+Circular indeterminate
+       ╱─╲         ← 360° 회전
+      ╱▓▓ ╲
+     │     │
+      ╲___╱
+```
+
+핵심 설계 원칙:
+- **compound 컴포넌트**. `Progress.Root / Track / Indicator / Label / ValueText` 다섯 소계. Context 로 상태 공유.
+- **단축 사용**. `<Progress value={n} />` 는 Root + Track + Indicator + (옵션) ValueText 를 자동 조립하는 convenience wrapper. 90% 케이스를 한 줄로.
+- **shape 이원화**. `shape="linear"` (flex 바) | `shape="circular"` (SVG circle + `stroke-dasharray`). DOM/CSS 는 완전히 다르지만 API 는 동일.
+- **determinate / indeterminate / buffer / segmented** 4 가지 mode 가 직교 또는 배타 관계. 조합 규칙을 §3.3 에서 엄격히 정의.
+- **runtime-zero**. 외부 애니메이션 라이브러리 없음. 모든 모션은 CSS keyframes(`@keyframes plastic-progress-*`) 로 선언. React re-render 없이 브라우저가 애니메이트.
+- **controlled/uncontrolled 이중 API**. `value` / `defaultValue` / `onValueChange` (단, Progress 는 비상호작용이므로 `onValueChange` 는 "외부 tick 이 바뀔 때 콜백" 성격이 아닌 내부적 의미 최소 — 주로 controlled 만 쓰인다).
+- **접근성 1등 시민**. `role="progressbar"` + `aria-valuenow/min/max` + `aria-label` 필수, indeterminate 시 `aria-valuenow` 제거, 선택적 `aria-live="polite"` 로 보조공학 announcement.
+- **CSS 변수 테마**. 색상·두께·라운드 반경·애니메이션 duration 을 `--plastic-progress-*` 로 노출하여 사용자가 override 가능.
+- **Stepper 와 경계 분리**. Stepper 는 "UI 라벨/콘텐츠가 붙는 단계 네비게이션", Progress.segments 는 "라벨 없는 순수 시각적 분할 막대". §16.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. **Linear** + **Circular** 두 shape 지원. 동일 prop 표(variant, size, state, label, striped 등)을 공유.
+2. **Determinate** (value 0~max) 정확한 진행 렌더.
+3. **Indeterminate** 상태 — value 미지정 시 혹은 `indeterminate` prop 이 true 일 때. CSS 기반 무한 애니메이션 (Linear: 좌→우 슬라이딩 스트라이프, Circular: 회전 arc).
+4. **Buffer** 보조 게이지 — 1 차(primary) 위에 연한 2 차(buffer) 를 겹쳐 "다운로드된 데이터 vs 재생된 데이터" 유형 표현. Linear 전용(Circular buffer 는 v1 범위 밖).
+5. **Segmented stepper bar** — `segments={n}` 으로 n 개 동일 너비 셀 분할, value 0~n 의 정수 진행. Linear 전용. (단계 **라벨/클릭** 은 Stepper 소관 — 경계 §16.)
+6. **변형 `variant`** : `"default" | "success" | "warning" | "error"`. 트랙/필 색상 팔레트 전환.
+7. **사이즈 `size`** : `"sm" | "md" | "lg"`. Linear 는 track 높이(4/8/12 px), Circular 는 직경(24/40/64 px).
+8. **라벨 placement** : `"inside" | "outside" | "none"`. Linear 의 "inside" 는 필 위에 % 텍스트 오버레이, "outside" 는 트랙 위/아래, Circular 는 중앙 홀에 표시.
+9. **Striped + Animated** 옵션. `striped` (대각선 패턴) + `animated` (스트라이프가 흐르는 애니메이션). Linear 전용.
+10. **Circular 전용 프롭**: `strokeWidth`, `strokeLinecap` ("butt" | "round"), `trackOpacity`.
+11. **controlled/uncontrolled 이중 API**: `value` / `defaultValue`.
+12. **Light / Dark 테마**.
+13. **접근성**: role/aria 완비. indeterminate 시 `aria-valuenow` 제거, `aria-label` 또는 `aria-labelledby` 필수 dev warn.
+14. **runtime-zero**: React + DOM + CSS 만. 외부 의존 0.
+
+### Non-goals (v1 제외)
+- **Circular buffer** (이중 호 겹치기) — 수요 적음, v1.1.
+- **Dashboard gauge** (Ant `type="dashboard"`) — 호의 일부만 그리는 3/4 원. v1.1.
+- **Gradient stroke** — `from`/`to` 두 색을 linearGradient 로 보간하는 채움. v1.1.
+- **사용자 상호작용** (클릭·드래그로 값 변경) — 그건 Slider/ProgressBar Input 의 역할. Progress 는 **표시만**.
+- **Animated number counting** (value 가 바뀔 때 42→75 로 숫자가 흐르는 효과) — CSS transition 으로 fill 만 보간. 숫자 counting 은 애플리케이션 단 훅 사용.
+- **Tooltip on hover** — Tooltip 컴포넌트로 감싸면 됨. Progress 자체에는 내장 안 함.
+- **Marquee label scroll** — 라벨이 너무 길 때 자동 스크롤. v1 은 `text-overflow: ellipsis`.
+- **SVG export / download** — Circular 를 PNG 로 내려받기 등. 범위 밖.
+- **실시간 ETA 계산** — 남은 시간 자동 계산. 사용자 측 책임.
+- **Queue / multi-file progress 조합 UI** — 여러 Progress 를 모아 보여주는 리스트는 애플리케이션 책임. (단, v1.1 `uploader` preset 예시는 §17.)
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Progress/Progress.types.ts`
+
+```ts
+export type ProgressTheme = "light" | "dark";
+export type ProgressShape = "linear" | "circular";
+export type ProgressSize = "sm" | "md" | "lg";
+export type ProgressVariant = "default" | "success" | "warning" | "error";
+export type ProgressLabelPlacement = "inside" | "outside" | "none";
+export type ProgressStrokeLinecap = "butt" | "round";
+
+/**
+ * Progress 의 외형/상태를 결정하는 공통 프롭. Root/단축 wrapper 모두 공유.
+ */
+export interface ProgressCommonProps {
+  /** 현재 값. 0 ~ max. undefined 이면 indeterminate 로 해석. */
+  value?: number;
+  /** uncontrolled 기본값. 이후 외부에서 바꿔도 반영 안 됨(`value` 를 써야 함). */
+  defaultValue?: number;
+  /** value 상한. 기본 100. 음수/0 은 dev warn 후 100 으로 fallback. */
+  max?: number;
+  /**
+   * true 이면 값과 무관하게 indeterminate 애니메이션.
+   * false 이면 value 미지정도 determinate=0 취급.
+   * 미지정(undefined) 이면 "value 가 undefined 이면 indeterminate, 아니면 determinate" 자동 판정.
+   */
+  indeterminate?: boolean;
+  /** 선/원 택일. 기본 "linear". */
+  shape?: ProgressShape;
+  /** 크기. 기본 "md". */
+  size?: ProgressSize;
+  /** 상태별 팔레트. 기본 "default". */
+  variant?: ProgressVariant;
+  /** Light/Dark 팔레트. 기본 "light". */
+  theme?: ProgressTheme;
+
+  /**
+   * 단계형 막대(세그먼트). Linear 전용.
+   * 2 이상의 정수 지정 시 n 개 동일 너비 셀로 분할하고, value 는 0..segments 정수로 해석.
+   * Circular 와 함께 지정하면 dev warn + 무시.
+   */
+  segments?: number;
+
+  /**
+   * 보조 게이지(primary 뒤 연한 색). Linear 전용. 예: 다운로드된 바이트 vs 재생된 바이트.
+   * Circular/segmented 와 함께 지정 시 dev warn + 무시.
+   */
+  buffer?: number;
+
+  /** 대각선 줄무늬 패턴. Linear 전용. */
+  striped?: boolean;
+  /** striped 가 true 일 때 스트라이프가 흐르는 애니메이션. */
+  animated?: boolean;
+
+  /** 라벨 배치. 기본 "none". "inside" 는 필 위 오버레이, "outside" 는 트랙 바깥, Circular 는 중앙. */
+  labelPlacement?: ProgressLabelPlacement;
+  /**
+   * 라벨 포맷터. 기본: `(v, max) => \`${Math.round((v/max)*100)}%\``.
+   * indeterminate 이면 호출되지 않음(라벨 자체를 숨긴다).
+   */
+  formatLabel?: (value: number, max: number) => React.ReactNode;
+
+  /** Circular 전용: stroke 두께(px). 기본 size 별 (sm=3, md=4, lg=6). */
+  strokeWidth?: number;
+  /** Circular 전용: stroke 끝 모양. 기본 "round". */
+  strokeLinecap?: ProgressStrokeLinecap;
+  /** Circular 전용: 트랙(빈 원) 투명도(0~1). 기본 0.12. */
+  trackOpacity?: number;
+
+  /**
+   * 접근성 라벨. 스크린리더가 progressbar 를 "무엇의 진행" 으로 읽을지.
+   * `aria-label` 또는 `aria-labelledby` 중 하나는 반드시 지정 권장. dev warn.
+   */
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  /**
+   * true 이면 컨테이너에 `aria-live="polite"` 를 걸어 value 변경을 읽음.
+   * 기본 false (동적 변경 잦을 때 스팸 방지).
+   */
+  announce?: boolean;
+
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * 단축 API (90% 사용). compound 를 자동 조립한다.
+ * children 은 Circular 의 중앙 텍스트나 Linear 의 커스텀 라벨에 쓰인다(labelPlacement 해석).
+ */
+export interface ProgressProps extends ProgressCommonProps {
+  children?: React.ReactNode;
+}
+
+export interface ProgressRootProps extends ProgressCommonProps {
+  children: React.ReactNode;
+}
+
+export interface ProgressTrackProps {
+  className?: string;
+  style?: React.CSSProperties;
+  /** Track 내부에 놓일 Indicator(들). Linear 는 1~2 개(primary/buffer), Circular 는 1 개. */
+  children: React.ReactNode;
+}
+
+export interface ProgressIndicatorProps {
+  /**
+   * "primary" (기본) | "buffer".
+   * "buffer" 는 Linear 에서만 의미 있음.
+   */
+  kind?: "primary" | "buffer";
+  /**
+   * kind === "buffer" 일 때 사용할 별도 값. kind === "primary" 일 때는 무시.
+   */
+  value?: number;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export interface ProgressLabelProps {
+  /** "inside" | "outside". 기본 "outside". */
+  placement?: "inside" | "outside";
+  className?: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}
+
+export interface ProgressValueTextProps {
+  /** formatter override. 없으면 Root 의 formatLabel. */
+  format?: (value: number, max: number) => React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
+```
+
+### 2.2 배럴 — `src/components/Progress/index.ts`
+
+```ts
+export { Progress } from "./Progress";
+export type {
+  ProgressProps,
+  ProgressRootProps,
+  ProgressTrackProps,
+  ProgressIndicatorProps,
+  ProgressLabelProps,
+  ProgressValueTextProps,
+  ProgressCommonProps,
+  ProgressTheme,
+  ProgressShape,
+  ProgressSize,
+  ProgressVariant,
+  ProgressLabelPlacement,
+  ProgressStrokeLinecap,
+} from "./Progress.types";
+```
+
+그리고 `src/components/index.ts` 에 `export * from "./Progress";` 한 줄 추가.
+
+### 2.3 Compound namespace
+
+```ts
+// Progress.tsx
+const ProgressShortcut = (props: ProgressProps) => { /* convenience wrapper */ };
+
+ProgressShortcut.Root = ProgressRoot;
+ProgressShortcut.Track = ProgressTrack;
+ProgressShortcut.Indicator = ProgressIndicator;
+ProgressShortcut.Label = ProgressLabel;
+ProgressShortcut.ValueText = ProgressValueText;
+
+export const Progress = ProgressShortcut;
+```
+
+사용자는 다음 두 스타일 중 택일:
+
+```tsx
+// Shortcut
+<Progress value={42} />
+
+// Compound
+<Progress.Root value={42}>
+  <Progress.Label>업로드</Progress.Label>
+  <Progress.Track>
+    <Progress.Indicator />
+  </Progress.Track>
+  <Progress.ValueText />
+</Progress.Root>
+```
+
+displayName: `"Progress"`, `"Progress.Root"`, `"Progress.Track"`, `"Progress.Indicator"`, `"Progress.Label"`, `"Progress.ValueText"`.
+
+---
+
+## 3. 도메인 모델
+
+### 3.1 value · max · percent
+
+- 내부적으로 계산되는 단일 파생 값:
+  ```ts
+  const clampedMax = max > 0 ? max : 100;
+  const clampedValue = value == null ? null : Math.max(0, Math.min(clampedMax, value));
+  const percent = clampedValue == null ? null : (clampedValue / clampedMax) * 100;
+  ```
+- `percent` 는 항상 `0 ~ 100` 범위이며, 외부 노출은 안 함(내부 렌더 계산용).
+- `value == null` → indeterminate 로 해석 (단 `indeterminate={false}` 가 명시되면 determinate=0).
+
+### 3.2 상태 판정 우선순위
+
+1. `indeterminate === true` → indeterminate.
+2. `indeterminate === false` → determinate (value 미지정이면 0).
+3. `indeterminate === undefined`:
+   - `value == null` → indeterminate.
+   - `value != null` → determinate.
+
+이 규칙을 한 함수로:
+
+```ts
+function resolveMode(
+  value: number | undefined,
+  indeterminate: boolean | undefined,
+): "determinate" | "indeterminate" {
+  if (indeterminate === true) return "indeterminate";
+  if (indeterminate === false) return "determinate";
+  return value == null ? "indeterminate" : "determinate";
+}
+```
+
+### 3.3 mode 조합 합법성 매트릭스
+
+| shape    | segments | buffer | indeterminate | striped | 합법? |
+|----------|----------|--------|---------------|---------|-------|
+| linear   | -        | -      | false         | any     | ✅   |
+| linear   | -        | -      | true          | any     | ✅ (stripe 는 indeterminate 모션 대체) |
+| linear   | -        | 양수   | false         | any     | ✅ (buffer mode) |
+| linear   | -        | 양수   | true          | -       | ❌ dev warn, buffer 무시 |
+| linear   | ≥2       | -      | false         | -       | ✅ (segmented) |
+| linear   | ≥2       | any    | -             | -       | ❌ dev warn, segments 우선 |
+| linear   | ≥2       | -      | true          | -       | ❌ dev warn, indeterminate 무시 |
+| circular | -        | any    | -             | -       | ❌ dev warn, buffer 무시(v1) |
+| circular | any      | -      | -             | -       | ❌ dev warn, segments 무시 |
+| circular | -        | -      | any           | any     | ✅ (stripe 는 무시 — circular 전용 X) |
+
+충돌 시 dev 빌드에서 `console.warn("[Progress] …")`. prod 에서는 조용히 무시.
+
+### 3.4 Context
+
+```ts
+interface ProgressContextValue {
+  mode: "determinate" | "indeterminate";
+  shape: ProgressShape;
+  size: ProgressSize;
+  variant: ProgressVariant;
+  theme: ProgressTheme;
+  value: number | null;      // clamped
+  max: number;                // sanitized
+  percent: number | null;     // 0..100 or null (indeterminate)
+  buffer: number | null;      // clamped
+  bufferPercent: number | null;
+  segments: number | null;
+  striped: boolean;
+  animated: boolean;
+  labelPlacement: ProgressLabelPlacement;
+  formatLabel: (value: number, max: number) => React.ReactNode;
+  strokeWidth: number;        // resolved by size
+  strokeLinecap: ProgressStrokeLinecap;
+  trackOpacity: number;
+  labelledBy?: string;        // aria-labelledby 가 지정되었으면 사용, 아니면 ariaLabel
+  ariaLabel?: string;
+  announce: boolean;
+}
+
+const ProgressContext = createContext<ProgressContextValue | null>(null);
+```
+
+`useProgressContext()` — null 이면 `"Progress.* must be used within Progress.Root"` throw.
+
+---
+
+## 4. 시각 / 구조 설계
+
+### 4.1 Linear DOM 구조
+
+```html
+<div
+  class="plastic-progress plastic-progress--linear"
+  data-variant="default"
+  data-size="md"
+  data-mode="determinate"
+  data-striped="false"
+  data-animated="false"
+  role="progressbar"
+  aria-valuenow="42"
+  aria-valuemin="0"
+  aria-valuemax="100"
+  aria-label="업로드 진행">
+  <!-- optional outside label -->
+  <div class="plastic-progress__label plastic-progress__label--outside">업로드</div>
+  <div class="plastic-progress__track">
+    <!-- buffer (선택) -->
+    <div class="plastic-progress__fill plastic-progress__fill--buffer" style="transform: scaleX(0.68)"></div>
+    <!-- primary -->
+    <div class="plastic-progress__fill plastic-progress__fill--primary" style="transform: scaleX(0.42)">
+      <!-- optional inside label (value text) -->
+      <span class="plastic-progress__value-text">42%</span>
+    </div>
+  </div>
+</div>
+```
+
+fill 은 `transform: scaleX(p)` + `transform-origin: left` 로 구현 (width 애니메이션보다 GPU 가속 유리). `[dir="rtl"]` 에서는 `transform-origin: right` 로 자동 스왑.
+
+### 4.2 Linear Segmented DOM
+
+```html
+<div class="plastic-progress plastic-progress--linear" data-segmented="true" role="progressbar" aria-valuenow="3" aria-valuemin="0" aria-valuemax="5">
+  <div class="plastic-progress__track plastic-progress__track--segmented">
+    <div class="plastic-progress__seg" data-filled="true"></div>
+    <div class="plastic-progress__seg" data-filled="true"></div>
+    <div class="plastic-progress__seg" data-filled="true"></div>
+    <div class="plastic-progress__seg" data-filled="false"></div>
+    <div class="plastic-progress__seg" data-filled="false"></div>
+  </div>
+</div>
+```
+
+각 `__seg` 는 flex:1 + gap 4px 로 균등 분할. `data-filled="true"` 에 variant 색.
+
+### 4.3 Circular SVG 구조
+
+```html
+<div
+  class="plastic-progress plastic-progress--circular"
+  data-variant="default"
+  data-size="md"
+  data-mode="determinate"
+  role="progressbar"
+  aria-valuenow="72"
+  aria-valuemin="0"
+  aria-valuemax="100"
+  aria-label="로딩 중">
+  <svg class="plastic-progress__svg" viewBox="0 0 40 40" width="40" height="40">
+    <!-- 트랙 원 (연함) -->
+    <circle class="plastic-progress__circle plastic-progress__circle--track"
+            cx="20" cy="20" r="16" fill="none" stroke-width="4" />
+    <!-- 진행 호 -->
+    <circle class="plastic-progress__circle plastic-progress__circle--indicator"
+            cx="20" cy="20" r="16" fill="none" stroke-width="4"
+            stroke-dasharray="100.53"    <!-- 2*π*r -->
+            stroke-dashoffset="28.15"    <!-- (1 - 0.72) * 100.53 -->
+            stroke-linecap="round"
+            transform="rotate(-90 20 20)" />  <!-- 12 시 방향 시작 -->
+  </svg>
+  <!-- 중앙 라벨 (holepiece) -->
+  <div class="plastic-progress__center">72%</div>
+</div>
+```
+
+핵심 공식:
+```ts
+const C = 2 * Math.PI * r;                 // 둘레
+const offset = C * (1 - percent / 100);    // 현재 미완성 구간
+// stroke-dasharray = "C"  stroke-dashoffset = offset
+```
+
+`transform="rotate(-90 cx cy)"` 로 시작점을 12 시 방향으로 회전. indeterminate 시 전체 SVG 에 `animation: plastic-progress-circular-rotate 1.4s linear infinite`, 동시에 `circle--indicator` 자체에 dasharray/offset 을 달리해 "호 길이가 줄었다 늘었다 하는" MUI 스타일 2중 애니메이션.
+
+### 4.4 Indeterminate Linear 애니메이션 (CSS)
+
+```css
+.plastic-progress[data-mode="indeterminate"] .plastic-progress__fill--primary {
+  /* determinate 용 transform 제거 */
+  transform: none;
+  width: 40%;
+  position: absolute;
+  top: 0; bottom: 0;
+  animation: plastic-progress-linear-indeterminate 1.6s ease-in-out infinite;
+}
+
+@keyframes plastic-progress-linear-indeterminate {
+  0%   { left: -40%; right: 100%; }
+  60%  { left: 100%; right: -40%; }
+  100% { left: 100%; right: -40%; }
+}
+```
+
+(MUI 레퍼런스 스타일. `left`/`right` 를 같이 움직여 "폭 가변 + 슬라이딩" 을 일체화.)
+
+### 4.5 Indeterminate Circular 애니메이션 (CSS)
+
+```css
+.plastic-progress--circular[data-mode="indeterminate"] .plastic-progress__svg {
+  animation: plastic-progress-circular-rotate 1.4s linear infinite;
+}
+.plastic-progress--circular[data-mode="indeterminate"] .plastic-progress__circle--indicator {
+  stroke-dasharray: 80, 200;
+  stroke-dashoffset: 0;
+  animation: plastic-progress-circular-dash 1.4s ease-in-out infinite;
+}
+
+@keyframes plastic-progress-circular-rotate {
+  100% { transform: rotate(360deg); }
+}
+@keyframes plastic-progress-circular-dash {
+  0%   { stroke-dasharray: 1, 200;  stroke-dashoffset: 0; }
+  50%  { stroke-dasharray: 100, 200; stroke-dashoffset: -15; }
+  100% { stroke-dasharray: 100, 200; stroke-dashoffset: -125; }
+}
+```
+
+### 4.6 Striped + Animated (Linear 전용)
+
+```css
+.plastic-progress[data-striped="true"] .plastic-progress__fill--primary {
+  background-image: linear-gradient(
+    45deg,
+    rgba(255,255,255,0.2) 25%, transparent 25%,
+    transparent 50%, rgba(255,255,255,0.2) 50%,
+    rgba(255,255,255,0.2) 75%, transparent 75%
+  );
+  background-size: 16px 16px;
+}
+.plastic-progress[data-striped="true"][data-animated="true"] .plastic-progress__fill--primary {
+  animation: plastic-progress-stripes 1s linear infinite;
+}
+@keyframes plastic-progress-stripes {
+  0%   { background-position: 0 0; }
+  100% { background-position: 16px 0; }
+}
+```
+
+### 4.7 팔레트 (variant · state)
+
+```ts
+// Progress/theme.ts
+export const progressPalette = {
+  light: {
+    track:          "rgba(0,0,0,0.08)",
+    trackSegmented: "rgba(0,0,0,0.05)",
+    labelFg:        "#374151",
+    valueTextFg:    "#ffffff",        // fill 위 inside 라벨
+    valueTextFgOut: "#374151",        // outside 라벨
+    variants: {
+      default: { fill: "#2563eb", buffer: "rgba(37,99,235,0.30)" },
+      success: { fill: "#16a34a", buffer: "rgba(22,163,74,0.30)" },
+      warning: { fill: "#d97706", buffer: "rgba(217,119,6,0.30)" },
+      error:   { fill: "#dc2626", buffer: "rgba(220,38,38,0.30)" },
+    },
+  },
+  dark: {
+    track:          "rgba(255,255,255,0.10)",
+    trackSegmented: "rgba(255,255,255,0.06)",
+    labelFg:        "#e5e7eb",
+    valueTextFg:    "#0b1220",
+    valueTextFgOut: "#e5e7eb",
+    variants: {
+      default: { fill: "#60a5fa", buffer: "rgba(96,165,250,0.30)" },
+      success: { fill: "#34d399", buffer: "rgba(52,211,153,0.30)" },
+      warning: { fill: "#fbbf24", buffer: "rgba(251,191,36,0.30)" },
+      error:   { fill: "#f87171", buffer: "rgba(248,113,113,0.30)" },
+    },
+  },
+} as const;
+```
+
+CSS 변수 노출 (Root 에 inline `style={{ '--plastic-progress-fill': … }}`):
+
+```
+--plastic-progress-track
+--plastic-progress-track-segmented
+--plastic-progress-fill
+--plastic-progress-buffer
+--plastic-progress-label-fg
+--plastic-progress-value-fg-inside
+--plastic-progress-value-fg-outside
+--plastic-progress-size-linear     (4 | 8 | 12 px)
+--plastic-progress-size-circular   (24 | 40 | 64 px)
+--plastic-progress-stroke-width    (3 | 4 | 6)
+--plastic-progress-radius          (9999px 또는 4px — segmented 때)
+```
+
+사용자는 `style={{ '--plastic-progress-fill': '#8b5cf6' }}` 로 커스텀 색을 넣을 수 있다(컴포넌트 prop 확장 없이).
+
+### 4.8 size 토큰
+
+| size | linear height | circular diameter | stroke width | label font |
+|------|---------------|-------------------|--------------|------------|
+| sm   | 4 px          | 24 px             | 3            | 11 px      |
+| md   | 8 px          | 40 px             | 4            | 12 px      |
+| lg   | 12 px         | 64 px             | 6            | 14 px      |
+
+---
+
+## 5. 핵심 로직
+
+### 5.1 값 정규화
+
+```ts
+// Progress/Progress.utils.ts
+export function sanitizeMax(max: number | undefined): number {
+  if (max == null) return 100;
+  if (!Number.isFinite(max) || max <= 0) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[Progress] max must be a positive finite number. Fallback to 100.");
+    }
+    return 100;
+  }
+  return max;
+}
+
+export function clampValue(
+  value: number | undefined,
+  max: number,
+): number | null {
+  if (value == null) return null;
+  if (!Number.isFinite(value)) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[Progress] value must be a finite number.");
+    }
+    return 0;
+  }
+  if (value < 0) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(`[Progress] value ${value} < 0. Clamped to 0.`);
+    }
+    return 0;
+  }
+  if (value > max) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(`[Progress] value ${value} > max ${max}. Clamped to max.`);
+    }
+    return max;
+  }
+  return value;
+}
+
+export function toPercent(value: number | null, max: number): number | null {
+  return value == null ? null : (value / max) * 100;
+}
+```
+
+### 5.2 Circular geometry
+
+```ts
+export function circularGeometry(
+  diameter: number,
+  strokeWidth: number,
+  percent: number,
+): { r: number; c: number; offset: number } {
+  const r = (diameter - strokeWidth) / 2;
+  const c = 2 * Math.PI * r;
+  const clampedPct = Math.max(0, Math.min(100, percent));
+  const offset = c * (1 - clampedPct / 100);
+  return { r, c, offset };
+}
+```
+
+### 5.3 segments 매핑
+
+```ts
+export function resolveSegments(
+  segments: number | undefined,
+  value: number | null,
+): { count: number; filled: number } | null {
+  if (segments == null) return null;
+  const n = Math.max(2, Math.floor(segments));
+  const v = value == null ? 0 : Math.max(0, Math.min(n, Math.floor(value)));
+  return { count: n, filled: v };
+}
+```
+
+segmented 일 때 `aria-valuemax = n`, `aria-valuenow = filled`.
+
+### 5.4 CSS 변수 inline 적용
+
+Root 에서 palette 객체를 한 번만 읽어 `style` 로 CSS 변수 세팅:
+
+```ts
+const p = progressPalette[theme].variants[variant];
+const rootStyle: React.CSSProperties = {
+  "--plastic-progress-track": progressPalette[theme].track,
+  "--plastic-progress-fill": p.fill,
+  "--plastic-progress-buffer": p.buffer,
+  "--plastic-progress-label-fg": progressPalette[theme].labelFg,
+  "--plastic-progress-value-fg-inside": progressPalette[theme].valueTextFg,
+  "--plastic-progress-value-fg-outside": progressPalette[theme].valueTextFgOut,
+  "--plastic-progress-size-linear":
+    size === "sm" ? "4px" : size === "lg" ? "12px" : "8px",
+  "--plastic-progress-size-circular":
+    size === "sm" ? "24px" : size === "lg" ? "64px" : "40px",
+  "--plastic-progress-stroke-width":
+    String(strokeWidth ?? (size === "sm" ? 3 : size === "lg" ? 6 : 4)),
+  ...(props.style ?? {}),
+} as React.CSSProperties;
+```
+
+사용자가 `props.style` 로 같은 변수를 override 하면 덮어씀 (spread 순서).
+
+### 5.5 mode 전환 시 transition
+
+determinate → indeterminate 혹은 그 반대 전환 시, primary fill 의 inline transform 과 CSS animation 이 같은 프레임에 공존하면 깜빡임이 생긴다. 해결:
+
+```css
+.plastic-progress__fill--primary {
+  transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.plastic-progress[data-mode="indeterminate"] .plastic-progress__fill--primary {
+  transition: none;   /* indeterminate 애니메이션과 충돌 방지 */
+}
+```
+
+그리고 `data-mode` 변경은 1 tick 안에 React state 로 반영되므로 깜빡임 없이 교체된다. (Chrome/FF/Safari 모두 확인 필요 — §13.)
+
+---
+
+## 6. 제약
+
+### 6.1 value 경고·클램프
+
+- `value < 0` → dev warn, 0 으로 클램프.
+- `value > max` → dev warn, max 로 클램프.
+- `value` 가 `NaN`/`Infinity` → dev warn, 0.
+- `max <= 0` 또는 non-finite → dev warn, max=100 fallback.
+
+production 에서는 silent — 단, 렌더는 항상 올바른 clamp 된 값을 사용한다.
+
+### 6.2 buffer 경고·클램프
+
+- `buffer < 0` → 0.
+- `buffer > max` → max.
+- `buffer < value` → dev warn (의미 없음. 렌더는 그대로 하되 시각적으로 primary 가 buffer 를 덮는다).
+
+### 6.3 조합 모순 (§3.3 매트릭스)
+
+- segmented + buffer → `buffer` 무시 + warn.
+- segmented + indeterminate → `indeterminate` 무시 + warn.
+- circular + buffer / segments / striped → 각각 무시 + warn.
+- indeterminate + buffer → buffer 무시 + warn (의미 상충).
+- indeterminate + striped → 허용 (striped 는 indeterminate 의 폭 좁은 필 위에 그려져 "스트라이프 슬라이딩" 느낌이 됨).
+
+### 6.4 접근성 경고
+
+- `aria-label` 과 `aria-labelledby` 가 모두 없으면 dev warn: `"[Progress] aria-label or aria-labelledby is recommended for screen readers."` — throw 는 아니고 warn 1 회 (React ref 해시로 dedupe 는 v1 미포함).
+
+### 6.5 children 검증 (compound 사용 시)
+
+- `Progress.Root` 의 `children` 에 `Progress.Track` 이 없으면 dev warn.
+- `Progress.Track` 의 `children` 에 `Progress.Indicator` 가 없으면 dev warn.
+- `Progress.Indicator kind="buffer"` 가 circular 컨텍스트 안에 있으면 dev warn + 무시.
+
+구현은 `React.Children.toArray + React.isValidElement + child.type === ProgressTrack` 으로 체크. (여기서 직접 비교 가능 — 같은 모듈이므로 identity 일치.)
+
+---
+
+## 7. 키보드
+
+Progress 는 **비상호작용** 컴포넌트이다. 포커스 가능하지 않고, 키 입력을 처리하지 않는다.
+
+- `tabindex` 기본 미지정. 사용자가 명시적으로 focusable 하려면 `tabIndex={0}` 을 넘겨야 하지만 v1 에서 권장하지 않음.
+- 역할은 순전히 `role="progressbar"` 로, 보조공학이 "진척도" 로 읽을 수 있도록 한다.
+- Slider/RadioGroup 처럼 값을 바꾸는 키 처리는 없다.
+
+→ Progress 는 "시각 + ARIA 메타데이터" 만 제공. 사용자가 키보드 상호작용으로 값을 바꾸고 싶다면 Progress 는 적합하지 않으며 다른 컴포넌트(Slider) 가 필요하다. 이를 §16 트레이드오프에서 명시.
+
+---
+
+## 8. 상태 관리
+
+### 8.1 controlled / uncontrolled 이중 API
+
+`useControllable` 훅을 그대로 쓴다:
+
+```ts
+const [value, setValue] = useControllable<number | undefined>(
+  props.value,
+  props.defaultValue ?? 0,
+  /* onChange = */ undefined,
+);
+```
+
+- Progress 는 "외부 값 반영" 이 주이므로 보통 controlled 로 쓰인다.
+- uncontrolled (`defaultValue`) 는 "마운트 시 한 번만 값 세팅" 정도 용도 — 실제 변하는 progress 는 controlled 필수.
+- `onValueChange` 콜백은 v1 미포함 (Progress 는 내부에서 값을 바꾸지 않음). 향후 Slider 계열로 승격 시 추가.
+
+### 8.2 indeterminate 상태 렌더링
+
+indeterminate 는 React state 에 의존하지 않고 **CSS 애니메이션** 으로 순환한다. 즉 Progress 자체는 re-render 하지 않아도 브라우저가 매 프레임 paint. 이는 성능(§14) 과 runtime-zero 를 동시에 만족한다.
+
+- Root 는 `data-mode` 를 `"indeterminate" | "determinate"` 로만 바꾼다.
+- 나머지는 CSS selector (`[data-mode="indeterminate"] .…`) 가 결정.
+
+### 8.3 announce (aria-live)
+
+`announce === true` 이면 Root 컨테이너에 `aria-live="polite"` + `aria-atomic="true"` 가 걸린다. determinate 에서 value 가 변경되면 보조공학이 `"업로드 진행 42%"` 식으로 읽는다. 단 너무 자주 바뀌면 스팸이므로:
+
+- 기본 `announce=false`.
+- announce=true 여도 구현은 `aria-live` 만 켜는 단순 방식. 스로틀은 사용자 측에서 (예: value 를 10% 단위로 snap 해 넘기기).
+
+### 8.4 segmented value 반올림
+
+segmented 에서 value 가 정수가 아니면 `Math.floor(value)` 로 내림. 이 rule 은 ARIA 에도 적용 (`aria-valuenow` = floor).
+
+---
+
+## 9. 변형 / 상태
+
+### 9.1 variant (상태별 팔레트)
+
+| variant   | 용도                          | 대표 컨텍스트             |
+|-----------|-------------------------------|---------------------------|
+| default   | 일반 진행 (파란색)            | 업로드, 로딩              |
+| success   | 완료 임박/완료 직후 (초록)    | 설치 성공 직후 3초간      |
+| warning   | 경고 임계 (주황)              | 디스크 사용률 80% 이상    |
+| error     | 실패/중단 (빨강)              | 업로드 실패 후 부분 진행  |
+
+사용자는 value 에 따라 variant 를 스위치하는 파생 로직을 외부에서 주도.
+
+```tsx
+<Progress value={v} variant={v >= 100 ? "success" : v < 10 ? "error" : "default"} />
+```
+
+### 9.2 shape
+
+- `"linear"`: 수평 막대. 기본. 대부분 케이스.
+- `"circular"`: 원형. SVG 렌더. 아이콘 버튼 옆 배지, 모달 내 "처리 중" 스피너.
+
+### 9.3 size
+
+`"sm"` | `"md"` | `"lg"`. Linear 는 트랙 높이, Circular 는 직경. 라벨 폰트도 스케일 (§4.8 표).
+
+### 9.4 label placement
+
+- **outside** (기본): 트랙 위에 라벨, 오른쪽 끝에 value text. Linear.
+- **inside**: 필 위에 오버레이. Linear md/lg 에서만 권장 (sm 은 4 px 라 텍스트 불가 → dev warn + none 으로 fallback).
+- **none**: 라벨/값 텍스트 숨김.
+- Circular 는 labelPlacement 무관하게 "중앙 홀" 에 children 또는 `ValueText` 를 배치. `none` 이면 중앙도 비움.
+
+### 9.5 striped / animated
+
+| striped | animated | 효과                                   |
+|---------|----------|----------------------------------------|
+| false   | false    | 단색 필                                |
+| true    | false    | 정적 대각선 줄무늬                     |
+| true    | true     | 줄무늬가 흐름 (1s loop)                |
+| false   | true     | animated 만으로는 효과 없음, warn     |
+
+### 9.6 segmented
+
+`segments` 가 지정되면 variant 에 따라 채워진 셀 색 결정. 비어 있는 셀은 `--plastic-progress-track-segmented`. 셀 gap=4 px, border-radius=2 px.
+
+---
+
+## 10. 파일 구조
+
+```
+src/components/Progress/
+├── Progress.tsx                 # Shortcut + namespace export
+├── Progress.types.ts            # 공개 타입
+├── Progress.utils.ts            # sanitizeMax, clampValue, toPercent, circularGeometry, resolveSegments, resolveMode
+├── Progress.css                 # @keyframes + data-attr 기반 스타일
+├── ProgressContext.ts           # Context + useProgressContext
+├── ProgressRoot.tsx             # Root (compound 진입점, Context Provider)
+├── ProgressTrack.tsx            # Linear/Circular 공통 track 분기
+├── ProgressTrackLinear.tsx      # Linear 전용 track (+ segmented 렌더)
+├── ProgressTrackCircular.tsx    # Circular 전용 track (SVG)
+├── ProgressIndicator.tsx        # Linear fill / Circular arc, kind=primary|buffer
+├── ProgressLabel.tsx            # outside/inside 라벨
+├── ProgressValueText.tsx        # value 텍스트 (formatLabel)
+├── theme.ts                     # progressPalette
+└── index.ts                     # 배럴
+```
+
+각 파일 책임:
+
+- **Progress.tsx** — `ProgressShortcut(props)` 구현 (props 를 Root + Track + Indicator 에 뿌리는 편의 wrapper). namespace export.
+- **Progress.utils.ts** — pure functions only. React 의존 없음.
+- **Progress.css** — `@keyframes` 3 개 (linear indeterminate, circular rotate, circular dash, stripes), data-attr selector, CSS 변수 fallback.
+- **ProgressContext.ts** — `createContext<ProgressContextValue | null>(null)` + throw 훅.
+- **ProgressRoot.tsx** — useControllable, sanitize, resolveMode, resolveSegments, palette → CSS 변수, `role="progressbar"` 및 `aria-valuenow/min/max`, data-attr, children 검증.
+- **ProgressTrack.tsx** — shape 에 따라 Linear/Circular subtree 를 분기하여 렌더.
+- **ProgressTrackLinear.tsx** — `<div class="plastic-progress__track">` + segmented 분기. indicator children 은 그대로 배치.
+- **ProgressTrackCircular.tsx** — SVG + 트랙 circle + children (Indicator 는 호를 렌더).
+- **ProgressIndicator.tsx** — context.shape 에 따라 `<div>` (linear fill) 또는 `<circle>` (circular arc). kind=buffer 면 위치/색 변경.
+- **ProgressLabel.tsx** — placement 에 따른 DOM 위치/클래스.
+- **ProgressValueText.tsx** — formatLabel 호출, indeterminate 면 null 반환.
+- **theme.ts** — `progressPalette` const.
+
+---
+
+## 11. 구현 단계 (후속 agent 가 순차 실행)
+
+각 단계는 독립 커밋 권장. 각 커밋이 `npm run typecheck` + `npx tsup` 통과 상태.
+
+### Step 1 — 타입 + 배럴 + 팔레트 스켈레톤
+1. `Progress.types.ts` 작성 (§2.1 전부).
+2. `theme.ts` 작성 (`progressPalette`).
+3. `Progress.utils.ts` 작성 (`sanitizeMax`, `clampValue`, `toPercent`, `resolveMode`, `resolveSegments`, `circularGeometry`).
+4. `Progress.css` 파일 생성 (keyframes 만, 나머지 selector 는 후속 단계에서 채움).
+5. `ProgressContext.ts`.
+6. `Progress.tsx` placeholder: `export const Progress = Object.assign(() => null, { Root: () => null, Track: () => null, Indicator: () => null, Label: () => null, ValueText: () => null })`.
+7. `index.ts` 배럴.
+8. `src/components/index.ts` 에 `export * from "./Progress";`.
+9. `npm run typecheck` 통과.
+10. 커밋: `feat(Progress): 타입 + 팔레트 + 배럴 스켈레톤`.
+
+### Step 2 — Root + Context + Linear determinate 기본
+1. `ProgressRoot.tsx` 본체: useControllable, 값 정규화, resolveMode, Context Provider, root DOM.
+2. `ProgressTrack.tsx` + `ProgressTrackLinear.tsx` + `ProgressIndicator.tsx` — determinate 전용 (transform scaleX).
+3. `Progress.css` 에 `.plastic-progress--linear` 기본 레이아웃, `__track`, `__fill--primary` 스타일.
+4. 단축 wrapper `ProgressShortcut` 가 Root + Track + Indicator 를 자동 조립.
+5. 테스트: `<Progress value={42} />` 가 42% fill 로 보이는지.
+6. 커밋: `feat(Progress): Linear determinate 기본`.
+
+### Step 3 — variant / size / theme + CSS 변수
+1. Root 에서 palette → CSS 변수 inline 세팅.
+2. `data-variant`, `data-size`, `data-theme` 속성 적용.
+3. CSS selector 로 색/두께 분기.
+4. Light/Dark 전환 확인.
+5. 커밋: `feat(Progress): variant/size/theme + CSS 변수`.
+
+### Step 4 — Linear indeterminate
+1. `resolveMode` → `data-mode="indeterminate"`.
+2. `@keyframes plastic-progress-linear-indeterminate` 구현.
+3. `aria-valuenow` 를 indeterminate 시 제거 (Root 에서 조건부).
+4. 커밋: `feat(Progress): Linear indeterminate`.
+
+### Step 5 — Circular determinate + indeterminate
+1. `ProgressTrackCircular.tsx` SVG.
+2. `ProgressIndicator` 의 circular 분기 (stroke-dasharray/offset 계산).
+3. indeterminate 시 rotate + dash 이중 애니메이션.
+4. 중앙 children 렌더 (label).
+5. 커밋: `feat(Progress): Circular determinate/indeterminate`.
+
+### Step 6 — buffer (Linear)
+1. `<Progress.Indicator kind="buffer" value={n} />` 지원.
+2. primary/buffer z-index 및 색상 분리.
+3. §3.3 매트릭스 경고.
+4. 커밋: `feat(Progress): buffer (linear)`.
+
+### Step 7 — segments (Linear)
+1. `segments` prop → segmented DOM 렌더.
+2. 셀 `data-filled` 속성 + CSS.
+3. ARIA valuemax/valuenow 재매핑.
+4. 커밋: `feat(Progress): segmented`.
+
+### Step 8 — striped + animated
+1. `data-striped`, `data-animated` 속성.
+2. CSS 스트라이프 gradient + `@keyframes plastic-progress-stripes`.
+3. 커밋: `feat(Progress): striped/animated`.
+
+### Step 9 — Label / ValueText / labelPlacement
+1. `ProgressLabel.tsx`, `ProgressValueText.tsx`.
+2. outside/inside/none 분기.
+3. Circular 중앙 children 배치.
+4. `formatLabel` prop 반영.
+5. 커밋: `feat(Progress): Label + ValueText`.
+
+### Step 10 — 접근성 마감
+1. `role="progressbar"`, aria 속성 완비.
+2. `announce` → `aria-live="polite"`.
+3. aria-label 없을 때 dev warn.
+4. indeterminate 시 `aria-valuenow` 제거.
+5. 커밋: `feat(Progress): 접근성 완비`.
+
+### Step 11 — 데모 페이지
+1. `demo/src/pages/ProgressPage.tsx` 작성 (§12).
+2. `demo/src/App.tsx` NAV 에 `"progress"` 추가 + `Page` 유니온 확장 + 라우팅.
+3. 커밋: `feat(Progress): 데모 페이지`.
+
+### Step 12 — 마감
+1. Props 표 채움.
+2. §20 DoD 체크.
+3. 커밋: `feat(Progress): Props 표 + usage`.
+
+---
+
+## 12. 데모 페이지
+
+`demo/src/pages/ProgressPage.tsx`. CommandPalettePage 등 기존 페이지 구조 복제 — 좌측 사이드바 섹션 + 우측 본문 + 상단 헤더.
+
+### 12.1 NAV 추가 (App.tsx)
+
+```ts
+{ id: "progress", label: "Progress", description: "진행 상태 인디케이터", sections: [
+  { label: "Linear Basic",        id: "linear" },
+  { label: "Indeterminate",       id: "indeterminate" },
+  { label: "Buffer",              id: "buffer" },
+  { label: "Segmented",           id: "segmented" },
+  { label: "Circular",            id: "circular" },
+  { label: "States (variant)",    id: "states" },
+  { label: "Striped + Animated",  id: "striped" },
+  { label: "Sizes",               id: "sizes" },
+  { label: "Dark Theme",          id: "dark" },
+  { label: "Controlled Counter",  id: "controlled" },
+  { label: "Playground",          id: "playground" },
+  { label: "Props",               id: "props" },
+  { label: "Usage",               id: "usage" },
+]},
+```
+
+그리고 `Page` 유니온에 `"progress"` 추가 + `{current === "progress" && <ProgressPage />}`.
+
+### 12.2 섹션 구성
+
+**Linear Basic**
+```tsx
+<div className="flex flex-col gap-4">
+  <Progress value={0} aria-label="0%" />
+  <Progress value={25} aria-label="25%" />
+  <Progress value={60} aria-label="60%" />
+  <Progress value={100} aria-label="완료" />
+</div>
+```
+
+**Indeterminate**
+```tsx
+<div className="flex flex-col gap-4">
+  <Progress indeterminate aria-label="로딩 중" />
+  <Progress shape="circular" indeterminate aria-label="처리 중" />
+  <Progress indeterminate striped aria-label="업로드 중" />
+</div>
+```
+
+**Buffer (Linear)**
+```tsx
+<Progress.Root value={42} buffer={68} aria-label="다운로드/재생 위치">
+  <Progress.Track>
+    <Progress.Indicator kind="buffer" value={68} />
+    <Progress.Indicator />
+  </Progress.Track>
+</Progress.Root>
+```
+(단축: `<Progress value={42} buffer={68} />`.)
+
+**Segmented**
+```tsx
+<div className="flex flex-col gap-3">
+  <Progress segments={5} value={3} aria-label="단계 3/5" />
+  <Progress segments={10} value={7} variant="success" aria-label="Quiz 7/10" />
+  <Progress segments={4} value={0} aria-label="시작 전" />
+</div>
+```
+
+**Circular**
+```tsx
+<div className="flex items-center gap-6">
+  <Progress shape="circular" value={25} size="sm" />
+  <Progress shape="circular" value={50} size="md">50%</Progress>
+  <Progress shape="circular" value={75} size="lg" strokeWidth={8}>75%</Progress>
+  <Progress shape="circular" indeterminate size="md" aria-label="처리 중" />
+</div>
+```
+
+**States (variant)**
+```tsx
+<div className="flex flex-col gap-3">
+  <Progress value={30} variant="default"  aria-label="default" />
+  <Progress value={80} variant="success"  aria-label="success" />
+  <Progress value={90} variant="warning"  aria-label="warning" />
+  <Progress value={45} variant="error"    aria-label="error" />
+</div>
+```
+
+**Striped + Animated**
+```tsx
+<div className="flex flex-col gap-3">
+  <Progress value={60} striped aria-label="striped" />
+  <Progress value={60} striped animated aria-label="striped animated" />
+  <Progress value={60} striped animated variant="success" size="lg" aria-label="striped animated large" />
+</div>
+```
+
+**Sizes**
+```tsx
+<div className="flex flex-col gap-4">
+  <Progress value={40} size="sm" aria-label="sm" />
+  <Progress value={40} size="md" aria-label="md" />
+  <Progress value={40} size="lg" aria-label="lg" />
+</div>
+<div className="flex items-center gap-6 mt-6">
+  <Progress shape="circular" value={40} size="sm" />
+  <Progress shape="circular" value={40} size="md" />
+  <Progress shape="circular" value={40} size="lg" />
+</div>
+```
+
+**Dark Theme**
+```tsx
+<div style={{ background: "#0b1220", padding: 24, borderRadius: 8 }}>
+  <div className="flex flex-col gap-3">
+    <Progress value={50} theme="dark" aria-label="dark default" />
+    <Progress value={80} theme="dark" variant="success" aria-label="dark success" />
+    <Progress value={45} theme="dark" variant="error" striped animated aria-label="dark error animated" />
+    <Progress shape="circular" value={65} theme="dark" />
+  </div>
+</div>
+```
+
+**Controlled Counter (외부에서 값 주입)**
+```tsx
+function ControlledDemo() {
+  const [v, setV] = useState(0);
+  useEffect(() => {
+    if (v >= 100) return;
+    const t = setTimeout(() => setV(x => Math.min(100, x + 5)), 300);
+    return () => clearTimeout(t);
+  }, [v]);
+  return (
+    <div className="flex flex-col gap-3">
+      <Progress value={v} aria-label="자동 증가" announce />
+      <div className="flex gap-2">
+        <button onClick={() => setV(0)}>Reset</button>
+        <button onClick={() => setV(100)}>Jump to 100</button>
+      </div>
+      <div className="text-sm text-slate-600">current: {v}</div>
+    </div>
+  );
+}
+```
+
+**Playground**
+상단 컨트롤 바:
+- `shape` 라디오 (linear / circular)
+- `variant` 라디오 (default / success / warning / error)
+- `size` 라디오 (sm / md / lg)
+- `value` 슬라이더 0~100 (+ indeterminate 체크박스)
+- `buffer` 슬라이더 0~100 (+ 활성 체크)
+- `segments` 입력 (0 = 없음, 2~10)
+- `striped`, `animated` 체크박스
+- `labelPlacement` 라디오 (inside/outside/none)
+- `theme` 토글 (light/dark)
+- `announce` 체크박스
+- `strokeWidth` 슬라이더 (circular 시)
+- `strokeLinecap` 라디오 (butt/round)
+
+아래에 200 px 높이/폭 미리보기 박스. 조작 즉시 반영.
+
+**Props 표**
+기존 페이지 패턴. `Progress` (단축) / `Progress.Root` / `Progress.Track` / `Progress.Indicator` / `Progress.Label` / `Progress.ValueText` 각각의 모든 prop × 타입 × 기본값 × 설명.
+
+**Usage (4 개)**
+
+1. **파일 업로드 인라인**
+    ```tsx
+    function UploadRow({ filename, percent }: { filename: string; percent: number }) {
+      return (
+        <div className="flex items-center gap-3">
+          <span className="w-40 truncate text-sm">{filename}</span>
+          <Progress value={percent} size="sm" className="flex-1" aria-label={`${filename} 업로드`} />
+          <span className="w-10 text-xs text-slate-500">{percent}%</span>
+        </div>
+      );
+    }
+    ```
+
+2. **모달 로딩 스피너 (Circular indeterminate)**
+    ```tsx
+    <Dialog.Root open>
+      <Dialog.Content>
+        <div className="flex flex-col items-center gap-3 py-8">
+          <Progress shape="circular" indeterminate size="lg" aria-label="처리 중" />
+          <p>처리하는 중…</p>
+        </div>
+      </Dialog.Content>
+    </Dialog.Root>
+    ```
+
+3. **Quiz 진행 (segmented)**
+    ```tsx
+    <Progress segments={10} value={q} variant="success" aria-label={`문제 ${q}/10`} />
+    ```
+
+4. **버퍼링되는 비디오 플레이어 위치**
+    ```tsx
+    <Progress.Root value={played} buffer={loaded} max={duration} aria-label="재생 위치">
+      <Progress.Track>
+        <Progress.Indicator kind="buffer" value={loaded} />
+        <Progress.Indicator />
+      </Progress.Track>
+    </Progress.Root>
+    ```
+
+---
+
+## 13. 검증 계획
+
+### 13.1 자동화
+```bash
+cd /Users/neo/workspace/plastic
+npm run typecheck
+npx tsup
+```
+
+주의: `exactOptionalPropertyTypes: true` — optional prop 은 `?:` 로 받고, 디폴트 머지 시 `undefined` 분기를 명시. `noUncheckedIndexedAccess: true` — `React.Children.toArray()[i]` 는 `ReactNode | undefined`. `verbatimModuleSyntax: true` — 타입은 `import type { ... } from ...`.
+
+### 13.2 수동 (demo dev server)
+```bash
+cd demo && npm run dev
+```
+
+체크리스트:
+- [ ] Linear basic: 0/25/60/100 각각 정확한 비율 렌더.
+- [ ] value 변경 시 transform scaleX 전환이 **부드러움**(200ms cubic). 점프/깜빡임 없음.
+- [ ] indeterminate Linear: 스트라이프가 좌→우 왕복, 루프가 매끄럽고 **끝점에서 튀지 않음** (keyframe 0% / 60% / 100% 확인).
+- [ ] indeterminate Circular: SVG 가 360° 회전 + 호 길이(stroke-dasharray) 가 숨쉬듯 변함. 1.4s 주기.
+- [ ] Buffer: primary 가 buffer 위에 그려짐. buffer=68, primary=42 일 때 시각 겹침 올바름.
+- [ ] Segmented: segments=5 value=3 이면 좌측 3 개만 채워짐. gap=4px. `aria-valuemax=5`, `aria-valuenow=3`.
+- [ ] Circular: stroke-linecap="round" 일 때 호 끝이 **둥글게** 마감 (stroke-linecap 로컬 prop 테스트).
+- [ ] Circular: stroke-linecap="butt" 일 때 끝이 각짐 확인.
+- [ ] States: default(blue) / success(green) / warning(orange) / error(red) 팔레트 전환.
+- [ ] Striped: 45° 대각 줄무늬. animated 시 1s 주기로 흐름.
+- [ ] Sizes: sm=4px, md=8px, lg=12px track (linear). circular 24/40/64 px.
+- [ ] Dark: 트랙 색/필 색/라벨 색 모두 다크 팔레트.
+- [ ] Controlled Counter: setState → value reflect 즉시.
+- [ ] Playground: 모든 컨트롤 조합이 실시간 반영.
+- [ ] 다른 페이지 리그레션 없음.
+
+### 13.3 엣지 케이스
+- [ ] `value < 0` → dev warn + 0 렌더.
+- [ ] `value > max` → dev warn + max 렌더.
+- [ ] `value = NaN` → dev warn + 0.
+- [ ] `max = 0` 또는 음수 → warn + 100 fallback.
+- [ ] `value = undefined` + `indeterminate = undefined` → indeterminate 자동.
+- [ ] `value = undefined` + `indeterminate = false` → determinate=0.
+- [ ] `value = 50` + `indeterminate = true` → indeterminate (explicit 우선).
+- [ ] segmented + buffer → warn, buffer 무시.
+- [ ] circular + buffer → warn, buffer 무시 (v1).
+- [ ] circular + striped → striped 무시 (경고 없음 — 기본적으로 circular 에는 striped 가 시각적 의미 없음, silent ignore).
+- [ ] segments=1 → warn, 최소 2 로 올림.
+- [ ] segments=10.7 → floor(10).
+- [ ] Dark + striped: 흰색 반투명 스트라이프가 다크 배경에서도 대비 충분.
+- [ ] RTL (`dir="rtl"`) Linear: fill 이 오른쪽에서 시작하여 왼쪽으로 자람. `transform-origin: right`.
+- [ ] 라벨 너무 긺: `text-overflow: ellipsis` (linear outside).
+- [ ] aria-label 미지정 시 dev warn 1 회.
+- [ ] announce=true 상태에서 value 변경 → 보조공학 가청 (VoiceOver 수동 확인).
+- [ ] React.StrictMode 재마운트 시에도 애니메이션 루프 유지 (useEffect 로 관리 안 하므로 자연스러움).
+
+### 13.4 시각 회귀 (수동)
+- transition smoothness: devtools Performance 탭에서 value 변화 시 layout thrash 없음 (transform 만 바뀜).
+- indeterminate loop: 1 초 이상 녹화해 keyframe boundary 에서 jump 없음.
+- circular 둥근 끝 확대: 160 px 확대해 stroke-linecap 모양 확인.
+
+---
+
+## 14. 성능
+
+### 14.1 목표
+- 모든 애니메이션 **CSS 기반**. React re-render 없이 60 fps.
+- 초기 마운트 < 1 ms (CSS 변수 inline 적용 외 계산 없음).
+
+### 14.2 설계 포인트
+1. **width 대신 transform**: `transform: scaleX(p)` + `transform-origin: left` 로 필 길이 제어. GPU 가속, paint cost 없음.
+2. **indeterminate 는 CSS animation**: React 가 매 프레임 관여하지 않음. 사용자가 value 만 변경해도 `data-mode` 만 바뀌고 애니메이션 자체는 브라우저.
+3. **memo 불필요**: Progress 는 leaf 컴포넌트로 상태가 단순하며 부모 리렌더가 잦아도 cost 작다. `React.memo` 적용은 성능 이득 거의 없음 + 불필요한 shallow compare 비용.
+4. **SVG 재사용**: circular 도 값 변경 시 `stroke-dashoffset` 만 inline 업데이트. 노드 수 일정.
+5. **CSS 변수**: palette 바꿀 때 style 재계산 범위가 Root 이하로 제한.
+6. **context value identity**: Root 에서 context value 객체를 `useMemo` 로 묶음. indicator/label 가 불필요하게 리렌더되지 않게.
+
+### 14.3 메모리
+- 각 Progress 인스턴스: DOM 5~8 개 + (circular 일 때 SVG 2 circle + text). 가벼움.
+- 동시 100 개 업로드 리스트에서도 문제 없음 (benchmark: MUI LinearProgress 대비 동등).
+
+### 14.4 측정 방법
+- DevTools Performance 탭에서 indeterminate linear 2 초 녹화 → FPS 60 유지 + React 커밋 0 (CSS 애니메이션이므로).
+- determinate value 를 rAF 로 0→100 틱 100회 변경 → commit 수는 100 회지만 각 commit cost < 0.2 ms.
+
+---
+
+## 15. 접근성
+
+### 15.1 role / aria
+
+- Root: `role="progressbar"`.
+- `aria-valuemin`: 항상 0.
+- `aria-valuemax`: determinate 이면 `max` (segmented 이면 `segments`), indeterminate 이면 제거(없음).
+- `aria-valuenow`: determinate 이면 `value` (segmented 이면 `filled`), indeterminate 이면 **제거(속성 자체 없음)**. 단, `aria-valuetext` 를 쓰고 싶은 사용자는 Root 에 직접 지정 가능 (passthrough).
+- `aria-label` / `aria-labelledby`: 하나 필수 권장. 없으면 dev warn.
+
+Indeterminate 판정이 `aria-valuenow` 제거 시점의 규칙:
+```ts
+const ariaProps = mode === "determinate"
+  ? { "aria-valuenow": Math.round(percent ?? 0), "aria-valuemin": 0, "aria-valuemax": 100 }
+  : { "aria-valuemin": 0, "aria-valuemax": 100 /* valuenow 없음 */ };
+```
+
+segmented 일 때는 valuemax/valuenow 를 segments/filled 로 덮는다.
+
+### 15.2 aria-live (announce prop)
+
+`announce === true` 이면 Root 에 `aria-live="polite"` + `aria-atomic="true"`. determinate 에서 value 가 바뀌면 스크린리더가 "42 percent" 또는 `aria-valuetext` 를 읽는다.
+
+디폴트 false 인 이유: value 가 잦게(초당 수십 회) 바뀌면 음성이 스팸된다. 사용자가 10% 단위로만 announce 하고 싶다면 외부에서 값을 snap 해서 주입.
+
+### 15.3 숨겨진 value text
+
+labelPlacement === "none" 이어도 `<span class="sr-only">` 로 현재 % 를 읽게 할 수 있다 (옵션). v1 에서는 기본 off — 사용자가 `aria-valuetext` 로 직접 커스터마이즈.
+
+### 15.4 motion-reduce
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .plastic-progress__fill--primary { transition: none; }
+  .plastic-progress[data-mode="indeterminate"] .plastic-progress__fill--primary,
+  .plastic-progress--circular[data-mode="indeterminate"] .plastic-progress__svg,
+  .plastic-progress--circular[data-mode="indeterminate"] .plastic-progress__circle--indicator,
+  .plastic-progress[data-striped="true"][data-animated="true"] .plastic-progress__fill--primary {
+    animation: none !important;
+  }
+}
+```
+
+indeterminate 애니메이션은 motion-reduce 시 완전 정지. "불확정" 은 시각적으로 전혀 표현되지 않지만 `role="progressbar"` 로 보조공학은 여전히 인식. (대안: 천천히 움직이는 opacity pulse. v1.1.)
+
+### 15.5 색맹
+
+variant 색 구분이 색각 이상자에게 잘 구분되지 않을 수 있다. 완화책:
+- success/error 에 아이콘 prefix 를 Label 안에 같이 넣기는 사용자 책임 (Progress 는 색만 제공).
+- 사용자가 색을 override 하려면 CSS 변수 `--plastic-progress-fill` 로.
+
+---
+
+## 16. 알려진 트레이드오프 · 결정
+
+1. **Stepper 와 segmented 의 경계**
+   - Stepper: "클릭 가능한 단계 라벨 + 각 단계의 콘텐츠(패널)". 복잡한 UX(다음/이전, 완료, 스킵 허용 여부) 가 있다.
+   - Progress.segmented: "라벨·클릭 없는 순수 시각적 n 분할 바". Quiz 10 문제 중 3 진척 등.
+   - 경계: "사용자가 클릭하거나, 각 단계에 다른 내용이 있다면 Stepper. 단순히 n 분의 m 을 보여주기만 한다면 Progress.segmented." 이 규칙을 README 에 명시.
+   - 동일 스타일 공유가 합리적이지만 v1 에선 팔레트만 공유하고 DOM 은 독립. Stepper 내부가 Progress 를 사용하도록 리팩터하면 cyclic 의존 위험 → v1.1 이후 고려.
+
+2. **Circular buffer 제외**
+   - SVG 2 중 호(outer + inner) 나 2 radius 겹침으로 구현 가능하지만, 시각 패턴이 덜 보편적 + 접근성(두 값 동시 읽기) 설계가 추가 필요. v1.1.
+
+3. **shape prop vs 분리 컴포넌트 (LinearProgress/CircularProgress)**
+   - MUI 는 분리, Ant 는 통합. plastic 은 **통합** 선택.
+   - 이유: prop 표 일원화 + TreeShake 는 dead code elimination 이 SVG 경로를 드롭해 줌. 사용자 학습 비용 감소.
+   - 단점: 번들에 두 shape 가 모두 포함 → SVG 경로 사용 안 하는 앱은 소폭 낭비. 측정 (≈0.5 KB). 허용.
+
+4. **width 대신 transform scaleX**
+   - transform 은 `transform-origin: left` 로 축 기준 확장. width 는 레이아웃을 바꾸지만 transform 은 paint 만. 60 fps 유리.
+   - 단점: scaleX 는 자식 콘텐츠(inside label "42%") 를 왜곡. 해결: primary fill 안에 자식(value text) 을 넣되 **자식은 역 scaleX 보정** 또는 primary fill 내부 absolute 자식 없이 value text 를 track 오버레이로 분리.
+   - v1 결정: value text 를 primary fill 의 **자식이 아닌** track 오버레이 absolute positioned 로 두고, 자체 `calc(100% * var(--p))` 위치로 이동. 이 방식이 왜곡 없음.
+
+5. **indeterminate 시 aria-valuenow 제거**
+   - WAI-ARIA 명세: indeterminate progressbar 는 `aria-valuenow` 를 쓰지 말라. MUI/Radix 가 준수. plastic 도 동일.
+
+6. **announce 기본 false**
+   - 값 변경 잦은 경우 스팸 방지. 사용자가 explicit 하게 켜야 함.
+
+7. **segments 최소값 2**
+   - segments=1 은 "하나의 셀" 이므로 단순 bar 와 구분 없음 → warn + 2.
+   - 상한 없음 (사용자 정의). 단 10 초과는 시각적으로 쓸모없어진다는 것을 문서화.
+
+8. **buffer 가 value 보다 작을 때**
+   - 의미적으로 이상하지만 (예: 다운로드 된 양이 재생된 양보다 적을 수는 없음), 렌더는 그대로. buffer fill 이 primary 보다 좁아지며 뒤에 가려짐. dev warn 만.
+
+9. **비상호작용 — Slider 와 구분**
+   - Progress 는 값 변경 X. 값 변경 UI 는 Slider(별도 컴포넌트, v 다음)  책임.
+   - 현재 plastic 에는 Slider 없음 — Progress 로 "드래그 가능한 진행바" 를 시도하는 사용자가 있을 수 있으나 Progress 는 의도적으로 거부.
+
+10. **CSS 파일 번들 포함**
+    - plastic 은 tsup 빌드. 현재 컴포넌트들은 inline style 위주로 CSS 파일 필요가 적었다. Progress 는 @keyframes 가 필수 → `Progress.css` 를 `ProgressRoot` 최상단에서 `import "./Progress.css"` 로 로드.
+    - tsup 기본 설정이 CSS 번들을 처리하도록 `loader: { '.css': 'css' }` 또는 `esbuildOptions` 조정이 필요할 수 있음. 현재 레포 설정 확인 후, 필요 시 Progress.css 내용을 `<style>` 태그로 Root 가 1 회만 주입하는 fallback 도 검토 (§19 참조).
+
+11. **styled-components / emotion 미사용**
+    - 런타임 제로 원칙. CSS 파일 + 인라인 변수 조합.
+
+12. **ValueText 가 children 과 중복 가능**
+    - `<Progress shape="circular" value={72}>72%</Progress>` 는 children 을 중앙에 렌더.
+    - `<Progress shape="circular" value={72} />` + `<Progress.ValueText />` 는 포매터 사용.
+    - 둘 다 사용하면 children 우선.
+
+---
+
+## 17. 후속 작업 (v1.1+)
+
+- **Uploader preset**: 파일 여러 개에 대한 Progress 리스트 + 취소/재시도 버튼 조합. `Progress` 를 primitive 로 하는 helper 컴포넌트.
+- **멀티파트 dash**: `Progress.Indicator` 를 여러 개 나열해 "0~30% 성공, 30~60% 스킵, 60~100% 대기" 같은 다중 세그먼트. Linear 전용 확장.
+- **원형 그라데이션**: Circular 에 `linearGradient` 를 넣어 호를 색 그라데이션으로. `<linearGradient id="plastic-progress-gradient" />` 를 defs 에 넣고 `stroke="url(#plastic-progress-gradient)"` 로 참조.
+- **Dashboard gauge** (3/4 원): Ant `type="dashboard"` 상응. `arcAngle={270}` prop.
+- **Animated value counting**: value 42→75 로 바뀔 때 내부 숫자가 흐르게 보이는 옵션. `numberTransition` prop.
+- **aria-valuetext 커스터마이저**: 스크린리더용 텍스트 포맷터 (`ariaValueText(v, max)`).
+- **motion-reduce pulse fallback**: indeterminate 애니메이션을 단순 opacity pulse 로 대체.
+- **Stepper 리팩터**: Stepper 의 세퍼레이터/진행 시각을 Progress.segmented primitive 로 내부 위임. 공통 스타일 토큰 공유.
+- **Circular buffer**: 2 중 호.
+- **Stripe 속도 prop**: `stripesSpeed: number` (기본 1s).
+- **Server-rendered**: determinate SVG 는 SSR 안전. indeterminate 도 CSS 애니메이션이라 SSR 안전. 명시적 테스트 + 문서 필요.
+
+---
+
+## 18. 관련 파일 인벤토리 (구현 시 참조)
+
+| 용도 | 경로 |
+|---|---|
+| controlled/uncontrolled 훅 | `/Users/neo/workspace/plastic/src/components/_shared/useControllable.ts` |
+| 단계-기반 진행의 boundary (라벨/콘텐츠 있는 진행) | `/Users/neo/workspace/plastic/src/components/Stepper/` |
+| 컴포넌트 배럴 등록 | `/Users/neo/workspace/plastic/src/components/index.ts` |
+| 데모 App 라우팅 / NAV | `/Users/neo/workspace/plastic/demo/src/App.tsx` |
+| 데모 페이지 레이아웃 템플릿 (최신) | `/Users/neo/workspace/plastic/demo/src/pages/CommandPalettePage.tsx` |
+| tsconfig 제약 | `/Users/neo/workspace/plastic/tsconfig.json` |
+| 이전 plan 포맷 (구조·톤 레퍼런스) | `/Users/neo/workspace/plastic/docs/plans/017-splitpane-component.md` |
+
+---
+
+## 19. 의존성 영향
+
+신규 런타임 의존 없음. React 18.3 (기존) + DOM/SVG + CSS `@keyframes` 만 사용.
+
+번들 영향:
+- Progress 자체 예상 크기: JS ~2.0 KB (min) / ~0.9 KB (min+gzip) + CSS ~1.2 KB (min) / ~0.5 KB (min+gzip).
+- plastic 전체 dist 영향 미미.
+
+CSS 파일 처리:
+- 현재 레포는 대부분 inline style. tsup 설정이 CSS import 를 어떻게 처리하는지 검토 필요.
+- 방안 A: `tsup.config.ts` 에 `loader: { '.css': 'copy' }` 추가하여 `dist/Progress.css` 로 내보내고 사용자에게 `import "plastic/dist/Progress.css"` 안내.
+- 방안 B: CSS 문자열을 상수로 export 하고 Root 가 최초 마운트 시 `<style data-plastic-progress />` 를 `document.head` 에 1 회 주입. 런타임 주입이므로 SSR 환경에선 hydration 충돌 가능 — useLayoutEffect + `typeof document !== "undefined"` 가드.
+- **v1 권장**: 방안 B (self-contained). 플러그 앤 플레이. 성능 이슈 없으며 라이브러리의 "런타임 제로 설치" 원칙과 잘 어울림. 중복 주입은 `data-plastic-progress="injected"` 마커로 1 회만.
+
+Browser 지원:
+- CSS `@keyframes`, `transform`, `stroke-dasharray`: IE10 이상 (이미 모던만 지원 중이므로 OK).
+- `prefers-reduced-motion`: Chrome 74+, Safari 10.1+, FF 63+.
+
+---
+
+## 20. 구현 완료 정의 (Definition of Done)
+
+- [ ] `npm run typecheck` 통과.
+- [ ] `npx tsup` 통과 (타입 선언 포함).
+- [ ] demo 에 `/#/progress` (또는 현재 라우팅 방식) 로 `ProgressPage` 접근 가능.
+- [ ] §13.2 수동 체크리스트 항목 전부 눈으로 확인.
+- [ ] §13.3 엣지 케이스 항목 전부 눈으로 확인 또는 "v1 범위 밖" 이유 기재.
+- [ ] 기존 페이지 (Button/Card/CodeView/Actionable/PathInput/Toast/Dialog/Tooltip/DataTable/Stepper/CommandPalette/HexView/PipelineGraph) 리그레션 없음.
+- [ ] `src/components/index.ts` 배럴에 `export * from "./Progress";` 추가됨.
+- [ ] `package.json` dependencies 변경 없음.
+- [ ] Props 문서 섹션이 표로 채워져 있음 (Progress 단축 / Root / Track / Indicator / Label / ValueText 여섯).
+- [ ] Usage 섹션에 최소 4 개 스니펫 (업로드 / Circular indeterminate / Quiz segmented / 버퍼 비디오).
+- [ ] 데모 Playground 에서 모든 prop 토글 가능.
+- [ ] Light/Dark 테마 전환 시 시각 이상 없음.
+- [ ] indeterminate 상태에서 `aria-valuenow` 가 DOM 에 존재하지 않음 (DevTools Elements 탭 확인).
+- [ ] determinate 상태에서 `aria-valuenow` = `Math.round(percent)` 정확.
+- [ ] segmented 상태에서 `aria-valuemax` = segments, `aria-valuenow` = filled.
+- [ ] `announce` 활성 시 스크린리더(VoiceOver) 에서 value 변경 announcement 가청.
+- [ ] `prefers-reduced-motion: reduce` 환경에서 indeterminate 애니메이션이 정지.
+- [ ] 모든 @keyframes 가 단일 CSS 번들/style 주입으로 1 회만 정의 (중복 없음).
+- [ ] CSS 변수 `--plastic-progress-fill` 를 사용자가 override 하여 커스텀 색 적용 가능함을 예시 및 확인.
+
+---
+
+**끝.**

--- a/docs/plans/021-skeleton-component.md
+++ b/docs/plans/021-skeleton-component.md
@@ -1,0 +1,1432 @@
+# Skeleton 컴포넌트 설계문서
+
+## Context
+
+plastic 라이브러리에 "로딩 중임을 나타내는 회색 플레이스홀더" `Skeleton` 컴포넌트를 추가한다. 역할 비유: YouTube/Facebook 피드가 데이터 fetch 전에 보여주는 회색 가상의 카드, GitHub 파일트리가 로딩 시 보여주는 줄무늬, macOS Finder 의 썸네일 로딩 전 회색 칸. 전통적인 Spinner 와 달리 "실제 레이아웃과 동일한 자리를 미리 차지" 함으로써 콘텐츠가 로드될 때 페이지가 튀지 않도록(layout shift 방지) 돕는 UX 프리미티브다. plastic 의 다른 컴포넌트(`Card`, `DataTable`, `CommandPalette` 비동기 모드 등)가 로딩 상태에서 각자 별도 인라인 플레이스홀더를 그리고 있는 현재 상태를, 공통 `Skeleton` 로 흡수하여 시각 일관성을 확보하는 것이 1차 목적이다.
+
+참고 (prior art — UX 근거):
+- **Ant Design `Skeleton`** — `Skeleton.Input`, `Skeleton.Avatar`, `Skeleton.Image`, `Skeleton.Button`, `Skeleton` (paragraph+title+avatar 조합). `active` prop 으로 shimmer 애니메이션 on/off.
+- **MUI `Skeleton`** — `variant="text" | "circular" | "rectangular" | "rounded"`, `animation="pulse" | "wave" | false`, `width/height` 자유, 텍스트 variant 는 자동으로 적절한 높이 계산.
+- **Chakra UI `Skeleton`, `SkeletonText`, `SkeletonCircle`** — `isLoaded` prop 으로 swap, fade-in 내장.
+- **react-content-loader** — SVG path 자유 지정형. v1 범위 밖 (§17 SVG editor preset 후보).
+- **Shopify Polaris `SkeletonBodyText`, `SkeletonDisplayText`, `SkeletonThumbnail`** — 프리셋 네이밍 참고.
+- **VSCode Explorer 로딩** — 줄별 랜덤 길이(60~95%) shimmer. "실제 파일명처럼 보이는 리얼리즘" 이 핵심.
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/Card/` — `Skeleton.Card` 프리셋이 흉내낼 레이아웃(헤더/바디/푸터 3단). media 영역이 있는 카드는 별도 프리셋 옵션(§9).
+- `src/components/DataTable/` — `DataTableLoading.tsx` 가 이미 존재; row skeleton 을 추출·일반화하여 `Skeleton.Table` 로 흡수할 여지(§17 후속 리팩터링).
+- `src/components/CommandPalette/` — 비동기 `items` 로딩 시 현재는 단순 텍스트 `"Loading..."`. `Skeleton.Text lines=3` 으로 대체 가능(후속).
+- `src/components/index.ts` — 배럴 등록 지점.
+- `demo/src/App.tsx` — NAV 추가 지점.
+- `demo/src/pages/CommandPalettePage.tsx` — 데모 페이지 관례(섹션/사이드바) 참조 템플릿.
+- `tsconfig.json` — `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax`, `strict` 제약.
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+// 1. 단일 모양 (헤드리스 프리미티브)
+<Skeleton.Root shape="rect" width={240} height={16} animation="shimmer" />
+<Skeleton.Root shape="circle" size={40} />
+<Skeleton.Root shape="text" width="80%" />
+
+// 2. 텍스트 프리셋 — N 라인, 마지막 줄만 짧게(리얼리즘)
+<Skeleton.Text lines={3} />
+
+// 3. 아바타 프리셋
+<Skeleton.Avatar shape="circle" size={40} />
+<Skeleton.Avatar shape="rounded" size={56} />
+
+// 4. 카드 프리셋
+<Skeleton.Card hasMedia mediaHeight={140} lines={2} />
+
+// 5. 테이블 프리셋
+<Skeleton.Table rows={5} cols={4} />
+
+// 6. 실제 컨텐츠 ↔ 스켈레톤 swap (fade)
+<Skeleton.Root visible={!user} shape="text" width={120}>
+  {user?.name}
+</Skeleton.Root>
+```
+
+렌더 결과 (개념 — `Skeleton.Card hasMedia lines={2}`):
+```
+┌──────────────────────────────────┐
+│ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ │  ← media (140px)
+│ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ │
+├──────────────────────────────────┤
+│ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓          │  ← title line (full width)
+│ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓           │  ← text line 1 (~85%)
+│ ▓▓▓▓▓▓▓▓▓▓▓▓                 │  ← text line 2 (~62%, 마지막 짧게)
+└──────────────────────────────────┘
+```
+
+핵심 설계 원칙:
+- **compound 컴포넌트**. `Skeleton.Root` (원자) + `Skeleton.Text` / `Skeleton.Avatar` / `Skeleton.Card` / `Skeleton.Table` (프리셋). 프리셋은 내부에서 `Root` 를 조합한다 — layered 설계로 사용자는 원자 단위에서도 고수준에서도 사용 가능.
+- **runtime-zero**. CSS keyframes + DOM 만 사용. React state 는 `visible` swap 에만.
+- **pulse vs shimmer 기본값**: `animation="shimmer"` 가 기본. `"pulse"` 와 `false` (=no-animation) 도 지원.
+- **prefers-reduced-motion 자동 감지**: 유저 OS 설정이 "동작 감소" 면 `false` 로 downgrade. prop 이 명시적 `"pulse"`/`"shimmer"` 여도 감지 결과가 우선.
+- **swap (visible) API**: `visible={false}` 이면 스켈레톤 대신 `children` 을 180 ms fade 로 교체. 기본 180 ms.
+- **hydration-safe 랜덤**: `Skeleton.Text` 의 각 줄 width 를 "랜덤처럼 자연스럽게" 그리되 SSR mismatch 방지를 위해 **고정 시드 의사랜덤** 사용. 줄 index → width 매핑이 결정적.
+- **headless 정신**: 모든 색/테두리/radius 를 CSS variable 로 export. 사용자는 `style`/`className` 으로 덮어쓸 수 있다.
+- **accessibility**: `role="status"` + `aria-busy="true"` + `aria-label="Loading"`. Swap 후 실제 콘텐츠 렌더 시 `aria-busy` 는 자동 해제.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. 3 가지 기본 shape: `text` (한 줄 높이), `rect` (사각 블록, radius 4), `circle` (원형).
+2. 2 가지 애니메이션 + off: `shimmer` (좌→우 그라디언트 이동), `pulse` (opacity 0.6→1.0 반복), `false`.
+3. `prefers-reduced-motion: reduce` 미디어 쿼리 감지 → 애니메이션 자동 off.
+4. Light / Dark 테마 (`theme="light" | "dark"`). palette 는 `Skeleton/theme.ts` 로 집중.
+5. `width`, `height`, `size` (circle), `borderRadius` 직접 지정 가능.
+6. 프리셋 4종:
+   - `Skeleton.Text` — N 줄 텍스트 시뮬레이션. `lines`, `lastLineWidth`, `gap`, `randomize`.
+   - `Skeleton.Avatar` — `shape` (circle/rounded/square), `size`.
+   - `Skeleton.Card` — 헤더/media/body/푸터 조합. `hasMedia`, `mediaHeight`, `lines`, `hasFooter`.
+   - `Skeleton.Table` — `rows`, `cols`, `rowHeight`, `colWidths`.
+7. `visible` swap API: `true` 면 스켈레톤 표시, `false` 면 children 렌더 (둘은 상호배타). 전환 시 180 ms fade.
+8. 접근성: `role="status"`, `aria-busy`, `aria-label`.
+9. SSR-safe: `randomize` 의 width 배열이 서버/클라이언트 동일(고정 시드).
+10. 배럴 + namespace API: `export const Skeleton = { Root, Text, Avatar, Card, Table };`.
+
+### Non-goals (v1 제외)
+- **SVG path 자유 지정형** (react-content-loader 식). `Skeleton.Svg path={...}` 는 v1.1.
+- **이미지 blurhash / LQIP 통합**: v1 은 순수 회색 블록만. blurhash 플레이스홀더는 v1.2.
+- **자동 사이즈 추출** (`Skeleton.Mimic ref={realEl}`): 실제 요소를 측정해 동일 dimension 으로 복제하는 기능. v1 에서는 user 가 수동 지정. v1.2.
+- **데이터 페처 통합**: `<Skeleton.Query query={...} />` 같은 data-layer 통합 없음. `visible` prop 만.
+- **스토리 북 / 인터랙션 테스트**: plastic 전체에 없음.
+- **리스트 infinite loading sentinel**: v1 범위 밖.
+- **progress-aware 스켈레톤**: 로드 % 에 따라 밝아지는 변형. v1 없음.
+- **animated placeholder text ("ghost typing")**: v1 없음.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Skeleton/Skeleton.types.ts`
+
+```ts
+export type SkeletonTheme = "light" | "dark";
+
+/**
+ * 기본 shape.
+ * - "text":   한 줄 텍스트 높이(기본 1em). border-radius 4. 세로 여백 0.
+ * - "rect":   사각 블록. border-radius 4.
+ * - "circle": 원형. width=height=size. border-radius 50%.
+ */
+export type SkeletonShape = "text" | "rect" | "circle";
+
+/**
+ * 애니메이션 모드.
+ * - "shimmer": 좌→우 그라디언트 스윕 (기본).
+ * - "pulse":   opacity 0.6 ↔ 1.0 반복.
+ * - false:     애니메이션 없음.
+ *
+ * 사용자가 "shimmer" 를 명시해도 prefers-reduced-motion: reduce 면 false 로 downgrade.
+ */
+export type SkeletonAnimation = "shimmer" | "pulse" | false;
+
+/** Size 단위 — number 는 px, string 은 CSS 길이 그대로 passthrough (e.g. "80%", "2rem"). */
+export type SkeletonSize = number | string;
+
+export interface SkeletonRootProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "children"> {
+  /** 기본 "rect". */
+  shape?: SkeletonShape;
+  /** 애니메이션. 기본 "shimmer". false 로 완전 off. */
+  animation?: SkeletonAnimation;
+  /** 너비. shape="circle" 면 무시(size 사용). 기본: shape=="text" 이면 "100%", 그 외 필수. */
+  width?: SkeletonSize;
+  /** 높이. shape="text" 면 기본 "1em". shape="circle" 면 무시. shape="rect" 면 필수. */
+  height?: SkeletonSize;
+  /** circle 전용. width=height=size 로 매핑. 기본 40. */
+  size?: SkeletonSize;
+  /** border-radius override. 기본: text/rect=4, circle=50%. */
+  borderRadius?: SkeletonSize;
+  /** 테마. 기본 "light". */
+  theme?: SkeletonTheme;
+  /**
+   * 스켈레톤 표시 여부 제어.
+   * - true (기본): 스켈레톤 렌더.
+   * - false: children 렌더 (fade-in). children 없으면 null.
+   */
+  visible?: boolean;
+  /** swap 페이드 ms. 기본 180. 0 이면 애니 없이 즉시 교체. */
+  fadeMs?: number;
+  /** swap 대상 실제 콘텐츠. visible=false 시 노출. */
+  children?: React.ReactNode;
+  /** 접근성 라벨. 기본 "Loading". */
+  "aria-label"?: string;
+}
+
+export interface SkeletonTextProps {
+  /** 기본 3. */
+  lines?: number;
+  /** 마지막 줄 폭(비율 or size). 기본 "60%". null 이면 풀폭. */
+  lastLineWidth?: SkeletonSize | null;
+  /** 줄 간 세로 간격(px). 기본 8. */
+  gap?: number;
+  /** 각 줄 폭을 자연스러운 랜덤처럼 변주할지. 기본 true. SSR-safe (고정 시드). */
+  randomize?: boolean;
+  /** 줄 높이. 기본 "1em" (text shape 기본값 따라감). */
+  lineHeight?: SkeletonSize;
+  /** 각 줄 폭 범위(randomize=true 일 때). 기본 [0.75, 0.95]. */
+  widthRange?: [number, number];
+  /** 랜덤 시드. 기본 1. 같은 페이지에서 서로 다른 시드로 서로 다른 패턴 원할 때만. */
+  seed?: number;
+  /** animation / theme / visible / className / style 등은 Root 와 동일. */
+  animation?: SkeletonAnimation;
+  theme?: SkeletonTheme;
+  visible?: boolean;
+  fadeMs?: number;
+  children?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+  "aria-label"?: string;
+}
+
+export interface SkeletonAvatarProps {
+  /** 기본 "circle". */
+  shape?: "circle" | "rounded" | "square";
+  /** 한 변 길이. 기본 40. */
+  size?: SkeletonSize;
+  animation?: SkeletonAnimation;
+  theme?: SkeletonTheme;
+  visible?: boolean;
+  fadeMs?: number;
+  children?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+  "aria-label"?: string;
+}
+
+export interface SkeletonCardProps {
+  /** media 영역 표시 여부. 기본 false. */
+  hasMedia?: boolean;
+  /** media 높이 px. 기본 160. */
+  mediaHeight?: SkeletonSize;
+  /** title 표시 여부. 기본 true. */
+  hasTitle?: boolean;
+  /** body 줄 수. 기본 2. */
+  lines?: number;
+  /** footer (action row) 표시 여부. 기본 false. */
+  hasFooter?: boolean;
+  /** avatar 왼쪽에 포함 (헤더 스타일). 기본 false. */
+  hasAvatar?: boolean;
+  /** 카드 폭. 기본 "100%". */
+  width?: SkeletonSize;
+  /** 내부 패딩 px. 기본 16. */
+  padding?: number;
+  animation?: SkeletonAnimation;
+  theme?: SkeletonTheme;
+  visible?: boolean;
+  fadeMs?: number;
+  children?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+  "aria-label"?: string;
+}
+
+export interface SkeletonTableProps {
+  /** 기본 5. */
+  rows?: number;
+  /** 기본 4. */
+  cols?: number;
+  /** 헤더 row 포함. 기본 true. */
+  hasHeader?: boolean;
+  /** row 높이 px. 기본 44. */
+  rowHeight?: SkeletonSize;
+  /** 컬럼별 폭 배열. 길이가 cols 와 맞지 않으면 균등 분배. */
+  colWidths?: SkeletonSize[];
+  animation?: SkeletonAnimation;
+  theme?: SkeletonTheme;
+  visible?: boolean;
+  fadeMs?: number;
+  children?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+  "aria-label"?: string;
+}
+```
+
+### 2.2 배럴
+
+```ts
+// src/components/Skeleton/index.ts
+export { Skeleton } from "./Skeleton";
+export type {
+  SkeletonRootProps,
+  SkeletonTextProps,
+  SkeletonAvatarProps,
+  SkeletonCardProps,
+  SkeletonTableProps,
+  SkeletonShape,
+  SkeletonAnimation,
+  SkeletonSize,
+  SkeletonTheme,
+} from "./Skeleton.types";
+```
+
+그리고 `src/components/index.ts` 에 `export * from "./Skeleton";` 한 줄 추가.
+
+### 2.3 Compound namespace
+
+```ts
+// Skeleton.tsx
+export const Skeleton = {
+  Root: SkeletonRoot,
+  Text: SkeletonText,
+  Avatar: SkeletonAvatar,
+  Card: SkeletonCard,
+  Table: SkeletonTable,
+};
+```
+
+displayName: `"Skeleton.Root"`, `"Skeleton.Text"`, `"Skeleton.Avatar"`, `"Skeleton.Card"`, `"Skeleton.Table"`.
+
+### 2.4 사용 예 (최소 스니펫)
+
+```tsx
+// 원자
+<Skeleton.Root shape="rect" width={200} height={14} />
+
+// 프리셋
+<Skeleton.Text lines={4} />
+<Skeleton.Avatar size={56} />
+<Skeleton.Card hasMedia hasFooter lines={3} />
+<Skeleton.Table rows={8} cols={5} />
+
+// Swap
+{users.map((user) => (
+  <Skeleton.Root key={user.id} visible={!user.hydrated} shape="text" width={120}>
+    {user.name}
+  </Skeleton.Root>
+))}
+```
+
+---
+
+## 3. 도메인 모델
+
+### 3.1 shape ↔ width/height 계산
+
+| shape | width | height | borderRadius |
+|---|---|---|---|
+| `text` | prop 지정. 기본 `"100%"`. | prop 지정. 기본 `"1em"`. | prop 지정. 기본 `4`. |
+| `rect` | prop 지정. **필수** (런타임 체크 X, TS 타입은 optional). 누락 시 `"100%"` fallback + dev warn. | prop 지정. **필수**. 누락 시 `16` fallback + dev warn. | 기본 `4`. |
+| `circle` | `size` 로부터 유도 (기본 40). width/height prop 은 무시 + dev warn. | 동일. | 기본 `"50%"`. |
+
+런타임 정규화:
+```ts
+// Skeleton.utils.ts
+export function resolveDimensions(props: SkeletonRootProps): {
+  width: string; height: string; borderRadius: string;
+} {
+  const shape = props.shape ?? "rect";
+  if (shape === "circle") {
+    const s = props.size ?? 40;
+    const px = toCssLength(s);
+    return { width: px, height: px, borderRadius: toCssLength(props.borderRadius ?? "50%") };
+  }
+  if (shape === "text") {
+    return {
+      width: toCssLength(props.width ?? "100%"),
+      height: toCssLength(props.height ?? "1em"),
+      borderRadius: toCssLength(props.borderRadius ?? 4),
+    };
+  }
+  // rect
+  if (import.meta.env?.DEV) {
+    if (props.width === undefined) console.warn("[Skeleton] shape='rect' requires width. Falling back to '100%'.");
+    if (props.height === undefined) console.warn("[Skeleton] shape='rect' requires height. Falling back to 16.");
+  }
+  return {
+    width: toCssLength(props.width ?? "100%"),
+    height: toCssLength(props.height ?? 16),
+    borderRadius: toCssLength(props.borderRadius ?? 4),
+  };
+}
+
+export function toCssLength(v: SkeletonSize): string {
+  return typeof v === "number" ? `${v}px` : v;
+}
+```
+
+### 3.2 Text 라인 폭 — 고정 시드 의사랜덤
+
+```ts
+/**
+ * SSR 안전한 결정적 의사랜덤 (Mulberry32).
+ * 같은 seed + index 는 항상 같은 값 → hydration mismatch 방지.
+ */
+export function seededRandom(seed: number, index: number): number {
+  let t = (seed + index * 0x6d2b79f5) >>> 0;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+
+export function computeTextLineWidths(
+  lines: number,
+  range: [number, number],
+  lastLineWidth: SkeletonSize | null | undefined,
+  randomize: boolean,
+  seed: number,
+): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < lines; i++) {
+    const isLast = i === lines - 1;
+    if (isLast && lastLineWidth !== null && lastLineWidth !== undefined) {
+      out.push(toCssLength(lastLineWidth));
+      continue;
+    }
+    if (!randomize) {
+      out.push("100%");
+      continue;
+    }
+    const [lo, hi] = range;
+    const pct = lo + (hi - lo) * seededRandom(seed, i);
+    out.push(`${(pct * 100).toFixed(1)}%`);
+  }
+  return out;
+}
+```
+
+정책:
+- `randomize=false` 면 모든 줄 100% (마지막 줄만 lastLineWidth 적용).
+- `randomize=true` + `lastLineWidth="60%"` 가 기본: 0~N-2 번째 줄은 75~95% 사이 결정적 변주, 마지막 줄은 60%.
+- `lastLineWidth={null}` 명시 시 마지막 줄도 randomize 에 포함.
+- seed 는 기본 1. 페이지 내 여러 `Skeleton.Text` 가 완전히 같은 패턴을 보이면 부자연스러우므로, 사용자는 서로 다른 seed 를 줄 수 있다. 다만 **같은 seed 는 항상 같은 결과** 라는 계약이 SSR 계약.
+
+### 3.3 Table 컬럼 폭 분배
+
+```ts
+export function computeTableColWidths(cols: number, overrides: SkeletonSize[] | undefined): string[] {
+  if (overrides && overrides.length === cols) return overrides.map(toCssLength);
+  // 균등 분배. 각 컬럼에 (100/cols)% 씩.
+  const pct = 100 / cols;
+  return Array.from({ length: cols }, () => `${pct.toFixed(4)}%`);
+}
+```
+
+### 3.4 Root Context — **없음**
+
+`Skeleton` 은 상태를 공유할 필요가 없다 (각 인스턴스 독립). 따라서 context 도, provider 도 없다. 단, 프리셋이 Root 에 prop 을 forward 할 때 공통 prop set (`animation`, `theme`, `visible`, `fadeMs`, `aria-label`) 을 **하나의 유틸** 로 추출한다:
+
+```ts
+// Skeleton.utils.ts
+export function extractCommonProps<T extends {
+  animation?: SkeletonAnimation;
+  theme?: SkeletonTheme;
+  visible?: boolean;
+  fadeMs?: number;
+  "aria-label"?: string;
+}>(p: T): Pick<SkeletonRootProps, "animation" | "theme" | "visible" | "fadeMs" | "aria-label"> {
+  return {
+    animation: p.animation,
+    theme: p.theme,
+    visible: p.visible,
+    fadeMs: p.fadeMs,
+    "aria-label": p["aria-label"],
+  };
+}
+```
+
+---
+
+## 4. 시각 / 구조
+
+### 4.1 DOM 구조
+
+**`Skeleton.Root`** (단일 원자):
+```html
+<div
+  role="status"
+  aria-busy="true"
+  aria-label="Loading"
+  class="sk-root sk-root--shimmer sk-root--light"
+  data-shape="rect"
+  style="width: 200px; height: 16px; border-radius: 4px;"
+>
+  <!-- shimmer 일 때 내부 빛 overlay. pulse / false 면 없음. -->
+  <span class="sk-shimmer" aria-hidden="true"></span>
+</div>
+```
+
+**`Skeleton.Text`**:
+```html
+<div role="status" aria-busy="true" aria-label="Loading" class="sk-text" style="display:flex;flex-direction:column;gap:8px">
+  <div class="sk-root sk-root--shimmer sk-root--light" style="width:87.3%; height:1em; border-radius:4px">
+    <span class="sk-shimmer" aria-hidden="true"></span>
+  </div>
+  <div class="sk-root sk-root--shimmer sk-root--light" style="width:91.1%; ..."><span .../></div>
+  <div class="sk-root sk-root--shimmer sk-root--light" style="width:60%; ..."><span .../></div>
+</div>
+```
+
+Text 래퍼는 `role="status"` 가 **한 번만** 오도록(중첩된 individual Root 는 `role` 을 덮지 않는 옵션 내부 prop `_suppressAria`) 처리 — 스크린리더가 각 줄마다 "Loading" 반복하지 않도록.
+
+**`Skeleton.Avatar`** — 단일 Root 의 shape 변환:
+- `shape="circle"` → Root shape=circle.
+- `shape="rounded"` → Root shape=rect + borderRadius=8.
+- `shape="square"` → Root shape=rect + borderRadius=0.
+
+**`Skeleton.Card`**:
+```html
+<div role="status" aria-busy="true" aria-label="Loading" class="sk-card sk-card--light" style="padding:16px;width:100%">
+  {hasMedia && <div class="sk-root sk-root--shimmer" style="height:160px;width:100%;border-radius:8px 8px 0 0" />}
+  {hasAvatar && (
+    <div style="display:flex;gap:12px;align-items:center;margin-top:12px">
+      <div class="sk-root" style="width:40px;height:40px;border-radius:50%"/>
+      <div class="sk-root" style="height:14px;width:40%"/>
+    </div>
+  )}
+  {hasTitle && <div class="sk-root" style="height:20px;width:70%;margin-top:12px"/>}
+  <!-- body lines (Skeleton.Text 재사용) -->
+  <div style="margin-top:12px">
+    <Skeleton.Text lines={lines} {...common} _suppressAria />
+  </div>
+  {hasFooter && (
+    <div style="display:flex;gap:8px;margin-top:16px">
+      <div class="sk-root" style="width:72px;height:28px;border-radius:6px"/>
+      <div class="sk-root" style="width:72px;height:28px;border-radius:6px"/>
+    </div>
+  )}
+</div>
+```
+
+**`Skeleton.Table`**:
+```html
+<div role="status" aria-busy="true" aria-label="Loading" class="sk-table">
+  {hasHeader && (
+    <div class="sk-table-row sk-table-row--header" style="display:flex;gap:12px;height:44px;align-items:center">
+      <div class="sk-root" style="width:25%;height:12px"/> <div class="sk-root" style="width:25%;height:12px"/> ...
+    </div>
+  )}
+  {Array.from({length: rows}).map((_, r) => (
+    <div class="sk-table-row" style="display:flex;gap:12px;height:44px;align-items:center;border-top:1px solid ...">
+      {colWidths.map((w, c) => <div class="sk-root" style={{width: w, height: 14}} />)}
+    </div>
+  ))}
+</div>
+```
+
+### 4.2 Shimmer gradient
+
+```css
+.sk-root {
+  position: relative;
+  display: inline-block;
+  background-color: var(--sk-bg);
+  overflow: hidden;
+  isolation: isolate; /* shimmer overlay 가 바깥 합성에 영향 없음 */
+  line-height: 1;
+}
+.sk-root[data-shape="text"] { display: block; vertical-align: middle; }
+
+.sk-shimmer {
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--sk-shine) 50%,
+    transparent 100%
+  );
+  animation: sk-shimmer 1500ms linear infinite;
+  will-change: transform;
+}
+@keyframes sk-shimmer {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+.sk-root--pulse {
+  animation: sk-pulse 1500ms ease-in-out infinite;
+}
+.sk-root--pulse > .sk-shimmer { display: none; }
+@keyframes sk-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.55; }
+}
+
+.sk-root--none > .sk-shimmer { display: none; }
+.sk-root--none { animation: none; }
+
+/* 시스템 감소 설정 시 무조건 off */
+@media (prefers-reduced-motion: reduce) {
+  .sk-root,
+  .sk-shimmer {
+    animation: none !important;
+  }
+  .sk-shimmer { display: none !important; }
+}
+```
+
+### 4.3 Palette 토큰
+
+```ts
+// Skeleton/theme.ts
+export const skeletonPalette = {
+  light: {
+    bg:      "#e5e7eb",       // gray-200
+    shine:   "rgba(255,255,255,0.7)",
+    border:  "rgba(0,0,0,0.06)",
+    cardBg:  "#ffffff",
+    cardBorder: "rgba(0,0,0,0.08)",
+    rowSep:  "rgba(0,0,0,0.06)",
+  },
+  dark: {
+    bg:      "#334155",       // slate-700
+    shine:   "rgba(255,255,255,0.08)",
+    border:  "rgba(255,255,255,0.06)",
+    cardBg:  "#0f172a",
+    cardBorder: "rgba(255,255,255,0.08)",
+    rowSep:  "rgba(255,255,255,0.06)",
+  },
+} as const;
+```
+
+CSS variable 주입은 Root 요소 인라인 스타일로:
+```ts
+const vars = {
+  "--sk-bg": palette.bg,
+  "--sk-shine": palette.shine,
+} as React.CSSProperties;
+```
+
+### 4.4 이유 — 왜 shimmer overlay 를 `<span>` 자식으로?
+
+대안들:
+1. **`background: linear-gradient` + `background-size: 200%` + `background-position` animation** — 한 요소만 사용. 단점: border-radius=circle 에서 그라디언트가 원 바깥 사각형 기준으로 계산되어 어색. 또한 GPU 레이어가 독립되지 않아 text 스크롤 시 리페인트 비용 올라감.
+2. **`::before` pseudo-element** — DOM 추가 없음. 단점: user 의 `className` 으로 `::before` 를 덮어쓸 경우 충돌.
+3. **inner `<span>`** (선택). 독립 GPU 레이어 + `overflow:hidden` 으로 자연스럽게 mask. `aria-hidden="true"` 로 접근성 안전.
+
+### 4.5 Swap / fade DOM
+
+`visible` 이 `false` 로 전이되면:
+```
+t0:           [skeleton opacity 1]
+t0 ~ fadeMs/2: [skeleton opacity 1 → 0]  (skeleton 여전히 DOM 존재)
+t0+fadeMs/2:  [skeleton unmount, children mount with opacity 0]
+~ fadeMs:     [children opacity 0 → 1]
+```
+
+구현은 간단히:
+```tsx
+{visible ? (
+  <div className="sk-root ..." style={{opacity: visible ? 1 : 0, transition: `opacity ${fadeMs}ms`}}>...</div>
+) : (
+  <div className="sk-content-fadein" style={{animation: `sk-fadein ${fadeMs}ms ease-out`}}>
+    {children}
+  </div>
+)}
+```
+
+그리고:
+```css
+@keyframes sk-fadein { from { opacity: 0 } to { opacity: 1 } }
+```
+
+단, React 가 conditional 로 엘리먼트를 교체하면 skeleton 의 out-transition 을 놓칠 수 있다. v1 은 "mount/unmount 순간 교체 + children 에만 fadein" 으로 단순화 (skeleton 이 사라질 때는 opacity 전이 없음). `fadeMs=0` 이면 fadein 없이 즉시 교체. 자연스러운 two-way crossfade 는 후속 작업(§17).
+
+---
+
+## 5. 핵심 로직
+
+### 5.1 prefers-reduced-motion 감지
+
+```ts
+// Skeleton/useReducedMotion.ts
+import { useEffect, useState } from "react";
+
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(mql.matches);
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
+    // Safari < 14 는 addListener/removeListener
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    }
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
+  }, []);
+
+  return reduced;
+}
+```
+
+Root 내부:
+```ts
+const reduced = useReducedMotion();
+const effectiveAnimation: SkeletonAnimation =
+  reduced ? false : (props.animation ?? "shimmer");
+```
+
+참고: CSS 차원에서도 `@media (prefers-reduced-motion: reduce)` 로 animation 을 강제 off 한다 (4.2 참조) — 이는 React state 로 감지되기 전(첫 페인트) 또는 JS 미실행 환경에서의 fallback.
+
+### 5.2 visible swap 라이프사이클
+
+```ts
+// Skeleton.tsx (Root 내부)
+const [mountedChildren, setMountedChildren] = useState(!visible);
+
+useEffect(() => {
+  if (!visible && !mountedChildren) setMountedChildren(true);
+  if (visible && mountedChildren) setMountedChildren(false);
+}, [visible, mountedChildren]);
+
+return mountedChildren
+  ? <div className="sk-content-fadein" style={fadeStyle}>{children}</div>
+  : <div role="status" aria-busy="true" className={rootClass} style={rootStyle}>
+      <span className="sk-shimmer" aria-hidden="true" />
+    </div>;
+```
+
+(실제 구현은 더 단순; 위는 의사코드.)
+
+`fadeMs=0` 특수 케이스: `sk-content-fadein` 클래스 대신 `undefined` 사용 → 즉시 교체.
+
+### 5.3 animation CSS 모드 스위치
+
+className 조합:
+```ts
+const classes = clsx(
+  "sk-root",
+  `sk-root--${theme ?? "light"}`,
+  effectiveAnimation === "shimmer" && "sk-root--shimmer",
+  effectiveAnimation === "pulse"   && "sk-root--pulse",
+  effectiveAnimation === false     && "sk-root--none",
+  props.className,
+);
+```
+
+`sk-root--shimmer` 자체에는 animation 이 없고, 내부 `sk-shimmer` span 의 animation 을 통제. `sk-root--pulse` 는 자체 animation. `sk-root--none` 은 둘 다 off.
+
+### 5.4 randomize hydration-safe
+
+`computeTextLineWidths` 는 순수 함수 (seed+index → 결정적). SSR 과 CSR 양쪽에서 같은 결과. 단, Math.random() 은 **절대 사용 금지** — hydration mismatch 의 근원.
+
+```ts
+const widths = useMemo(
+  () => computeTextLineWidths(lines, range, lastLineWidth, randomize, seed),
+  [lines, range[0], range[1], lastLineWidth, randomize, seed],
+);
+```
+
+---
+
+## 6. 제약 (엣지 케이스)
+
+### 6.1 width/height 가 0 또는 undefined
+
+- `shape="rect"` + `width`/`height` 누락: §3.1 참조. dev warn + fallback.
+- `width={0}`: CSS 상 invisible 하지만 DOM 은 존재. 접근성 지장 없음.
+- parent 가 `display:none` 등으로 숨겨진 상태에서 마운트: 애니메이션은 GPU 에서 돌아가도 비가시. 디마운트 시 `will-change` 해제.
+
+### 6.2 숨겨진 컨테이너 (display:none)
+
+`display:none` 내부의 Skeleton 은 보이지 않음에도 CSS animation 은 pause 되지 않는다. 단, browser 가 offscreen 요소의 animation 을 throttle 하므로 cost 는 미미. 사용자가 탭 보이기 복귀 시 정상 동작.
+
+### 6.3 매우 큰 수의 row (Table rows >= 1000)
+
+`Skeleton.Table rows={1000}` 은 DOM 1000개 row × cols 개 = 수천 개 skeleton 요소. 60 fps 유지 어려움. v1 은 dev warn `[Skeleton.Table] rows > 200 may cause perf issues; consider virtualization`.
+
+### 6.4 너무 짧은 width (text lines)
+
+`width="2%"` 같은 극단값은 그대로 렌더. 사용자 책임.
+
+### 6.5 animation prop + reduced-motion 충돌
+
+prop 이 `"shimmer"` 이어도 OS 설정이 reduce 면 `false`. 사용자가 "나는 reduce 를 무시하고 싶다" 는 **허용하지 않음** — 접근성 가이드라인 우선. 필요 시 v1.1 에서 `respectReducedMotion?: boolean` 옵트아웃.
+
+### 6.6 0 lines
+
+`Skeleton.Text lines={0}` → 빈 `<div role="status">` 만 렌더. warn 없음 (사용자 의도 있을 수 있음).
+
+### 6.7 visible=false + children 없음
+
+빈 `null` 반환. 접근성 영향 없음.
+
+### 6.8 borderRadius + circle
+
+`shape="circle"` + `borderRadius={4}` → borderRadius 우선. 비원형 "원 모양이 아닌" circle 이 될 수 있다. 사용자 override 존중.
+
+---
+
+## 7. 키보드
+
+Skeleton 은 **비상호작용 컴포넌트** 이다. 기본적으로 포커스 대상이 아니며, `tabindex` 도 설정하지 않는다.
+
+- `children` 이 실제 포커스 가능한 요소(`<button>` 등) 를 포함하는 경우 (`visible=false` 스왑 후), 그 요소의 기본 포커스 동작을 따름. Skeleton 은 개입 없음.
+- 포커스 트랩 없음.
+- keyboard shortcut 없음.
+
+단, `role="status"` 는 aria-live region 으로 스크린리더가 자동 announce 한다 → 로딩 시작/종료가 들린다.
+
+---
+
+## 8. 상태 관리
+
+### 8.1 visible swap
+
+`visible` 은 controlled prop (기본 `true`). `undefined` 이면 `true` 취급 → skeleton 표시.
+
+```ts
+const visible = props.visible ?? true;
+```
+
+swap 시점:
+- `visible: true → false`: skeleton 즉시 unmount, `children` 이 `sk-content-fadein` 애니메이션과 함께 mount.
+- `visible: false → true`: children unmount, skeleton mount (fade-in 없음, 즉시).
+
+양방향 crossfade 는 구현 복잡도 상승(두 요소 동시 mount + absolute overlay) 이므로 v1 제외. 일방향 fade 만.
+
+### 8.2 skeleton 내부 state
+
+- **없음**. `Skeleton.Root` 는 state-less. 애니메이션은 CSS keyframes.
+- `useReducedMotion()` 훅 하나만 state 보유.
+- `Skeleton.Text` 의 `widths` 는 `useMemo` 결과 (state 아님).
+
+### 8.3 fade 지속 시간 관리
+
+`fadeMs` 는 단순 CSS `animation-duration` 으로 inline 주입:
+```tsx
+<div style={{animationDuration: `${fadeMs}ms`}} className="sk-content-fadein">
+  {children}
+</div>
+```
+
+별도 setTimeout 불필요.
+
+### 8.4 children 이 `<Suspense>` 안에 있을 때
+
+`<Skeleton.Root visible={false}><SuspendedData/></Skeleton.Root>`.  
+Suspense 경계가 Skeleton 을 먹지 않음(Skeleton 이 바깥). 이 경우 Skeleton 은 단순 plain fallback 로 기능하지 않는다 — Suspense fallback 은 별도. 사용자가 직접 `<Suspense fallback={<Skeleton.Card/>}>...</Suspense>` 패턴으로 써야 함. Usage 예제(§12)에서 언급.
+
+---
+
+## 9. 프리셋
+
+### 9.1 Skeleton.Text
+
+기본값:
+```ts
+lines = 3
+lastLineWidth = "60%"
+gap = 8
+randomize = true
+widthRange = [0.75, 0.95]
+seed = 1
+lineHeight = "1em"
+```
+
+리얼리즘의 핵심:
+- 줄 개수 3 이 가장 "댓글/본문" 느낌.
+- 마지막 줄 짧게(60%) + 앞줄들은 87~93% 랜덤 → 실제 문단처럼 보임.
+- `randomize=false` 는 "의도적으로 정형화된 모양" 원할 때 (폼 라벨 등).
+
+### 9.2 Skeleton.Avatar
+
+기본값:
+```ts
+shape = "circle"
+size = 40
+```
+
+`shape="rounded"` 는 borderRadius=8. 앱 아이콘 스타일(iOS).  
+`shape="square"` 는 borderRadius=0. 거의 쓰이지 않지만 완전성 위해 제공.
+
+### 9.3 Skeleton.Card
+
+기본값:
+```ts
+hasMedia = false
+mediaHeight = 160
+hasTitle = true
+lines = 2
+hasFooter = false
+hasAvatar = false
+width = "100%"
+padding = 16
+```
+
+조합 예시:
+- **단순 블로그 카드**: `<Skeleton.Card hasMedia lines={3} />`
+- **아바타가 있는 댓글**: `<Skeleton.Card hasAvatar lines={2} />` (이 경우 title 은 자동 숨김 권장 — dev warn `hasAvatar+hasTitle 동시 사용 시 UX 어색`; 허용은 함)
+- **액션 버튼 포함**: `<Skeleton.Card hasMedia hasFooter lines={2} />`
+
+### 9.4 Skeleton.Table
+
+기본값:
+```ts
+rows = 5
+cols = 4
+hasHeader = true
+rowHeight = 44
+colWidths = undefined  // 균등 분배
+```
+
+`rows * cols` 개의 개별 Skeleton 을 렌더. perf 체크(§6.3). 내부적으로 모두 `_suppressAria` 로 개별 role 제거, 최상위만 `role="status"`.
+
+### 9.5 DataTable 과의 관계
+
+`src/components/DataTable/DataTableLoading.tsx` 는 현재 자체 skeleton 로직 보유. v1 에서는 **DataTable 을 손대지 않는다** (다른 agent 작업 충돌 회피). 후속 PR 에서 `Skeleton.Table` 로 교체 (§17).
+
+### 9.6 Card 와의 관계
+
+`src/components/Card/` 의 실제 컴포넌트와 레이아웃을 모방. padding=16, radius=8, 그림자는 skeleton 에선 제외(로딩 중임을 명확히). 실제 Card 와 1:1 대응을 원한다면 v1.1 에서 `mimicCard` 옵션.
+
+---
+
+## 10. 파일 구조
+
+```
+src/components/Skeleton/
+├── Skeleton.tsx              # Root + Text + Avatar + Card + Table + namespace
+├── Skeleton.types.ts         # 공개 타입
+├── Skeleton.utils.ts         # resolveDimensions, seededRandom, computeTextLineWidths 등
+├── Skeleton.css              # keyframes + .sk-root / .sk-shimmer / fadein
+├── theme.ts                  # skeletonPalette
+├── useReducedMotion.ts       # prefers-reduced-motion 훅
+└── index.ts                  # 배럴
+```
+
+책임:
+
+- **Skeleton.tsx**
+  - `SkeletonRoot`, `SkeletonText`, `SkeletonAvatar`, `SkeletonCard`, `SkeletonTable` 5 개 함수 컴포넌트.
+  - `Skeleton` namespace 구성 + displayName.
+  - `_suppressAria` (internal prop, types.ts 에는 export 안 함) 로 중첩 시 outer 만 role 유지.
+  - swap 로직 (inline).
+
+- **Skeleton.utils.ts**
+  - `resolveDimensions(props) → {width, height, borderRadius}`
+  - `toCssLength(v: SkeletonSize) → string`
+  - `seededRandom(seed, index) → [0,1)`
+  - `computeTextLineWidths(lines, range, lastLineWidth, randomize, seed) → string[]`
+  - `computeTableColWidths(cols, overrides) → string[]`
+  - `extractCommonProps` (§3.4)
+
+- **Skeleton.css**
+  - `.sk-root`, `.sk-shimmer`, `.sk-root--shimmer`, `.sk-root--pulse`, `.sk-root--none`
+  - `@keyframes sk-shimmer`, `sk-pulse`, `sk-fadein`
+  - `@media (prefers-reduced-motion: reduce)` 블록
+  - `.sk-content-fadein`
+
+- **theme.ts**
+  - `skeletonPalette` (light/dark) + `applyPaletteVars(theme): CSSProperties`.
+
+- **useReducedMotion.ts**
+  - `matchMedia` 훅.
+
+- **index.ts**
+  - `export { Skeleton }` + 타입 재노출.
+
+---
+
+## 11. 구현 단계 (후속 agent 가 순차 실행)
+
+각 단계는 독립 커밋. 각 커밋이 `npm run typecheck` + `npx tsup` 통과.
+
+### Step 1 — 타입 + 배럴 + 테마 스켈레톤
+1. `Skeleton.types.ts` 작성 (§2.1 전부).
+2. `theme.ts` — `skeletonPalette` light/dark.
+3. `Skeleton.utils.ts` — `toCssLength`, `resolveDimensions`, `seededRandom`, `computeTextLineWidths`, `computeTableColWidths`, `extractCommonProps`.
+4. `Skeleton.css` — keyframes + base classes (§4.2 전부).
+5. `index.ts` 배럴.
+6. `src/components/index.ts` 에 `export * from "./Skeleton";`.
+7. `Skeleton.tsx` placeholder: `export const Skeleton = { Root: () => null, Text: () => null, Avatar: () => null, Card: () => null, Table: () => null };`.
+8. `npm run typecheck` 통과.
+9. 커밋: `feat(Skeleton): 타입 + 테마 + 유틸 + CSS 스켈레톤`.
+
+### Step 2 — useReducedMotion + Skeleton.Root 원자
+1. `useReducedMotion.ts` 작성.
+2. `SkeletonRoot` 구현: shape 해석, dimension 계산, animation className, palette vars inline.
+3. `<span class="sk-shimmer" aria-hidden="true">` 자식 렌더.
+4. 접근성: `role="status"`, `aria-busy`, `aria-label`.
+5. 커밋: `feat(Skeleton): Root 원자 + reduced-motion 감지`.
+
+### Step 3 — visible swap
+1. Root 에 `visible` prop 반영.
+2. `visible=false` 시 `children` 을 `sk-content-fadein` 으로 감싸 렌더.
+3. `fadeMs=0` 특수 처리.
+4. `aria-busy` 를 visible 에 바인딩.
+5. 커밋: `feat(Skeleton): visible swap + fade`.
+
+### Step 4 — Skeleton.Text 프리셋
+1. `SkeletonText` 구현 — `computeTextLineWidths` 사용, gap 으로 간격, `_suppressAria`.
+2. `lastLineWidth={null}` 경로.
+3. `randomize=false` 경로.
+4. SSR 테스트 (간단): `renderToString` 두 번 호출해 동일 HTML 확인 (수동).
+5. 커밋: `feat(Skeleton): Text 프리셋`.
+
+### Step 5 — Skeleton.Avatar 프리셋
+1. `SkeletonAvatar` — shape → Root shape/borderRadius 매핑.
+2. 커밋: `feat(Skeleton): Avatar 프리셋`.
+
+### Step 6 — Skeleton.Card 프리셋
+1. `SkeletonCard` — hasMedia/hasAvatar/hasTitle/lines/hasFooter 조합.
+2. padding, width, radius 반영.
+3. 내부에서 `Skeleton.Text` 재활용.
+4. 커밋: `feat(Skeleton): Card 프리셋`.
+
+### Step 7 — Skeleton.Table 프리셋
+1. `SkeletonTable` — rows/cols 그리드.
+2. `computeTableColWidths` 사용.
+3. perf warn (rows > 200).
+4. 커밋: `feat(Skeleton): Table 프리셋`.
+
+### Step 8 — 데모 페이지
+1. `demo/src/pages/SkeletonPage.tsx` (§12 전부).
+2. `demo/src/App.tsx` NAV + 라우팅.
+3. 커밋: `feat(Skeleton): 데모 페이지`.
+
+### Step 9 — Props 표 + Usage
+1. 데모 Props 섹션 (Root/Text/Avatar/Card/Table 각각).
+2. Usage 스니펫 4개 (기본, Card, swap, Suspense 조합).
+3. 커밋: `feat(Skeleton): 데모 props 표 + usage`.
+
+### Step 10 — 마감
+1. §20 DoD 전체 체크.
+2. 다른 페이지 리그레션 없음 육안 확인.
+3. 커밋: `feat(Skeleton): DoD`.
+
+---
+
+## 12. 데모 페이지
+
+`demo/src/pages/SkeletonPage.tsx`. 기존 페이지(CommandPalettePage, SplitPanePage 등) 구조 복제. 섹션별 `<section id="...">` + 우측 사이드바 NAV 연동.
+
+### 12.1 NAV 추가 (App.tsx)
+
+```ts
+{ id: "skeleton", label: "Skeleton", description: "로딩 플레이스홀더", sections: [
+  { label: "Basic shapes",         id: "basic" },
+  { label: "Text multi-line",      id: "text" },
+  { label: "Avatar",               id: "avatar" },
+  { label: "Card preset",          id: "card" },
+  { label: "Table preset",         id: "table" },
+  { label: "Pulse vs Shimmer",     id: "animation" },
+  { label: "Reduced motion",       id: "reduced" },
+  { label: "Dark",                 id: "dark" },
+  { label: "Swap to real content", id: "swap" },
+  { label: "Playground",           id: "playground" },
+  { label: "Props",                id: "props" },
+  { label: "Usage",                id: "usage" },
+]},
+```
+
+`Page` 타입에 `"skeleton"` 추가 + 하단 `{current === "skeleton" && <SkeletonPage />}`.
+
+### 12.2 섹션 구성
+
+**Basic shapes**
+```tsx
+<div className="flex gap-4 items-center">
+  <Skeleton.Root shape="text" width={200} />
+  <Skeleton.Root shape="rect" width={160} height={80} />
+  <Skeleton.Root shape="circle" size={56} />
+</div>
+```
+
+**Text multi-line**
+```tsx
+<div className="flex flex-col gap-6">
+  <div>
+    <h4>lines=1</h4>
+    <Skeleton.Text lines={1} />
+  </div>
+  <div>
+    <h4>lines=3 (기본)</h4>
+    <Skeleton.Text lines={3} />
+  </div>
+  <div>
+    <h4>lines=5 + randomize=false</h4>
+    <Skeleton.Text lines={5} randomize={false} />
+  </div>
+  <div>
+    <h4>lastLineWidth=null (마지막도 랜덤)</h4>
+    <Skeleton.Text lines={3} lastLineWidth={null} />
+  </div>
+  <div>
+    <h4>seed=7 (다른 패턴)</h4>
+    <Skeleton.Text lines={3} seed={7} />
+  </div>
+</div>
+```
+
+**Avatar**
+```tsx
+<div className="flex gap-4 items-end">
+  <div><div className="text-xs">circle/40</div><Skeleton.Avatar size={40}/></div>
+  <div><div className="text-xs">rounded/56</div><Skeleton.Avatar shape="rounded" size={56}/></div>
+  <div><div className="text-xs">square/72</div><Skeleton.Avatar shape="square" size={72}/></div>
+</div>
+```
+
+**Card preset**
+```tsx
+<div className="grid grid-cols-3 gap-4">
+  <Skeleton.Card />
+  <Skeleton.Card hasMedia lines={3} />
+  <Skeleton.Card hasMedia hasFooter lines={2} />
+  <Skeleton.Card hasAvatar lines={2} />
+  <Skeleton.Card hasMedia mediaHeight={80} lines={1} />
+  <Skeleton.Card hasFooter lines={4} />
+</div>
+```
+
+**Table preset**
+```tsx
+<Skeleton.Table rows={5} cols={4} />
+<hr />
+<h4>colWidths 지정</h4>
+<Skeleton.Table rows={3} cols={4} colWidths={[60, "30%", "40%", 120]} />
+<h4>헤더 없음</h4>
+<Skeleton.Table rows={4} cols={3} hasHeader={false} />
+```
+
+**Pulse vs Shimmer**
+```tsx
+<div className="grid grid-cols-3 gap-4">
+  <div>
+    <h4>shimmer (기본)</h4>
+    <Skeleton.Card hasMedia lines={2} animation="shimmer"/>
+  </div>
+  <div>
+    <h4>pulse</h4>
+    <Skeleton.Card hasMedia lines={2} animation="pulse"/>
+  </div>
+  <div>
+    <h4>off</h4>
+    <Skeleton.Card hasMedia lines={2} animation={false}/>
+  </div>
+</div>
+```
+
+**Reduced motion**
+```tsx
+<p>
+  이 페이지는 시스템의 "동작 감소" 설정을 자동 감지합니다.
+  macOS: 설정 → 손쉬운 사용 → 디스플레이 → 동작 줄이기.
+  현재 상태: <code>{reduced ? "reduce ON" : "reduce OFF"}</code>
+</p>
+<Skeleton.Card hasMedia lines={2} animation="shimmer"/>
+```
+(useReducedMotion 훅을 demo 에서도 호출해 상태 노출.)
+
+**Dark**
+```tsx
+<div style={{background:"#0f172a",padding:24,borderRadius:12}}>
+  <Skeleton.Card theme="dark" hasMedia lines={3}/>
+  <div style={{height:16}}/>
+  <Skeleton.Table theme="dark" rows={4} cols={4}/>
+</div>
+```
+
+**Swap to real content**
+```tsx
+function SwapDemo() {
+  const [loaded, setLoaded] = useState(false);
+  return (
+    <div>
+      <Button onClick={() => setLoaded(l => !l)}>
+        {loaded ? "Reset to skeleton" : "Load data"}
+      </Button>
+      <div style={{marginTop:12}}>
+        <Skeleton.Card visible={!loaded} hasMedia lines={3} fadeMs={240}>
+          <Card.Root>
+            <Card.Header title="실제 콘텐츠"/>
+            <Card.Body>
+              여기에 실제 데이터가 들어옵니다. Swap 은 180ms fade (fadeMs 로 조정 가능).
+            </Card.Body>
+          </Card.Root>
+        </Skeleton.Card>
+      </div>
+    </div>
+  );
+}
+```
+
+**Playground**
+상단 컨트롤 바:
+- `preset` select (Root / Text / Avatar / Card / Table)
+- `shape` select (text / rect / circle) — Root 일 때만
+- `animation` 라디오 (shimmer / pulse / false)
+- `theme` 라디오 (light / dark)
+- `width` / `height` input (Root rect 일 때)
+- `size` input (circle / avatar)
+- `lines` input (Text / Card)
+- `rows` / `cols` input (Table)
+- `hasMedia` / `hasFooter` / `hasAvatar` 체크 (Card)
+- `visible` 체크
+- `fadeMs` input
+
+아래에 240~320 px 고정 높이 preview 컨테이너에 `<Skeleton.{Preset} {...args}/>` 렌더. visible=false 시 자리에 작은 "Real content" 박스 표시.
+
+**Props 표**
+기존 페이지 패턴 그대로. `Skeleton.Root`, `Skeleton.Text`, `Skeleton.Avatar`, `Skeleton.Card`, `Skeleton.Table` 5개 표.
+
+**Usage (5개)**
+1. 단일 텍스트 플레이스홀더.
+2. 카드 리스트 (3개 카드) 로딩.
+3. 테이블 로딩 → 데이터 도착 swap.
+4. Suspense fallback 으로 `<Skeleton.Card/>` 사용.
+5. 아바타 + 이름 한 줄 (댓글 목록 로딩).
+
+**Usage 샘플 — Suspense**:
+```tsx
+<Suspense fallback={<Skeleton.Card hasMedia lines={3}/>}>
+  <UserCard userId={1}/>
+</Suspense>
+```
+
+**Usage 샘플 — 댓글 목록**:
+```tsx
+<ul className="flex flex-col gap-3">
+  {Array.from({length:5}).map((_,i) => (
+    <li key={i} className="flex gap-3 items-start">
+      <Skeleton.Avatar size={40}/>
+      <div className="flex-1">
+        <Skeleton.Root shape="text" width="30%"/>
+        <div style={{height:4}}/>
+        <Skeleton.Text lines={2}/>
+      </div>
+    </li>
+  ))}
+</ul>
+```
+
+---
+
+## 13. 검증 계획
+
+### 13.1 자동화
+```bash
+cd /Users/neo/workspace/plastic
+npm run typecheck
+npx tsup
+```
+주의: `exactOptionalPropertyTypes: true` — optional prop 은 `?:` 로 받고 값 병합 시 `undefined` 분기 명시. `noUncheckedIndexedAccess: true` — `colWidths[i]` 는 `SkeletonSize | undefined`. `verbatimModuleSyntax: true` — 타입은 `import type`.
+
+### 13.2 수동 (demo dev server)
+```bash
+cd demo && npm run dev
+```
+
+체크리스트:
+- [ ] Basic shapes 3종 시각 확인.
+- [ ] Text multi-line: 각 줄 너비가 자연스러운 변주(75~95%), 마지막 60%.
+- [ ] Text seed 변경 시 패턴 다름.
+- [ ] randomize=false 시 모든 줄 100%.
+- [ ] Avatar circle/rounded/square 3종.
+- [ ] Card 6가지 조합 모두 정상.
+- [ ] Table rows/cols 동적 변경 반영.
+- [ ] Pulse: opacity 1500ms 주기로 오르내림.
+- [ ] Shimmer: 1500ms 주기로 좌→우 스윕.
+- [ ] animation=false: 완전 정적.
+- [ ] Reduced motion: macOS/Windows 설정 ON → 애니메이션 즉시 멈춤 (새로고침 없이도 `matchMedia` change 이벤트로 반영).
+- [ ] Dark: 배경 `#334155`, shine 흰색 저명도.
+- [ ] Swap: `Load data` 클릭 → skeleton fade-out 직후 children fade-in 180ms. `aria-busy` 가 `false` 로 전환되거나 role 자체가 사라짐.
+- [ ] Playground: 모든 prop 조합 실시간 반영.
+- [ ] Props 표 Root/Text/Avatar/Card/Table 모두 채워짐.
+- [ ] Usage 5개 전부 정상 렌더.
+- [ ] 다른 페이지(CommandPalette, SplitPane 등) 리그레션 없음.
+
+### 13.3 엣지 케이스
+- [ ] `shape="rect"` + width/height 누락 → 콘솔 warn + fallback 렌더.
+- [ ] `width={0}` / `height={0}` → 0px 블록 (보이지 않음). 에러 없음.
+- [ ] `lines={0}` → 빈 div.
+- [ ] `lines={1000}` → 렌더 됨 (warn 없음), perf 저하 없음(단일 요소는 많아도 CSS animation).
+- [ ] `Skeleton.Table rows={300}` → dev warn 노출.
+- [ ] `visible=false` + children 없음 → `null`, 에러 없음.
+- [ ] `fadeMs=0` → 즉시 교체.
+- [ ] SSR hydration: `renderToString` 2회 비교 시 동일 HTML (randomize 결정적).
+- [ ] reducedMotion 런타임 변경 (toggle) → 즉시 반영.
+- [ ] `theme="dark"` + `style={{backgroundColor:"red"}}` → style 우선 (inline 이 last).
+- [ ] circle + borderRadius 커스텀 → 사용자 값 적용.
+- [ ] animation prop 을 제거(undefined) 로 바꾸면 "shimmer" 기본값.
+- [ ] `className` 으로 `.sk-root` 에 width 추가 override 가능.
+
+### 13.4 스크린리더 (VoiceOver)
+- [ ] skeleton 마운트 시 "Loading" 음성.
+- [ ] `visible=false` 전환 시 aria-busy 해제 → "Loading" 반복 없음.
+- [ ] Card/Table/Text 의 내부 하위 Skeleton 에 대해 `role="status"` 가 **한 번만** 읽힘(중복 없음).
+
+---
+
+## 14. 성능
+
+### 14.1 목표
+- 1 페이지에 Skeleton 100개 있어도 **60 fps**.
+- 초기 마운트 < 1 ms/컴포넌트 (유틸 함수들이 모두 O(1) 또는 O(lines)).
+
+### 14.2 병목 가설 + 완화
+1. **CSS animation 개수**: shimmer 는 요소당 1개 keyframe. 브라우저는 GPU 합성으로 거의 무료. 단 `will-change: transform` 이 너무 많으면 메모리 폭증 → `.sk-shimmer` 에만 `will-change`, `.sk-root` 자체에는 없음.
+2. **Table 1000 rows**: DOM 수가 압도적. v1 은 `rows>200` dev warn 만, 가상화는 v1.2. 사용자가 가상화 리스트 안에서 skeleton 을 쓰는 것은 권장.
+3. **re-render**: Root 는 state-less. Text 는 `useMemo` 로 widths 캐시. Avatar/Card/Table 도 인라인 스타일 외 상태 없음. Parent re-render 시에도 자식은 props 동일하면 대부분 reconciliation 만.
+4. **color palette CSS vars inline**: 매 요소마다 `style={{--sk-bg:..., --sk-shine:...}}` — 문자열 비교 OK. 사용자 style 과 merge 시 spread 주의.
+5. **`className` clsx 연산**: 미세. infinite loop 없음.
+
+### 14.3 repaint
+- shimmer 의 `transform: translateX(...)` 는 compositor-only (repaint 없음).
+- pulse 의 `opacity` 도 compositor-only.
+- 따라서 100개 shimmer + 스크롤 해도 main thread 부담 없음.
+
+### 14.4 측정 방법
+- DevTools Performance 탭 → `Skeleton` demo 페이지 스크롤/마운트 녹화 → long task 없음 확인.
+- `npx tsup` 결과 bundle 크기 확인: skeleton 전체 예상 ~2 KB min, ~0.9 KB gzip.
+
+---
+
+## 15. 접근성
+
+### 15.1 role / aria 계약
+
+- Root: `role="status"` + `aria-busy="true"` + `aria-label="Loading"` (사용자 override 가능).
+- `role="status"` 는 aria-live="polite" 와 동치. 스크린리더가 방해 없이 읽는다.
+- `<span class="sk-shimmer">`: `aria-hidden="true"`. 시각 장식물.
+- 프리셋(Text/Card/Table) 의 최상위만 role 보유. 내부 자식 Root 는 `_suppressAria=true` 로 role/aria-busy/aria-label 모두 제거.
+
+### 15.2 swap 후 announcement
+
+`visible=false` 가 되면:
+- skeleton 은 unmount → role="status" 요소 사라짐.
+- children 의 일반 콘텐츠가 노출됨.
+- 스크린리더는 더 이상 "Loading" 반복하지 않음. 콘텐츠 변화 자체는 기본 announce 하지 않음(명시적 live region 필요).
+
+### 15.3 비상호작용
+
+- `tabindex` 미설정.
+- 포커스 이동/트랩 없음.
+- 키보드 단축키 없음.
+
+### 15.4 reduced motion
+
+§5.1 참조. OS 설정 감지 → `animation=false` 강제. CSS 미디어 쿼리로 fallback.
+
+### 15.5 명시적 label
+
+사용자가 `aria-label="댓글 로딩 중"` 같이 주면 override. 다국어 앱에서는 필수적으로 지정 권장.
+
+---
+
+## 16. 알려진 트레이드오프 · 결정
+
+1. **pulse vs shimmer 기본값**: shimmer 가 시각적 인상이 더 강하고 "로딩 중"을 명확히 알림(VSCode/GitHub/Ant Design 대세). pulse 는 성능 우위가 있으나 "그냥 비활성화된 UI" 와 혼동될 여지. v1 은 **shimmer 기본**. 사용자가 `animation="pulse"` 로 쉽게 바꿈.
+
+2. **text 줄 width 랜덤 — SSR hydration mismatch 위험**: `Math.random()` 을 쓰면 서버/클라이언트 값 다름 → React 경고 + 시각 깜빡. 대응: 고정 시드 Mulberry32 의사랜덤(§3.2). 계약: "같은 seed+index 는 항상 같은 값". 사용자가 seed 변경 시만 패턴 바뀜.
+
+3. **visible swap one-way fade**: 양방향 crossfade 는 두 요소 동시 mount + absolute overlap + 높이 계산 필요. 복잡도 대비 UX 이득 작음. v1 은 "skeleton 즉시 unmount → children fade-in" 한 방향만. `fadeMs=0` 로 완전 즉시 교체도 가능.
+
+4. **prop 이 `animation="shimmer"` 여도 reduced-motion 강제 off**: 접근성 우선. 사용자 옵트아웃(`respectReducedMotion=false`) 허용 시 WCAG 위반 쉬움 → v1 미지원. 나중에 정책 변경 가능.
+
+5. **프리셋 내부에서 Root 를 직접 조립 (context 없음)**: context 를 둬서 프리셋이 공통 설정을 자동 전파하는 설계도 가능하지만, "Text/Card/Table 은 독립적인 프리셋" 이라는 구조가 더 단순. prop drilling 최소화는 `extractCommonProps` 유틸로 충분.
+
+6. **`_suppressAria` internal prop**: 공개 API 에는 없음 (types.ts 에 export 안 함). 프리셋이 내부 Root 에 전달. TS 레벨에서 `SkeletonRootProps` 에는 포함하되 public 문서화 안 함. 대안: 모든 Root 에 role 유지하고 스크린리더 중복 감수 — VoiceOver 실험 결과 "Loading" 이 3~5회 반복되어 UX 나쁨. 억제가 정답.
+
+7. **Table 가상화 없음**: rows > 200 에서 perf 저하. 실제 데이터도 가상화가 정답이므로, skeleton 만 별도 가상화하는 것은 복잡도 대비 이득 낮음. warn 만.
+
+8. **CSS in file (별도 .css) vs inline style**: 기존 plastic 컴포넌트는 inline style + className 혼용. Skeleton 은 keyframes 를 inline 으로 표현 불가하므로 별도 .css 파일 필요. `src/index.ts` 또는 root 에서 `import "./components/Skeleton/Skeleton.css";` 한 번만. 사용자 앱이 CSS 를 import 하지 않으면 동작 안 함 — 번들러 설정 문서(README) 에 명시.
+
+9. **size prop 의 타입 `number | string`**: `number` 는 px, `string` 은 passthrough. `"80%"`, `"2rem"`, `"calc(100% - 16px)"` 모두 가능. 타입 guard 는 `toCssLength` 하나로 통합. 엄격 유니온(`number | \`${number}%\``) 은 너무 제한적.
+
+10. **Card 프리셋과 실제 Card 컴포넌트 1:1 매칭 안 됨**: skeleton 은 "대략적 레이아웃" 이 목적이며, 실제 Card 의 shadow/border/radius 를 정확히 따라하면 "진짜 Card 로 오해" 가능. 의도적으로 shadow 제거, 색만 회색. `mimicCard` 옵션은 v1.1 후보.
+
+---
+
+## 17. 후속 작업 (v1.1+)
+
+- **DataTable 통합**: `DataTableLoading.tsx` 내부 skeleton 을 `Skeleton.Table` 로 교체. 별도 PR (DataTable 작업자와 조율).
+- **CommandPalette async loading**: `items` 가 Promise 중일 때 `<Skeleton.Text lines={3}/>` 을 기본 loading UI 로.
+- **Skeleton.Svg**: react-content-loader 스타일 path 자유 지정. `<Skeleton.Svg width={300} height={100}><rect x=0 y=0 width=100 height=16/></Skeleton.Svg>`.
+- **Skeleton.Mimic**: `ref={realEl}` 혹은 `querySelector` 로 실제 DOM 측정 → 동일 dimension 스켈레톤 자동 생성. 복잡 레이아웃 자동 추출.
+- **blurhash / LQIP 이미지**: `<Skeleton.Image src="..." hash="LEHV6..."/>` 가 blur → sharp crossfade.
+- **양방향 crossfade swap**: `fadeMode="crossfade"` 옵션.
+- **progress aware**: `progress={0.6}` 이면 스켈레톤이 60% 만 회색, 나머지는 연한 회색.
+- **`mimicCard` 옵션**: 실제 Card 컴포넌트와 shadow/border 까지 일치.
+- **`respectReducedMotion=false`** 옵트아웃 (주의 필요).
+- **CSS 의존성 제거**: Emotion / styled-components / CSS-in-JS 기반으로 migration. v1 은 plain .css.
+- **RTL**: shimmer 방향이 LTR 기준 좌→우. RTL 에서 우→좌 가 자연스러우면 `[dir="rtl"]` 셀렉터로 반전.
+- **테스트**: Vitest 기반 단위 테스트 도입 시 `computeTextLineWidths` 결정성, `resolveDimensions` 케이스 커버.
+
+---
+
+## 18. 관련 파일 인벤토리 (구현 시 참조)
+
+| 용도 | 경로 |
+|---|---|
+| Card preset 레이아웃 참조 | `/Users/neo/workspace/plastic/src/components/Card/` |
+| Card 파일들 | `/Users/neo/workspace/plastic/src/components/Card/CardRoot.tsx`, `CardHeader.tsx`, `CardBody.tsx`, `CardFooter.tsx` |
+| Table row preset 참조 + 후속 리팩터링 대상 | `/Users/neo/workspace/plastic/src/components/DataTable/` |
+| 기존 DataTable loading 플레이스홀더 | `/Users/neo/workspace/plastic/src/components/DataTable/DataTableLoading.tsx` |
+| 배럴 등록 | `/Users/neo/workspace/plastic/src/components/index.ts` |
+| 데모 App 라우팅 / NAV | `/Users/neo/workspace/plastic/demo/src/App.tsx` |
+| 데모 페이지 레이아웃 템플릿 | `/Users/neo/workspace/plastic/demo/src/pages/CommandPalettePage.tsx` |
+| tsconfig 제약 | `/Users/neo/workspace/plastic/tsconfig.json` |
+| 이전 plan 포맷 참조 | `/Users/neo/workspace/plastic/docs/plans/017-splitpane-component.md` |
+| CommandPalette async 후속 연동 대상 | `/Users/neo/workspace/plastic/src/components/CommandPalette/` |
+
+---
+
+## 19. 의존성 영향
+
+신규 런타임 의존 **없음**. React 18.3 (기존) + DOM API (`matchMedia`, CSS keyframes) 만 사용.
+
+번들 영향:
+- Skeleton 자체 예상 크기: ~2.0 KB (min), ~0.9 KB (min+gzip).
+- CSS 파일 `Skeleton.css`: ~0.7 KB (min), ~0.3 KB (gzip).
+- plastic 전체 dist 거의 영향 없음.
+
+CSS import:
+- 소비자 앱이 `import "plastic/dist/Skeleton.css"` (또는 전체 `plastic/dist/style.css`) 을 한 번 import 해야 함.
+- 빌드 구성은 `tsup` + external CSS 방식. 기존 plastic 에 css 파일이 없는 경우 이 PR 이 최초 도입 → README/docs 에 import 라인 추가 필수.
+- 또는 inline CSS-in-JS 로 전환하는 방법도 있으나 runtime-zero 원칙과 배치. v1 은 plain .css.
+
+Browser 지원:
+- `matchMedia`: 모든 모던 브라우저.
+- `prefers-reduced-motion`: Chrome 74+, Firefox 63+, Safari 10.1+.
+- CSS `isolation: isolate`: 모든 모던 브라우저.
+- CSS variables: 모든 모던 브라우저.
+
+SSR:
+- `useReducedMotion` 이 `typeof window === "undefined"` 가드. 서버에서는 `false` 리턴 (애니메이션 off 가 아닌 "감지 못함 = 기본 shimmer" 의미로 렌더). 하이드레이션 직후 CSR 에서 다시 측정.
+- `seededRandom` 기반 width 는 서버/클라 동일.
+
+---
+
+## 20. 구현 완료 정의 (Definition of Done)
+
+- [ ] `npm run typecheck` 통과.
+- [ ] `npx tsup` 통과 (타입 선언 포함, `Skeleton.css` 가 dist 에 복사/포함됨).
+- [ ] demo 에 `/#/skeleton` 라우트 동작.
+- [ ] §13.2 수동 체크리스트 전부 확인.
+- [ ] §13.3 엣지 케이스 전부 확인 또는 "v1 범위 밖" 이유 기재.
+- [ ] §13.4 스크린리더 VoiceOver 동작 확인 (macOS Cmd+F5).
+- [ ] `src/components/index.ts` 배럴에 `export * from "./Skeleton";` 추가됨.
+- [ ] `package.json` dependencies 변경 없음 (신규 의존 없음).
+- [ ] Props 문서 섹션이 Props 표로 채워져 있음 (Root/Text/Avatar/Card/Table 5개).
+- [ ] Usage 섹션에 최소 5 개 스니펫 (단일 / Card 리스트 / Table swap / Suspense / 댓글 목록).
+- [ ] 데모 Playground 에서 모든 prop 토글 가능.
+- [ ] Light/Dark 테마 전환 시 시각 이상 없음.
+- [ ] Shimmer / Pulse / off 3모드 전환 검증.
+- [ ] OS reduced-motion ON/OFF 런타임 전환 시 즉시 반영.
+- [ ] swap (visible) 전환 시 fade 180ms 자연스러움.
+- [ ] SSR 안전성 (같은 seed+index 는 결정적) 확인 — 콘솔에 hydration mismatch 경고 없음.
+- [ ] CommandPalette / Card / DataTable / SplitPane / PipelineGraph / HexView / CodeView / Dialog / Popover / Tooltip / Toast / Stepper / PathInput 등 기존 페이지 리그레션 없음.
+- [ ] Card 프리셋이 실제 `Card` 컴포넌트와 레이아웃 대응되게 padding/radius 맞춤.
+- [ ] Table rows > 200 시 dev warn 노출.
+- [ ] `Skeleton.css` 의 `@media (prefers-reduced-motion: reduce)` 블록 존재 및 동작.
+
+---
+
+**끝.**

--- a/docs/plans/022-accordion-component.md
+++ b/docs/plans/022-accordion-component.md
@@ -1,0 +1,1318 @@
+# Accordion 컴포넌트 설계문서
+
+## Context
+
+plastic 라이브러리에 "수직으로 쌓인 섹션을 펼치고 접는(collapsible) 프리미티브" `Accordion` 을 추가한다. 역할 비유: VSCode 사이드바의 Explorer/Search/Source Control 섹션 collapse, IntelliJ 의 Tool Window 그룹, Chrome DevTools Styles 패널의 rule group, macOS System Settings 의 sidebar section. 이 컴포넌트는 "긴 수직 정보 목록을 카테고리 단위로 접어 화면 밀도를 조절" 하는 가장 기본적인 UI 블록이며, plastic 에서 장기적으로 DataTable 의 group header, Inspector 의 섹션 분리, Form Wizard 의 단계 요약 등에 공통 기반으로 재사용될 것이다.
+
+참고 (prior art — UX 근거):
+- **Radix `@radix-ui/react-accordion`** — compound API (`Root/Item/Header/Trigger/Content`), `type="single"|"multiple"`, `collapsible`, `value`/`defaultValue`, keyboard (Arrow/Home/End). 가장 가까운 설계 참조.
+- **Ant Design `Collapse`** — `items` 배열 props + `activeKey` 제어, `accordion` boolean(single vs multiple), `ghost`/`bordered`. declarative 데이터 중심.
+- **MUI `Accordion`** — 단일 Item 을 제어하는 패턴. `expanded`/`onChange` 가 Item 단위. 본 plan 은 "Root 단위 제어" 로 통일 (Radix 스타일 선호).
+- **HeadlessUI `Disclosure`** — 단일 토글 primitive. Accordion 은 Disclosure 의 그룹 버전이라는 관점.
+- **shadcn/ui Accordion** — Radix wrapper. 스타일 참조.
+- **네이티브 `<details>`/`<summary>`** — 브라우저 기본 UA. 비교 대상(§4, §16).
+- **CSS `::details-content`** (2024~) — `interpolate-size: allow-keywords` + `transition-behavior: allow-discrete` 조합으로 `height: auto` 전환 가능. 모던 웹의 새 선택지(§5, §16).
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/_shared/useControllable.ts` — controlled/uncontrolled 이중 API 표준 훅. 그대로 재사용 (`value`/`defaultValue`/`onValueChange`).
+- `src/components/PipelineGraph/PipelineGraphCluster.tsx` — 본 레포 내 유일한 "expand/collapse 접힘 UI" 선례. 트리거 버튼 + chevron rotate + height transition 패턴 참조.
+- `src/components/index.ts` — 배럴 export 위치.
+- `src/components/CommandPalette/` — compound API + dark 테마 + Playground 데모 스타일 기준점.
+- `demo/src/App.tsx` — NAV/라우팅 등록.
+- `demo/src/pages/CommandPalettePage.tsx` — 최신 데모 페이지 레이아웃 관례(Props/Usage/Playground 섹션 구조).
+- `tsconfig.json` — `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax` 제약.
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+<Accordion.Root
+  type="single"             // "single" | "multiple"
+  collapsible               // single 일 때 열린 항목을 다시 눌러 닫기 허용
+  defaultValue="overview"
+  theme="light"
+  onValueChange={(v) => log(v)}
+>
+  <Accordion.Item value="overview">
+    <Accordion.Header>
+      <Accordion.Trigger>Overview</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>
+      <p>Summary of the pipeline.</p>
+    </Accordion.Content>
+  </Accordion.Item>
+
+  <Accordion.Item value="nodes">
+    <Accordion.Header>
+      <Accordion.Trigger>Nodes</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>
+      <NodeList />
+    </Accordion.Content>
+  </Accordion.Item>
+
+  <Accordion.Item value="metrics" disabled>
+    <Accordion.Header>
+      <Accordion.Trigger>Metrics (coming soon)</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>
+      <MetricsPanel />
+    </Accordion.Content>
+  </Accordion.Item>
+</Accordion.Root>
+```
+
+렌더 결과 (개념):
+```
+┌───────────────────────────────────────────┐
+│ ▾  Overview                               │  ← Header (Trigger button, chevron ▸→▾ 회전)
+│    Summary of the pipeline.               │  ← Content (open)
+├───────────────────────────────────────────┤
+│ ▸  Nodes                                  │  ← Header (collapsed)
+├───────────────────────────────────────────┤
+│ ▸  Metrics (coming soon) [disabled dim]   │
+└───────────────────────────────────────────┘
+```
+
+핵심 설계 원칙:
+- **compound 컴포넌트**. `Root`/`Item`/`Header`/`Trigger`/`Content` 5 개 소계. Root 와 Item 은 각각 Context 를 가진다 (Root=컬렉션 상태, Item=단일 item 의 id/상태).
+- **type="single" vs "multiple"**. 내부 상태는 **항상 `string[]`** 로 통일해서 두고(value 축 단일화), `type` 에 따라 공개 API 의 `value` 타입만 `string` vs `string[]` 로 갈린다. 공개-내부 어댑터는 Root 가 담당.
+- **`collapsible` 은 single 전용**. `type="single"` 에서 기본 false (한 번 열면 다른 것을 눌러야 닫힘). true 이면 같은 trigger 재클릭 시 닫힘. `multiple` 은 항상 개별 토글이므로 이 prop 을 무시.
+- **controlled/uncontrolled 이중 API**. `useControllable` 동일 패턴 (`value`/`defaultValue`/`onValueChange`).
+- **런타임 의존 zero**. DOM + React 만. ResizeObserver, MutationObserver 등은 표준.
+- **접근성 · 키보드 우선**. Trigger 는 `button[aria-expanded][aria-controls]`, Content 는 `role="region" aria-labelledby`. Arrow/Home/End 내비게이션, Enter/Space 토글.
+- **애니메이션은 CSS 주도**. JS 타이머를 쓰지 않고, data-state=`open`/`closed` + CSS custom property `--accordion-content-height` 로 `max-height` 전환. reduced-motion 은 `transition: none`.
+- **div 기반, native `<details>` 거절**. 다중 expansion / 세밀한 ARIA / 키보드 그룹 내비게이션 요구를 위해 `<details>` 는 쓰지 않는다 (§4.3, §16).
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. 수직 스택 섹션 collapse. `type="single"` 과 `type="multiple"` 두 모드.
+2. `collapsible` (single 전용) — 열린 항목 재클릭으로 닫기 허용/불허.
+3. `value`/`defaultValue`/`onValueChange` 로 controlled/uncontrolled 이중 API. 타입은 `type` 에 따라 `string`/`string[]`.
+4. `disabled` (Root 수준 전체, Item 수준 개별) — 트리거 비활성화, 키보드 포커스 통과(skip) 여부 선택 가능.
+5. Expand/Collapse 애니메이션 — 200 ms ease-out, `max-height` + `opacity` 전환. 측정값을 CSS 변수로 주입.
+6. `prefers-reduced-motion` 자동 감지 → transition 제거(즉시 open/close).
+7. 키보드: `ArrowDown`/`ArrowUp` 로 트리거 간 이동 (Item wrap), `Home`/`End` 로 처음/끝 트리거, `Enter`/`Space` 로 토글.
+8. Chevron 회전 (0deg ↔ 90deg 또는 ↔ 180deg 옵션). 기본 `▸ → ▾` (90deg).
+9. 커스텀 trigger 내용 허용 — 아이콘 왼쪽/오른쪽, 배지, subtitle 자유.
+10. Nested Accordion (Content 내부에 또 다른 `Accordion.Root` 배치) — 독립 상태. 키보드는 가장 가까운 Root 로만 전파.
+11. Light / Dark 테마 (palette 토큰).
+12. 큰 Content 높이의 안정적 측정 (`ResizeObserver` on Content 내부 wrapper).
+
+### Non-goals (v1 제외)
+- **horizontal Accordion**: 수평 스택(좌→우 collapse)은 v1.1.
+- **Drag & Drop 로 Item 재정렬**: v1.1 (또는 별도 `ReorderableList` primitive 로 분리).
+- **`items` 배열 데이터 중심 API**: Ant Design 스타일 `items={[{ key, label, children }]}` 선언형 API 는 compound JSX 대비 유연성 낮음 → v1 compound 만. 차후 `Accordion.from(items)` 헬퍼만 고려.
+- **내장 검색/필터링** (큰 accordion 의 검색창): v1 범위 밖.
+- **sticky header**: 여러 open item 이 있을 때 현재 viewport 상단에 해당 item header 가 붙는 기능. v1.1.
+- **인디케이터 custom render prop**: v1 은 `Accordion.Trigger` 의 children 에 직접 chevron 을 포함하는 방식(사용자가 원하는 아이콘 직접 배치). `renderIndicator` prop 은 v1.1.
+- **애니메이션 커스터마이징 props** (duration/easing): v1 은 CSS 변수(`--accordion-duration`) override 만 지원, prop 은 추가하지 않음.
+- **SSR 특화 최적화** (초기 open 높이 서버 계산): v1 은 클라이언트 마운트 후 측정.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Accordion/Accordion.types.ts`
+
+```ts
+export type AccordionTheme = "light" | "dark";
+
+/**
+ * Accordion 의 값 축.
+ * - "single": 최대 1 개 열림. value 는 string. "" 은 "모두 닫힘" 을 의미.
+ * - "multiple": 여러 개 열림 가능. value 는 string[].
+ */
+export type AccordionType = "single" | "multiple";
+
+/** type="single" 의 값 */
+export type AccordionSingleValue = string;
+/** type="multiple" 의 값 */
+export type AccordionMultipleValue = string[];
+
+/** Root props (discriminated union: type 에 따라 value 타입이 달라짐) */
+export type AccordionRootProps =
+  | AccordionSingleRootProps
+  | AccordionMultipleRootProps;
+
+interface AccordionCommonRootProps {
+  theme?: AccordionTheme;
+  /** Root 전체 비활성화 (모든 Trigger 무효). 기본 false. */
+  disabled?: boolean;
+  /** 추가 className / style (root) */
+  className?: string;
+  style?: React.CSSProperties;
+  /** 섹션(Item) 리스트 */
+  children: React.ReactNode;
+  /**
+   * chevron 회전 각도 모드. 기본 "90". 지정 값에 따라 닫힘 0deg → 열림 90deg 또는 180deg.
+   */
+  chevronRotation?: 90 | 180;
+  /**
+   * 트리거 포커스 가능 여부. disabled item 을 tab 순서에 포함할지.
+   * 기본 "skip" (disabled 는 focus 통과).
+   */
+  disabledFocus?: "skip" | "include";
+  /** children 순회 wrap: ArrowDown 마지막 → 첫 번째 반환. 기본 true. */
+  loop?: boolean;
+}
+
+export interface AccordionSingleRootProps extends AccordionCommonRootProps {
+  type: "single";
+  /** 단일 열림. "" 은 모두 닫힘. */
+  value?: AccordionSingleValue;
+  defaultValue?: AccordionSingleValue;
+  onValueChange?: (value: AccordionSingleValue) => void;
+  /** 열린 항목 재클릭 시 닫기 허용. 기본 false. */
+  collapsible?: boolean;
+}
+
+export interface AccordionMultipleRootProps extends AccordionCommonRootProps {
+  type: "multiple";
+  value?: AccordionMultipleValue;
+  defaultValue?: AccordionMultipleValue;
+  onValueChange?: (value: AccordionMultipleValue) => void;
+  /** multiple 에서 collapsible 은 의미 없음. 타입 수준에서 차단. */
+  collapsible?: never;
+}
+
+export interface AccordionItemProps {
+  /** Item 의 유일 식별자. Root 내에서 유일해야 함 (dev 시 중복 검사). */
+  value: string;
+  /** 이 Item 비활성화. 기본 false. */
+  disabled?: boolean;
+  /** 추가 className / style */
+  className?: string;
+  style?: React.CSSProperties;
+  /** Header + Content 를 포함한 자식 */
+  children: React.ReactNode;
+}
+
+export interface AccordionHeaderProps extends React.HTMLAttributes<HTMLElement> {
+  /** 실제 wrap 태그. 기본 "h3". heading 레벨 제어용. */
+  as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "div";
+  children: React.ReactNode;
+}
+
+export interface AccordionTriggerProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "value"> {
+  /** 기본 chevron 을 숨기고 children 만. 기본 false. */
+  hideChevron?: boolean;
+  children: React.ReactNode;
+}
+
+export interface AccordionContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** forceMount: true 면 닫혀 있어도 DOM 에 유지 (내부 state 보존용). 기본 false. */
+  forceMount?: boolean;
+  children: React.ReactNode;
+}
+```
+
+### 2.2 배럴
+
+```ts
+// src/components/Accordion/index.ts
+export { Accordion } from "./Accordion";
+export type {
+  AccordionTheme,
+  AccordionType,
+  AccordionSingleValue,
+  AccordionMultipleValue,
+  AccordionRootProps,
+  AccordionSingleRootProps,
+  AccordionMultipleRootProps,
+  AccordionItemProps,
+  AccordionHeaderProps,
+  AccordionTriggerProps,
+  AccordionContentProps,
+} from "./Accordion.types";
+```
+
+그리고 `src/components/index.ts` 에 `export * from "./Accordion";` 한 줄 추가.
+
+### 2.3 Compound namespace
+
+```ts
+// Accordion.tsx
+export const Accordion = {
+  Root: AccordionRoot,
+  Item: AccordionItem,
+  Header: AccordionHeader,
+  Trigger: AccordionTrigger,
+  Content: AccordionContent,
+};
+```
+
+displayName 은 각각 `"Accordion.Root"`, `"Accordion.Item"`, `"Accordion.Header"`, `"Accordion.Trigger"`, `"Accordion.Content"`.
+
+### 2.4 controlled vs uncontrolled
+
+```tsx
+// uncontrolled, 단일
+<Accordion.Root type="single" collapsible defaultValue="a">…</Accordion.Root>
+
+// controlled, 다중
+const [open, setOpen] = useState<string[]>(["a", "c"]);
+<Accordion.Root type="multiple" value={open} onValueChange={setOpen}>…</Accordion.Root>
+```
+
+---
+
+## 3. 도메인 모델
+
+### 3.1 값 축의 단일화
+
+내부 상태는 **항상 `Set<string>`** 으로 유지.
+
+- `type="single"`: Set 의 size 는 0 또는 1.
+- `type="multiple"`: Set 의 size 는 0 이상.
+
+공개 API 경계에서만 어댑터를 두어, Root 가 controlled/uncontrolled 과 관계없이 `(next: Set<string>) => void` 를 호출하면 내부에서:
+- `type="single"`: `onValueChange?.(firstOf(next) ?? "")`.
+- `type="multiple"`: `onValueChange?.(Array.from(next))`.
+
+이로써 `toggle/open/close` 같은 reducer 로직은 Set 연산 하나로 통일된다.
+
+### 3.2 Item id 유일성
+
+`AccordionItem.value` 는 Root 내에서 유일해야 한다. dev 빌드에서 렌더 시 MutationObserver 없이 Root 가 Children.toArray 로 item value 를 수집해 `Set` 에 넣으며 중복이면 `console.error`.
+
+```ts
+// dev-only
+if (process.env.NODE_ENV !== "production") {
+  const seen = new Set<string>();
+  items.forEach((it) => {
+    if (seen.has(it.value)) console.error(`[Accordion] duplicate value: ${it.value}`);
+    seen.add(it.value);
+  });
+}
+```
+
+### 3.3 Root Context
+
+```ts
+interface AccordionRootContextValue {
+  type: AccordionType;
+  openSet: ReadonlySet<string>;
+  /** 해당 value 를 토글. type/collapsible 규칙 모두 반영. */
+  toggle: (value: string) => void;
+  /** 해당 value 를 명시적으로 open/close. (키보드 Space 와 분리 용도) */
+  setOpen: (value: string, nextOpen: boolean) => void;
+  disabled: boolean;
+  theme: AccordionTheme;
+  chevronRotation: 90 | 180;
+  disabledFocus: "skip" | "include";
+  loop: boolean;
+  /** 포커스 가능한 Trigger ref 목록 관리 (Arrow 내비게이션) */
+  registerTrigger: (value: string, el: HTMLButtonElement | null) => void;
+  /** Arrow 이동에 사용: 현재 포커스된 value 기준 다음/이전/첫/끝 */
+  focusTrigger: (
+    from: string,
+    dir: "next" | "prev" | "first" | "last",
+  ) => void;
+  /** value → Trigger/Content 내부 ARIA id 계산용 base id */
+  baseId: string;
+}
+```
+
+### 3.4 Item Context
+
+```ts
+interface AccordionItemContextValue {
+  value: string;
+  disabled: boolean;
+  /** 현재 열림 상태 */
+  open: boolean;
+  /** ARIA 쌍을 만드는 id (button.id, content.id) */
+  triggerId: string;
+  contentId: string;
+}
+```
+
+Trigger/Content 는 `useAccordionItemContext()` 로 자기 Item 의 id/open 을 알고, 동시에 `useAccordionRootContext()` 로 toggle/focusTrigger 에 접근한다. Nested Accordion 은 "가장 가까운 Root" 만 참조하므로 React Context 의 기본 동작으로 자연스럽게 해결.
+
+---
+
+## 4. 시각 / 구조 설계
+
+### 4.1 DOM 구조 (`type="single"`, collapsible=true 예)
+
+```
+<div role="presentation" class="acc-root" data-theme="light">
+  <div class="acc-item" data-state="open" data-disabled="false">
+    <h3 class="acc-header">
+      <button type="button"
+              class="acc-trigger"
+              id="acc-xyz-overview-trigger"
+              aria-expanded="true"
+              aria-controls="acc-xyz-overview-content"
+              aria-disabled="false">
+        <span class="acc-chevron" data-state="open">▸</span>
+        <span class="acc-trigger-label">Overview</span>
+      </button>
+    </h3>
+    <div role="region"
+         id="acc-xyz-overview-content"
+         aria-labelledby="acc-xyz-overview-trigger"
+         class="acc-content"
+         data-state="open"
+         style="--accordion-content-height: 124px">
+      <div class="acc-content-inner">Summary…</div>
+    </div>
+  </div>
+
+  <div class="acc-item" data-state="closed" data-disabled="false">
+    <h3 class="acc-header"><button …>…</button></h3>
+    <div role="region" data-state="closed" hidden>…</div>
+  </div>
+
+  <div class="acc-item" data-state="closed" data-disabled="true">
+    <h3 class="acc-header"><button aria-disabled="true" tabindex="-1">…</button></h3>
+    <div role="region" data-state="closed" hidden>…</div>
+  </div>
+</div>
+```
+
+### 4.2 chevron 회전
+
+```css
+.acc-chevron {
+  display: inline-block;
+  width: 12px; height: 12px;
+  transition: transform 180ms cubic-bezier(0.4, 0, 0.2, 1);
+  transform: rotate(0deg);
+  color: var(--acc-chevron-fg);
+}
+.acc-chevron[data-state="open"] {
+  transform: rotate(var(--acc-chevron-open-rotate, 90deg));
+}
+```
+
+`Root` 가 `chevronRotation=180` 이면 root 레벨에 `--acc-chevron-open-rotate: 180deg` 주입.
+
+기본 아이콘은 SVG ("chevron-right"). 사용자가 `hideChevron` 으로 숨길 수도 있고, 완전히 커스텀 아이콘을 사용하고 싶으면 `hideChevron` 후 Trigger children 에 본인 아이콘을 직접 배치.
+
+### 4.3 native `<details>`/`<summary>` vs `<div>` 선택
+
+**`<div>` 선택 이유**:
+
+1. **ARIA 표준 매핑 부정확**: `<details>` 는 UA 에 따라 `role="group"` 으로 노출되며 `aria-expanded` 가 `<summary>` 에 자동으로 들어가지만, "그룹 내 Arrow 내비게이션(다음 trigger 로 포커스 이동)" 이나 `aria-labelledby`/`aria-controls` 쌍은 강제할 수 없다. `<summary>` 는 `button` 이 아니라 고유한 role 을 가진다.
+2. **single mode (상호 배제) 구현 어려움**: native details 는 개별적으로만 열고 닫는다. 같은 그룹에서 하나만 열리도록 하려면 어차피 JS 로 `open` 속성을 조작해야 하며, 그럴거면 div 로 통일하는 편이 일관성 있다. HTML spec 의 `name` 속성(2024 도입)이 있지만 Safari 지원이 불완전.
+3. **애니메이션 제어**: `::details-content` pseudo-element 와 `interpolate-size: allow-keywords` 는 미래형 대안이지만(§5.4), 현재 cross-browser 안정성 + reduced-motion 세밀 제어 관점에서 직접 측정이 더 예측 가능.
+4. **compound API 일관성**: 본 라이브러리의 다른 컴포넌트(CommandPalette/Dialog/Popover)가 모두 div 기반 헤드리스이다. 일관성.
+5. **forceMount, disabled, nested Accordion** 등 세부 기능을 대응하려면 결국 div 가 유리.
+
+단, `<h3>` (`as` 로 변경 가능) 로 Trigger 를 감싸 "목차 문서" 의 heading 구조를 유지한다 — 스크린리더 "heading 목록" 내비게이션 호환성 확보.
+
+### 4.4 palette 토큰
+
+```ts
+// Accordion/theme.ts
+export const accordionPalette = {
+  light: {
+    rootBorder:         "rgba(0,0,0,0.08)",
+    itemBorder:         "rgba(0,0,0,0.08)",
+    headerBg:           "#ffffff",
+    headerBgHover:      "#f8fafc",
+    headerBgActive:     "#eef2f7",
+    triggerFg:          "#0f172a",
+    triggerFgDisabled:  "rgba(15,23,42,0.35)",
+    chevronFg:          "rgba(15,23,42,0.55)",
+    contentBg:          "#ffffff",
+    contentFg:          "#111827",
+    focusRing:          "#2563eb",
+  },
+  dark: {
+    rootBorder:         "rgba(255,255,255,0.08)",
+    itemBorder:         "rgba(255,255,255,0.06)",
+    headerBg:           "#0f172a",
+    headerBgHover:      "#121a2d",
+    headerBgActive:     "#17213b",
+    triggerFg:          "#e5e7eb",
+    triggerFgDisabled:  "rgba(229,231,235,0.35)",
+    chevronFg:          "rgba(229,231,235,0.7)",
+    contentBg:          "#0f172a",
+    contentFg:          "#cbd5e1",
+    focusRing:          "#60a5fa",
+  },
+} as const;
+```
+
+### 4.5 CSS 기본
+
+```css
+.acc-root {
+  border-top: 1px solid var(--acc-root-border);
+  background: transparent;
+}
+.acc-item {
+  border-bottom: 1px solid var(--acc-item-border);
+}
+.acc-header { margin: 0; }
+.acc-trigger {
+  width: 100%;
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 12px;
+  background: var(--acc-header-bg);
+  color: var(--acc-trigger-fg);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  border: 0;
+  outline: none;
+  transition: background 120ms;
+}
+.acc-trigger:hover           { background: var(--acc-header-bg-hover); }
+.acc-trigger[data-state="open"] { background: var(--acc-header-bg-active); }
+.acc-trigger:focus-visible   { box-shadow: inset 0 0 0 2px var(--acc-focus-ring); }
+.acc-trigger[aria-disabled="true"] {
+  color: var(--acc-trigger-fg-disabled);
+  cursor: not-allowed;
+}
+
+.acc-content {
+  overflow: hidden;
+  background: var(--acc-content-bg);
+  color: var(--acc-content-fg);
+  transition:
+    max-height var(--acc-duration, 200ms) cubic-bezier(0.4, 0, 0.2, 1),
+    opacity    var(--acc-duration, 200ms) cubic-bezier(0.4, 0, 0.2, 1);
+}
+.acc-content[data-state="closed"] {
+  max-height: 0;
+  opacity: 0;
+}
+.acc-content[data-state="open"] {
+  max-height: var(--accordion-content-height, 1000px);
+  opacity: 1;
+}
+.acc-content-inner {
+  padding: 12px 12px 16px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .acc-content, .acc-chevron { transition: none !important; }
+}
+```
+
+---
+
+## 5. 핵심 로직 (펼침/접힘 측정과 전환)
+
+### 5.1 접근 방식 비교
+
+| 방식 | 장점 | 단점 | 선택 |
+|---|---|---|---|
+| A. `display: none` 토글 | 간단 | 전환 애니메이션 불가 | ✗ |
+| B. `height: auto` ↔ `0` 직접 전환 | 직관적 | `auto` 는 interpolatable 아님 → 전환 안됨 | ✗ |
+| C. `max-height: 0` ↔ 고정 큰 값 | CSS 만으로 동작 | 큰 값이면 빈 delay, 작은 값이면 clipping | ✗ |
+| **D. 측정 + CSS 변수 주입** (`max-height: var(--h)`) | 정확 + 전환 가능 + cross-browser | 측정 시점 관리 필요 | **v1 선택** |
+| E. `::details-content` + `interpolate-size` | 스펙 일관 | Safari/Firefox 미지원 또는 제한적 | v2 고려 (§16) |
+| F. JS 타이머로 프레임마다 height 조정 | 정밀 제어 | 성능/복잡도 | ✗ |
+
+### 5.2 측정 로직 (방식 D)
+
+각 Item 의 Content 에 inner wrapper 를 두고 그 scrollHeight 를 `ResizeObserver` 로 감시한다.
+
+```ts
+// useContentHeight.ts
+export function useContentHeight(
+  innerRef: React.RefObject<HTMLDivElement | null>,
+  open: boolean,
+): number {
+  const [height, setHeight] = useState(0);
+  useLayoutEffect(() => {
+    const el = innerRef.current;
+    if (!el) return;
+    // 초기 측정
+    setHeight(el.scrollHeight);
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      // contentBoxSize 우선, fallback contentRect
+      const box = entry.contentBoxSize?.[0];
+      const h = box ? box.blockSize : entry.contentRect.height;
+      setHeight(h);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [innerRef, open /* 열릴 때 다시 관찰 */]);
+  return height;
+}
+```
+
+Content 에서 height 를 CSS 변수로 주입:
+```tsx
+<div
+  role="region"
+  className="acc-content"
+  data-state={open ? "open" : "closed"}
+  aria-labelledby={triggerId}
+  id={contentId}
+  style={{ ["--accordion-content-height" as never]: `${height}px` }}
+  hidden={!open && !animating && !forceMount}
+>
+  <div ref={innerRef} className="acc-content-inner">{children}</div>
+</div>
+```
+
+### 5.3 open/close 전환 시퀀스
+
+**Close**: `open: true → false`
+1. 현재 scrollHeight 를 CSS 변수에 기록.
+2. 다음 프레임에 `data-state="closed"` 로 전환 → CSS 가 `max-height: 0` 으로 transition.
+3. `transitionend` 에서 `hidden` 속성 추가(접근성 + 탭 순서 제외). 단 `forceMount` 이면 생략.
+
+**Open**: `open: false → true`
+1. `hidden` 제거 + `data-state="open"` (단, CSS 변수는 이미 마지막으로 측정된 값을 보존 — 첫 open 에서 측정이 없으면 직전 mount 시점 useLayoutEffect 로 미리 확보).
+2. React commit → paint → transition.
+
+**Race 방지**: 빠르게 토글 연속으로 눌렀을 때 `transitionend` 콜백이 다른 state 에 적용되면 이상 상태. `data-state` 값과 이벤트 target 의 상태를 비교해서 mismatch 이면 skip:
+```ts
+const onTransitionEnd = (e: React.TransitionEvent<HTMLDivElement>) => {
+  if (e.propertyName !== "max-height") return;
+  if (e.currentTarget.dataset.state !== "closed") return;
+  if (!forceMount) e.currentTarget.setAttribute("hidden", "");
+};
+```
+
+### 5.4 modern `::details-content` 대안 (v2 후보, §16에 연결)
+
+```css
+/* 참고용 (v1 미적용) */
+.acc-item {
+  interpolate-size: allow-keywords;
+}
+.acc-item::details-content {
+  height: 0;
+  transition:
+    height var(--acc-duration, 200ms) ease-out,
+    content-visibility var(--acc-duration, 200ms) allow-discrete;
+}
+.acc-item[open]::details-content {
+  height: auto;
+}
+```
+
+이 경우 `<details>/<summary>` 로 회귀해야 하며, 위 §4.3 단점(single 모드, Arrow 내비게이션)이 다시 발목을 잡는다. v1 은 div + 측정 방식을 유지하고, v2 에서 baseline 확산 후 재평가.
+
+### 5.5 reduced-motion
+
+- `@media (prefers-reduced-motion: reduce)` 에서 `transition: none`.
+- JS 에서도 `window.matchMedia("(prefers-reduced-motion: reduce)").matches` 를 확인해 `hidden` 속성을 `transitionend` 대기 없이 즉시 토글(transitionend 가 발생하지 않으므로 의존하면 stuck).
+
+```ts
+const reduceMotion = useMemo(
+  () => typeof window !== "undefined" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  [],
+);
+```
+
+마운트 후 media query change 구독은 v1.1. 한 번 읽어 캐시한 값으로 충분.
+
+---
+
+## 6. 제약 (큰 콘텐츠 · 지연 로드 이미지)
+
+### 6.1 매우 큰 Item (수천 px)
+
+- `max-height` 전환 중 브라우저는 매 프레임 layout 을 재계산한다. 단일 item 이 3000 px 을 넘으면 저사양 기기에서 transition 이 튀는 사례가 있다 → `--acc-duration` 기본 200 ms 에 맞춰 프레임 수가 12개 정도이므로 대부분 문제 없으나, 큰 콘텐츠 페이지에서는 사용자가 `style={{ ["--acc-duration"]: "0ms" }}` 로 무효화할 수 있도록 문서화.
+- `contain: layout paint` 를 Content 에 적용해 layout 전파를 격리(§14 참조).
+
+### 6.2 이미지 지연 로드
+
+`<img>` 가 open 후 비동기로 로드되면서 Content height 가 변한다. ResizeObserver 가 이 변화를 감지하면 CSS 변수가 다시 주입되지만, 이때 `data-state` 는 이미 `open` 이라 transition 가 트리거되어 높이가 "부드럽게 성장" 한다. 사용자는 원치 않을 수 있다.
+
+정책:
+- 초기 open 시점의 첫 transition 은 0 → measured 로 정상 진행.
+- 이후 `open` 상태에서 inner scrollHeight 변경은 CSS 변수 업데이트만 즉시 적용하고 transition 은 스킵하기 위해, `data-growing="true"` 플래그를 한 프레임 동안 세워 `.acc-content[data-growing="true"] { transition: none }` 로 우회.
+
+```ts
+const prevHeightRef = useRef(0);
+useLayoutEffect(() => {
+  if (!open) return;
+  if (prevHeightRef.current !== 0 && height !== prevHeightRef.current) {
+    const el = contentRef.current;
+    if (el) {
+      el.dataset.growing = "true";
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (el) delete el.dataset.growing;
+        });
+      });
+    }
+  }
+  prevHeightRef.current = height;
+}, [height, open]);
+```
+
+### 6.3 동적 자식 (Content 내부에 `<Accordion.Root>` nested)
+
+nested 가 열리면 바깥 height 도 증가한다. 바깥의 ResizeObserver 가 반응해 바깥 CSS 변수 갱신. 위 6.2 로직과 동일하게 "성장" 은 스킵(또는 허용 — 정책 결정).
+
+**결정**: 성장은 transition 스킵(튀지 않음). 수축은 자연 transition 없이 즉시 반영. 요약: **open 상태 유지 중 height 변경 → transition 없이 반영**. transition 은 오직 open↔closed 전환에서만.
+
+---
+
+## 7. 키보드
+
+Trigger 는 `<button type="button">` 이므로 네이티브로 Enter/Space 토글을 받는다. Arrow/Home/End 는 Root 컨텍스트의 `focusTrigger` 를 통해 구현.
+
+| 키 | 동작 (Trigger focus 상태) |
+|---|---|
+| `Enter` / `Space` | 현재 Item toggle. `type="single"` + `collapsible=false` 이면, 이미 열린 자기 자신은 토글 불가(무동작). |
+| `ArrowDown` | 다음 focusable Trigger 로 이동. `loop=true` 면 마지막에서 첫 번째로 wrap. |
+| `ArrowUp` | 이전 focusable Trigger. wrap 동일. |
+| `Home` | 첫 focusable Trigger. |
+| `End` | 마지막 focusable Trigger. |
+| `Tab` / `Shift+Tab` | 그룹을 벗어남 (roving tabindex 아님 — 모든 Trigger 는 tabindex=0). |
+
+### 7.1 roving tabindex 여부
+
+Radix 는 `ArrowDown/Up` 을 사용하므로 tabindex 를 개별 0 으로 두고 Arrow 만 우리가 처리. Tab 으로도 하나씩 넘길 수 있다(Radix 와 동일). 본 plan 도 이 방식 채택 — roving tabindex 불필요.
+
+단 `disabledFocus: "skip"` 이면 disabled Trigger 에 `tabindex="-1"` 를 주어 Tab 순회에서 제외하되, Arrow 로도 건너뛴다.
+
+### 7.2 키 처리 로직
+
+```ts
+function onTriggerKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
+  if (e.key === "ArrowDown") { e.preventDefault(); focusTrigger(value, "next"); }
+  else if (e.key === "ArrowUp") { e.preventDefault(); focusTrigger(value, "prev"); }
+  else if (e.key === "Home") { e.preventDefault(); focusTrigger(value, "first"); }
+  else if (e.key === "End") { e.preventDefault(); focusTrigger(value, "last"); }
+  // Enter/Space 는 native <button> click → toggle 로 처리됨
+}
+```
+
+### 7.3 `type="single"` + `collapsible=false` 의 특수 규칙
+
+- 이 조합은 "하나는 항상 열림" 을 강제.
+- 열린 항목의 Trigger 를 클릭해도 close 불가(사용자가 다른 Trigger 를 눌러야 전환).
+- Space/Enter 로도 close 불가. 이때 Trigger 의 `aria-expanded` 는 true 로 고정되고 사용자 입장에서 "아무 일도 안 일어남" → 혼란 방지를 위해 dev console 에서 1 회 디버그 힌트 출력("use collapsible prop to allow closing").
+- 초기 value 가 "" 이면, 첫 번째 non-disabled item 이 자동 open 되지는 않는다(사용자 의도 보존) — 단 dev warn.
+
+### 7.4 포커스 이동 구현
+
+Root 가 trigger element ref map 을 유지:
+```ts
+const triggerRefsRef = useRef<Map<string, HTMLButtonElement>>(new Map());
+const orderRef = useRef<string[]>([]); // DOM 순서 유지용
+
+function registerTrigger(value: string, el: HTMLButtonElement | null) {
+  if (el) {
+    triggerRefsRef.current.set(value, el);
+    if (!orderRef.current.includes(value)) orderRef.current.push(value);
+  } else {
+    triggerRefsRef.current.delete(value);
+    orderRef.current = orderRef.current.filter(v => v !== value);
+  }
+}
+```
+
+order 는 Item 이 렌더될 때 삽입되므로 실제 DOM 순서와 동일. `focusTrigger("a", "next")` 는 order 에서 a 다음 non-skipped value 를 찾아 `.focus()` 호출.
+
+---
+
+## 8. 상태 관리 (controlled / uncontrolled / onValueChange)
+
+### 8.1 내부 표현과 공개 표현 분리
+
+```ts
+function normalizeValue(
+  type: AccordionType,
+  external: string | string[] | undefined,
+): Set<string> {
+  if (external === undefined) return new Set();
+  if (type === "single") {
+    return typeof external === "string" && external ? new Set([external]) : new Set();
+  }
+  return new Set(Array.isArray(external) ? external : []);
+}
+
+function denormalize(
+  type: AccordionType,
+  internal: Set<string>,
+): string | string[] {
+  if (type === "single") {
+    return internal.size === 0 ? "" : Array.from(internal)[0]!;
+  }
+  return Array.from(internal);
+}
+```
+
+### 8.2 useControllable 활용
+
+`useControllable` 은 값 변환 없이 그대로 통과하므로, 여기서는 한 번 감싼다:
+
+```ts
+const [valueOpen, setValueOpen] = useControllable<Set<string>>(
+  props.value !== undefined ? normalizeValue(props.type, props.value) : undefined,
+  normalizeValue(props.type, props.defaultValue),
+  (next) => {
+    props.onValueChange?.(denormalize(props.type, next) as never);
+  },
+);
+```
+
+> 주의: `useControllable` 은 controlled 일 때 `controlled !== undefined` 로 판정한다. prop `value` 를 `Set` 으로 변환한 결과가 항상 truthy(빈 Set 도 존재) 이므로 판정 무결. 단, controlled 여부는 **원본 prop `value`** 기준이어야 하므로 `controlled` 인자로는 "value prop 이 undefined 이면 undefined, 아니면 Set" 을 넘긴다.
+
+### 8.3 toggle 규칙
+
+```ts
+function toggle(value: string) {
+  if (disabled) return;
+  if (disabledItems.has(value)) return;
+
+  const next = new Set(valueOpen);
+  const isOpen = next.has(value);
+
+  if (type === "single") {
+    if (isOpen) {
+      if (!collapsible) {
+        // ignore (dev hint)
+        if (process.env.NODE_ENV !== "production") {
+          console.debug("[Accordion] collapsible=false: cannot close the only open item");
+        }
+        return;
+      }
+      next.delete(value);
+    } else {
+      next.clear();
+      next.add(value);
+    }
+  } else {
+    if (isOpen) next.delete(value);
+    else next.add(value);
+  }
+
+  setValueOpen(next);
+}
+```
+
+### 8.4 onValueChange 호출 시점
+
+- 사용자 인터랙션으로 상태가 바뀔 때만 호출.
+- Root 의 `defaultValue` 로 인한 초기 mount 에서는 호출하지 않음.
+- controlled 모드에서는 상태 업데이트 없이 `onValueChange` 만 호출(owner 가 다음 `value` 를 결정).
+
+---
+
+## 9. 애니메이션
+
+### 9.1 duration / easing
+
+- 기본 200 ms, `cubic-bezier(0.4, 0, 0.2, 1)`.
+- CSS 변수 `--acc-duration` 과 `--acc-easing` 로 Root/Item 단위 override 가능:
+  ```tsx
+  <Accordion.Root style={{ ["--acc-duration"]: "120ms" }}>…</Accordion.Root>
+  ```
+
+### 9.2 reduced-motion
+
+위 §5.5. `prefers-reduced-motion: reduce` 에서 `transition: none`. JS 는 `transitionend` 대신 즉시 상태 적용 (transitionend 가 안 오는 경우 고려).
+
+### 9.3 Safari 의 `height: auto` / `max-height` 특이사항
+
+- Safari 17 이전은 `max-height` transition 중 children 에 sticky/position:fixed 가 있을 때 flicker 발생 사례. Content inner 에 `will-change: max-height` 금지 (오히려 악화) — plain transition 유지.
+- iOS Safari 는 `touch-action` 미지정 시 native pan gesture 가 transition 을 중단시키는 엣지케이스가 있다. Content 에는 `touch-action: pan-y` 를 명시하지 않고 default 그대로 둔다. Trigger button 은 기본 `touch-action: manipulation` 적용(double-tap zoom 방지).
+
+### 9.4 chevron 전환
+
+transform: rotate 는 composited 프로퍼티라 매우 저렴. 200 ms 가 아닌 180 ms 로 약간 짧게 두어 "먼저 회전 → content 펼침" 이라는 미세한 시각적 계층을 만든다.
+
+### 9.5 animation interrupt 허용
+
+빠르게 두 번 클릭 시:
+- 첫 클릭: 0 → measured 로 open 시작.
+- 두 번째 클릭: measured → 0 로 close 시작. 단, 현재 컴포넌트가 이미 transition 중이므로 `data-state` 만 갈아끼우면 브라우저가 "current computed max-height → 0" 으로 자연스레 전환. 실제 테스트 시 smooth interrupt 관찰됨. 별도 abort 로직 불필요.
+
+---
+
+## 10. 파일 구조
+
+```
+src/components/Accordion/
+├── Accordion.tsx              # Root + Item + Header + Trigger + Content 조립
+├── Accordion.types.ts         # 공개 타입
+├── AccordionContext.ts        # RootContext + ItemContext + hook
+├── useContentHeight.ts        # ResizeObserver 기반 measured height hook
+├── useAccordionState.ts       # controlled/uncontrolled + toggle reducer
+├── theme.ts                   # accordionPalette
+└── index.ts                   # 배럴
+```
+
+각 파일 책임:
+
+- **Accordion.tsx**
+  - `AccordionRoot` / `AccordionItem` / `AccordionHeader` / `AccordionTrigger` / `AccordionContent` 함수 컴포넌트.
+  - Root: `useAccordionState` 훅 호출 + RootContext.Provider + palette CSS 변수 주입 + children 검증(dev).
+  - Item: disabled 병합(Root+Item), Item id 생성(`useId`), ItemContext.Provider.
+  - Header: `as` 태그 (기본 `h3`).
+  - Trigger: button + aria-expanded/controls + keydown + registerTrigger.
+  - Content: role=region + ref + useContentHeight + hidden 관리 + transitionend.
+  - namespace `Accordion = { Root, Item, Header, Trigger, Content }`.
+
+- **Accordion.types.ts**
+  - §2.1 전부.
+
+- **AccordionContext.ts**
+  - `AccordionRootContext`, `AccordionItemContext`.
+  - `useAccordionRootContext()` / `useAccordionItemContext()` — null 이면 throw (`"must be used within Accordion.Root/Item"`).
+
+- **useContentHeight.ts**
+  - ResizeObserver 기반 scrollHeight 관측 + height setter + 성장 vs 전환 구분 플래그 (§6.2).
+
+- **useAccordionState.ts**
+  - normalizeValue/denormalize + toggle reducer + `registerTrigger`/`focusTrigger` + reduced-motion 감지.
+  - Root 내부에서 한 번 호출되는 단일 훅.
+
+- **theme.ts**
+  - `accordionPalette` (light/dark) + css variable 적용 헬퍼.
+
+- **index.ts**
+  - `export { Accordion } from "./Accordion";` + type re-exports.
+
+---
+
+## 11. 구현 단계 (후속 agent 가 순차 실행)
+
+각 단계는 독립 커밋 권장. 각 커밋이 `npm run typecheck` + `npx tsup` 통과 상태.
+
+### Step 1 — 타입 + 배럴 + 테마 스켈레톤
+1. `Accordion.types.ts` 작성 (§2.1 전부, discriminated union 포함).
+2. `theme.ts` 작성 (palette).
+3. `AccordionContext.ts` 기본 틀 (두 context + null-throw hook).
+4. `index.ts` 배럴.
+5. `src/components/index.ts` 에 `export * from "./Accordion";`.
+6. `Accordion.tsx` placeholder: `export const Accordion = { Root: () => null, Item: () => null, Header: () => null, Trigger: () => null, Content: () => null };`.
+7. `npm run typecheck` 통과.
+8. 커밋: `feat(Accordion): 타입 + 컨텍스트 + 배럴`.
+
+### Step 2 — Root 기본 렌더 + state hook
+1. `useAccordionState` 작성 — `useControllable` 감싸기 + normalize/denormalize + toggle reducer.
+2. `AccordionRoot` 에서 hook 호출 + RootContext.Provider + `<div class="acc-root">` 렌더.
+3. palette CSS 변수 주입.
+4. 커밋: `feat(Accordion): Root 상태 + context provider`.
+
+### Step 3 — Item / Header / Trigger (click toggle, chevron)
+1. `AccordionItem` — ItemContext + id 생성 + disabled 병합.
+2. `AccordionHeader` — `as` 태그.
+3. `AccordionTrigger` — `<button>` + `aria-expanded` / `aria-controls` + onClick → `toggle(value)` + chevron 스팬.
+4. chevron CSS (회전).
+5. 이 단계에서 Content 는 단순히 `hidden={!open}` 만 (애니메이션 없음). 토글 동작 확인.
+6. 커밋: `feat(Accordion): Item/Header/Trigger 토글`.
+
+### Step 4 — Content 애니메이션 (측정 + max-height)
+1. `useContentHeight` 작성.
+2. `AccordionContent` — role=region + ResizeObserver 연결 + CSS 변수 주입 + data-state + transitionend 로 hidden 재적용.
+3. CSS 전환 규칙.
+4. reduced-motion 분기.
+5. 커밋: `feat(Accordion): Content max-height 전환`.
+
+### Step 5 — 키보드 내비게이션 + 포커스 관리
+1. Root 에 `registerTrigger`/`focusTrigger` 구현.
+2. Trigger onKeyDown: Arrow/Home/End.
+3. `disabledFocus="skip"` 분기.
+4. 커밋: `feat(Accordion): 키보드 내비게이션`.
+
+### Step 6 — 이미지 지연 로드 / 성장 전환 스킵
+1. §6.2 prevHeightRef + data-growing 플래그.
+2. 커밋: `feat(Accordion): Content 성장 시 transition 스킵`.
+
+### Step 7 — Dark 테마 + 시각 마감
+1. `theme="dark"` palette.
+2. focus ring / hover / active 조정.
+3. 커밋: `feat(Accordion): dark 테마`.
+
+### Step 8 — 데모 페이지
+1. `demo/src/pages/AccordionPage.tsx` (§12).
+2. `demo/src/App.tsx` NAV 에 `"accordion"` 추가.
+3. 커밋: `feat(Accordion): 데모 페이지`.
+
+### Step 9 — Props 표 + Usage 예제
+1. Props 표 (Root/Item/Header/Trigger/Content 5 개).
+2. Usage (최소 4 개).
+3. 커밋: `feat(Accordion): 데모 props 표 + usage`.
+
+### Step 10 — 마감
+1. §20 Definition of Done 모두 체크.
+2. 커밋: `docs(Accordion): DoD 확인`.
+
+---
+
+## 12. 데모 페이지
+
+`demo/src/pages/AccordionPage.tsx`. 기존 `CommandPalettePage.tsx` 레이아웃 복제. 각 섹션은 `<section id="...">` + 우측 사이드바 NAV 와 연동.
+
+### 12.1 NAV 추가 (App.tsx)
+
+```ts
+{ id: "accordion", label: "Accordion", description: "수직 collapsible 섹션", sections: [
+  { label: "Basic (single)",       id: "basic-single" },
+  { label: "Multiple",             id: "multiple" },
+  { label: "Controlled",           id: "controlled" },
+  { label: "Disabled",             id: "disabled" },
+  { label: "Custom trigger",       id: "custom-trigger" },
+  { label: "Nested",               id: "nested" },
+  { label: "Reduced motion",       id: "reduced-motion" },
+  { label: "Dark",                 id: "dark" },
+  { label: "Playground",           id: "playground" },
+  { label: "Props",                id: "props" },
+  { label: "Usage",                id: "usage" },
+]},
+```
+
+그리고 `Page` 타입에 `"accordion"` 추가 + 하단 `{current === "accordion" && <AccordionPage />}`.
+
+### 12.2 섹션 구성
+
+**Basic (single)** — 가장 단순한 예. `collapsible` 포함.
+```tsx
+<Accordion.Root type="single" collapsible defaultValue="overview">
+  <Accordion.Item value="overview">
+    <Accordion.Header>
+      <Accordion.Trigger>Overview</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>
+      <p>This pipeline ingests 3 data sources and produces 2 artifacts.</p>
+    </Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="nodes">
+    <Accordion.Header>
+      <Accordion.Trigger>Nodes</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>
+      <ul><li>Source A</li><li>Transform B</li><li>Sink C</li></ul>
+    </Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="metrics">
+    <Accordion.Header>
+      <Accordion.Trigger>Metrics</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>
+      <p>Throughput: 1.2k rec/s, Latency p99: 420ms.</p>
+    </Accordion.Content>
+  </Accordion.Item>
+</Accordion.Root>
+```
+
+**Multiple**
+```tsx
+<Accordion.Root type="multiple" defaultValue={["overview", "metrics"]}>
+  …(동일 구조)
+</Accordion.Root>
+```
+
+**Controlled**
+```tsx
+const [open, setOpen] = useState<string>("overview");
+return (
+  <>
+    <div className="flex gap-2 mb-2">
+      <Button onClick={() => setOpen("overview")}>Open Overview</Button>
+      <Button onClick={() => setOpen("nodes")}>Open Nodes</Button>
+      <Button onClick={() => setOpen("")}>Close all</Button>
+    </div>
+    <Accordion.Root type="single" collapsible value={open} onValueChange={setOpen}>
+      …
+    </Accordion.Root>
+  </>
+);
+```
+
+**Disabled** — Root 전체 vs 개별 Item
+```tsx
+<Accordion.Root type="single" collapsible>
+  <Accordion.Item value="a"><Accordion.Header><Accordion.Trigger>A (enabled)</Accordion.Trigger></Accordion.Header><Accordion.Content>…</Accordion.Content></Accordion.Item>
+  <Accordion.Item value="b" disabled><Accordion.Header><Accordion.Trigger>B (disabled)</Accordion.Trigger></Accordion.Header><Accordion.Content>…</Accordion.Content></Accordion.Item>
+  <Accordion.Item value="c"><Accordion.Header><Accordion.Trigger>C</Accordion.Trigger></Accordion.Header><Accordion.Content>…</Accordion.Content></Accordion.Item>
+</Accordion.Root>
+```
+
+**Custom trigger (chevron 위치/아이콘 교체, 뱃지)**
+```tsx
+<Accordion.Root type="single" collapsible>
+  <Accordion.Item value="a">
+    <Accordion.Header>
+      <Accordion.Trigger hideChevron>
+        <MyIcon /> <span>Custom trigger</span>
+        <span className="ml-auto badge">3</span>
+      </Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>…</Accordion.Content>
+  </Accordion.Item>
+</Accordion.Root>
+```
+
+**Nested** — Content 안에 또 다른 Accordion.Root. 바깥/안쪽 독립 상태 동작 확인.
+```tsx
+<Accordion.Root type="multiple" defaultValue={["outer-1"]}>
+  <Accordion.Item value="outer-1">
+    <Accordion.Header><Accordion.Trigger>Outer 1</Accordion.Trigger></Accordion.Header>
+    <Accordion.Content>
+      <Accordion.Root type="single" collapsible defaultValue="inner-a">
+        <Accordion.Item value="inner-a">
+          <Accordion.Header><Accordion.Trigger>Inner A</Accordion.Trigger></Accordion.Header>
+          <Accordion.Content>Inner A body</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="inner-b">
+          <Accordion.Header><Accordion.Trigger>Inner B</Accordion.Trigger></Accordion.Header>
+          <Accordion.Content>Inner B body</Accordion.Content>
+        </Accordion.Item>
+      </Accordion.Root>
+    </Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="outer-2">…</Accordion.Item>
+</Accordion.Root>
+```
+
+**Reduced motion** — 사용자가 체크박스로 강제 `--acc-duration: 0ms` override. 시스템 reduced-motion 효과도 안내.
+```tsx
+const [instant, setInstant] = useState(false);
+return (
+  <>
+    <label><input type="checkbox" checked={instant} onChange={e => setInstant(e.target.checked)} /> Instant (0ms)</label>
+    <Accordion.Root type="single" collapsible style={instant ? { ["--acc-duration"]: "0ms" } : undefined}>…</Accordion.Root>
+  </>
+);
+```
+
+**Dark**
+```tsx
+<div style={{ background: "#0b1220", padding: 16 }}>
+  <Accordion.Root theme="dark" type="multiple" defaultValue={["a"]}>…</Accordion.Root>
+</div>
+```
+
+**Playground**
+상단 컨트롤 바:
+- `type` 라디오 (single / multiple)
+- `collapsible` 체크박스 (single 일 때만 활성)
+- `disabled` 체크박스 (Root)
+- `disabledFocus` 라디오 (skip / include)
+- `chevronRotation` 라디오 (90 / 180)
+- `loop` 체크박스
+- `theme` 라디오 (light / dark)
+- `--acc-duration` input (ms)
+
+아래에 Accordion 렌더 + 현재 value JSON 표시.
+
+**Props 표** — Root / Item / Header / Trigger / Content 5 개 섹션.
+
+**Usage (4개)**
+1. Basic single + collapsible.
+2. Multiple with external controls.
+3. Nested Accordion (바깥 multiple, 안쪽 single).
+4. Custom trigger with icon/badge + dark.
+
+---
+
+## 13. 검증 계획
+
+### 13.1 자동화
+```bash
+cd /Users/neo/workspace/plastic
+npm run typecheck
+npx tsup
+```
+주의:
+- `exactOptionalPropertyTypes: true` — optional prop 은 `?:` 유지, 내부 디폴트 머지에서 `undefined` 분기 필요.
+- `noUncheckedIndexedAccess: true` — `Array.from(openSet)[0]` 타입이 `string | undefined`. `!` 필요.
+- `verbatimModuleSyntax: true` — 타입 import 는 `import type`.
+- discriminated union 의 `collapsible?: never` 는 controlled caller 에게 타입 레벨에서 multiple+collapsible 조합을 차단.
+
+### 13.2 수동 (demo dev server)
+```bash
+cd demo && npm run dev
+```
+
+체크리스트:
+- [ ] Basic single: 첫 번째 열림, 다른 것 클릭 시 이전 닫히고 새로 열림, 열린 것 재클릭 시 닫힘(`collapsible`).
+- [ ] Basic single + `collapsible=false`: 열린 것 재클릭 무동작. dev console 힌트 출력.
+- [ ] Multiple: 여러 개 동시 열림/닫힘 각각 독립.
+- [ ] Controlled: 외부 버튼으로 open 전환 즉시 반영. 사용자 클릭 시 onValueChange 만 호출되고 외부 state 주도.
+- [ ] Disabled(item): 해당 Trigger 클릭 무동작, cursor=not-allowed, aria-disabled=true.
+- [ ] Disabled(Root): 모든 Trigger 무동작.
+- [ ] `disabledFocus="skip"`: Tab 으로 disabled Trigger 건너뜀. Arrow 로도 건너뜀.
+- [ ] Custom trigger: `hideChevron` 으로 chevron 숨김, children 만 표시. aria-expanded 여전히 동기화.
+- [ ] Nested: 바깥 Item 닫을 때 안쪽 상태 유지 여부 — `forceMount=false` 기본이면 닫힐 때 hidden. 다시 열면 안쪽 상태 유지(React state 는 그대로).
+- [ ] Nested: 안쪽 Accordion Arrow 내비게이션이 바깥으로 누출되지 않음.
+- [ ] Reduced motion: 시스템 설정 on → transition 없음. Instant 체크박스 동일.
+- [ ] Animation interrupt: 매우 빠른 연속 클릭에도 상태가 어긋나지 않음, 최종 aria-expanded 정확.
+- [ ] 이미지 load 후 height sync: placeholder → 이미지 로드 → CSS 변수 갱신, 기존 transition 끊기지 않음.
+- [ ] 키보드: ArrowDown/Up 로 Trigger 순회, Home/End 로 처음/끝, Enter/Space 로 토글, loop=false 이면 끝에서 멈춤.
+- [ ] ARIA: VoiceOver 로 "collapsed/expanded" 읽힘. Content 가 region 으로 읽힘. aria-controls 가 content id 일치.
+- [ ] Dark 테마: 모든 상태(hover/active/focus/open) 다크 팔레트 반영.
+- [ ] Playground: 모든 컨트롤 조합 실시간 반영.
+- [ ] 다른 페이지(CommandPalette/PipelineGraph/DataTable) 리그레션 없음.
+
+### 13.3 엣지 케이스
+- [ ] `type="single"` + `value=""` (모두 닫힘) 으로 controlled — 정상 동작.
+- [ ] `type="multiple"` + `value=[]` — 정상 동작.
+- [ ] 중복 `Accordion.Item value` — dev console.error + 첫 번째만 인식 (후속은 무시/마지막 승리 여부 정하기 — 본 plan: 후속 승리, 즉 같은 value 의 Trigger 2 개가 있으면 둘 다 상태를 공유).
+- [ ] Root 밖에서 Trigger 사용 시 Context null → throw (잡아냄).
+- [ ] Item 밖에서 Trigger/Content 사용 시 throw.
+- [ ] forceMount=true 인 Content: 닫혀도 DOM 유지 + hidden 속성으로 aria 감춤.
+- [ ] disabled item 이 현재 open 중일 때 runtime 에 disabled 로 바뀜 → 여전히 열린 채 유지되고 Trigger 만 비활성.
+- [ ] Content 내부에 `<input>` 이 있고 닫힘 상태일 때 Tab 이 그 input 에 도달하지 않음(`hidden` 덕).
+- [ ] Content 내부 `<iframe>` 의 scrollHeight 반영 — ResizeObserver 가 iframe 자체 크기 변화를 감지하지는 못하지만 iframe 은 보통 height 고정이라 문제 없음.
+- [ ] `prefers-reduced-motion: reduce` 세팅에서 첫 open 시 측정 → 즉시 반영.
+- [ ] React Strict Mode 이중 마운트: ResizeObserver 가 새로 생성+해제되어도 누수 없음.
+- [ ] unmount 직전 transition 중: cleanup 에서 ResizeObserver.disconnect, event listener 제거.
+
+---
+
+## 14. 성능
+
+### 14.1 목표
+- Item 10 개, 각 Content 1000 px 규모에서 toggle 시 **60 fps** 유지(transitionend 이전 dropped frame 0).
+- 100 개 Item, 모두 닫힘 상태 초기 마운트 < 20 ms.
+
+### 14.2 병목 가설 + 완화
+1. **ResizeObserver 대량 등록**: 100 Item 각각 RO 등록 시 브라우저 비용 상승. 완화: RO 는 **닫힌 Item 에서 비활성** (닫혔는데 측정할 이유 없음 — 단, 첫 open 시 측정값 확보를 위해 최초 1 회는 필요). 정책: Item 이 한 번이라도 open 된 이후에만 RO 유지. 구현 단순화를 위해 v1 은 항상 유지하되, 100 개 이상에서 체감 문제 시 v1.1 에 옵트아웃 도입.
+2. **Context 변경 시 전파 rerender**: Root 상태(openSet) 가 바뀌면 RootContext value 가 새 reference — 모든 Item/Trigger rerender. 완화:
+   - Root 는 openSet 만 바뀌어도 context value 재생성 불가피. 대신 Trigger/Content 가 자기 Item 의 `open` 에 의존 → 파생값은 Item Context 에서 selector 적 추출. 하지만 React Context 는 selector 미지원 → `React.memo` 로 Item/Trigger/Content 각각 감싸고 비교 함수에서 "자기 value 의 open 만" 비교.
+   - 실제 데이터: Item 100 개 중 한 쪽이 토글될 때 rerender 99 개 vs 1 개 차이. 측정 후 필요하면 `useSyncExternalStore` 패턴으로 전환 (v1.1).
+3. **flex/layout reflow**: max-height 전환 중 parent 가 overflow:auto 이면 scrollbar 가 튄다. 완화: root container 에 `contain: layout` 권장(문서화). Content 에는 `contain: layout paint` 적용.
+4. **큰 scrollHeight 변경 감지 빈도**: ResizeObserver 의 콜백은 rAF 단위 배치. 문제 없음.
+
+### 14.3 측정 방법
+- DevTools Performance 탭에서 토글 연속 녹화 → Long Task < 50 ms.
+- 눈으로 "툭"/"점프" 없는 부드러움 확인.
+
+---
+
+## 15. 접근성
+
+### 15.1 ARIA 매핑
+
+- `Accordion.Root`: `role="presentation"` (그룹 래퍼, semantic 은 각 Item 의 heading 으로). 대안 `role="group" aria-label` 도 논쟁 대상이나 Radix/MUI 전례에 따라 presentation.
+- `Accordion.Header`: 기본 `h3` (heading). 사용자가 `as` 로 레벨 조절.
+- `Accordion.Trigger`: `<button type="button">`. `aria-expanded={open}`, `aria-controls={contentId}`, `aria-disabled={disabled}`. disabled 일 때 `tabindex={disabledFocus === "skip" ? -1 : 0}`.
+- `Accordion.Content`: `<div role="region" id={contentId} aria-labelledby={triggerId}>`. 닫힘 상태에서 `hidden` 속성으로 AT 에서 숨김(forceMount 는 aria-hidden + visually hidden 전략도 가능하나 v1 은 `hidden` 고정).
+
+### 15.2 heading 권고
+
+Trigger 를 heading 으로 감싸는 것은 WAI-ARIA Authoring Practices (APG) 의 accordion 패턴 정석. `as="div"` 로 꺼도 동작은 하나 "landmark/heading 목록" 기반 내비게이션 호환성이 떨어지므로 dev warn:
+```ts
+if (as === "div" && process.env.NODE_ENV !== "production") {
+  console.warn("[Accordion.Header] as='div' disables heading-based screen reader nav; prefer h2~h6");
+}
+```
+
+### 15.3 키보드
+
+APG 권고 그대로:
+- Enter/Space: 토글.
+- ArrowDown/Up: Trigger 간 이동.
+- Home/End: 처음/끝.
+- Tab: Trigger 를 순회.
+
+### 15.4 포커스 가시성
+
+`:focus-visible` 로 2 px inset box-shadow. ring 색상은 palette focusRing.
+
+### 15.5 스크린리더 테스트
+
+- macOS VoiceOver: "Overview, collapsed, button" / "Overview, expanded, button".
+- NVDA(Windows): 동일.
+- Content open 후 VoiceOver 가 region 으로 읽고 aria-labelledby 로 "Overview region" 명시.
+
+### 15.6 reduced-motion
+
+시스템 설정 + CSS media query 로 transition 제거. JS 로직도 animation end 대기하지 않음.
+
+---
+
+## 16. 알려진 트레이드오프 · 결정
+
+1. **div 기반 vs native `<details>/<summary>`**: native 는 no-JS 에서도 작동하고 ARIA 자동이지만, single mode 상호배제, Arrow 내비게이션, 세밀한 애니메이션 제어, nested 시 Root 스코프 분리 모두 수동 JS 가 필요. 어차피 JS 필요하면 일관된 div 스택이 유리. Radix/HeadlessUI/MUI 전례와 일치.
+2. **`max-height` 측정 vs `::details-content` + `interpolate-size`**: 후자는 CSS-only 우아함이 매력이나 2026-04 기준 Safari 지원은 tech-preview. 본 plan 은 cross-browser 안정성과 `prefers-reduced-motion` 제어, 이미지 지연 로드 성장 스킵 등 세밀한 정책을 위해 측정 방식을 유지. Safari 17+ 지원이 baseline 확산되면 v2 에서 switch. 두 방식 모두 overflow:hidden 기반이라 focus-ring 짤림 같은 제약은 동일.
+3. **`max-height` vs `height` 직접 전환**: `max-height` 는 "content 보다 크게 설정해도 무해" 해서 측정 실패 시 graceful fallback (큰 값) 이 되지만, transition 이 실제 content height 까지만 보이게 보간되어 시각이 정확. height 는 auto 보간이 안 됨(§5.1). 측정값 주입 시 `max-height: var(--h)` vs `height: var(--h)` 둘 다 동작하나, max-height 이 더 permissive.
+4. **Set 내부 표현**: `string[]` 그대로 써도 되지만 중복/순서 고려 시 Set 이 reducer 를 단순화. 공개 API 는 배열/문자열 유지.
+5. **`collapsible` 이 single 전용**: discriminated union 으로 `multiple` + `collapsible` 를 타입 레벨에서 차단 (collapsible?: never). 의미 혼동 방지.
+6. **controlled + defaultValue 동시**: useControllable 의 contract 에 따라 controlled 이면 defaultValue 무시 (dev warn 없음 — 조용히). Radix 와 동일.
+7. **Arrow 내비게이션의 Root 경계**: nested 의 안쪽 Accordion 에서 Arrow 누르면 가장 가까운 Root 기준. 구현: Trigger 의 onKeyDown 에서 `useAccordionRootContext` 로 가장 가까운 Root 의 focusTrigger 호출. 바깥으로 누출 안 됨.
+8. **disabled Item 의 open 유지**: 이미 열린 Item 이 runtime 에 disabled 로 바뀌면? "열린 상태 유지, Trigger 만 무효" 로 결정(정보 소실 방지). Radix 도 동일.
+9. **forceMount**: 닫혀 있어도 DOM 유지. SEO/anchor scroll/내부 state 보존 등 용도. 대신 hidden=true 여서 인쇄에도 기본 제외.
+10. **heading level 기본 h3**: 본 라이브러리의 사용 맥락(페이지 내 sub-section) 에서 h3 이 흔함. 사용자가 `as="h2"`/`"h4"` 로 조정.
+11. **chevronRotation=180 의 의미**: 일부 디자인(특히 "+ → ×" 같은 플러스 아이콘 회전)은 180° 선호. 기본 90° 는 `▸→▾`, 180° 는 `＋→＋(회전)` 같은 컨텍스트에 적합.
+12. **`Accordion.from(items)` 헬퍼 미포함**: 데이터 중심 팀은 맵을 직접 쓰는 것으로 충분(`items.map(it => <Accordion.Item …>)`). 헬퍼는 API 표면만 늘린다.
+
+---
+
+## 17. 후속 작업 (v1.1+)
+
+- **horizontal Accordion**: `orientation="horizontal"` — 좌우 collapse. keyboard ArrowLeft/Right, chevron 회전 축 변경. layout 이 flex row 로 바뀌므로 재설계 범위.
+- **DnD 재정렬**: `dnd-kit` 또는 자체 pointer drag 로 Item 순서 교체. Accordion open 상태 유지 + value 배열 재정렬 콜백 (`onOrderChange`).
+- **sticky 헤더**: open 된 Item 이 viewport 를 넘치면 해당 Header 를 상단 sticky. `position: sticky; top: 0;` + z-index 조정. scrollable 부모와의 인터랙션 주의.
+- **인디케이터 render prop**: `<Accordion.Trigger renderIndicator={(open) => …}>` 로 chevron 을 완전 custom. 현재는 `hideChevron` + 사용자 children 직접 배치로 우회 가능하나 selector API 가 깔끔.
+- **`Accordion.from(items)`**: declarative 맵핑 헬퍼.
+- **lazy Content**: `lazy` prop — 최초 open 시에만 children 렌더. SSR/코드분할 친화.
+- **animation preset prop**: `animation={{ duration: 150, easing: "ease-in-out" }}` — CSS var 대안 API.
+- **`::details-content` 마이그레이션** (v2): baseline 안정 시 native 전환 실험.
+- **다른 plastic 컴포넌트 내부 활용**: DataTable 의 group header, PipelineGraphInspector 의 섹션 분리 — Accordion 으로 통합.
+- **SSR 초기 open 높이 추정**: Content 가 텍스트 중심이면 char count 기반 대략값을 주입해 first paint flicker 완화. v1.2.
+
+---
+
+## 18. 관련 파일 인벤토리 (구현 시 참조)
+
+| 용도 | 경로 |
+|---|---|
+| useControllable (dual API) | `/Users/neo/workspace/plastic/src/components/_shared/useControllable.ts` |
+| 선행 expand/collapse 로직 (chevron + 높이 전환 패턴) | `/Users/neo/workspace/plastic/src/components/PipelineGraph/PipelineGraphCluster.tsx` |
+| 배럴 등록 | `/Users/neo/workspace/plastic/src/components/index.ts` |
+| 데모 App 라우팅 / NAV | `/Users/neo/workspace/plastic/demo/src/App.tsx` |
+| 데모 페이지 레이아웃 템플릿 (최근 기준) | `/Users/neo/workspace/plastic/demo/src/pages/CommandPalettePage.tsx` |
+| tsconfig 제약 | `/Users/neo/workspace/plastic/tsconfig.json` |
+| 이전 plan 포맷 참고 (템플릿) | `/Users/neo/workspace/plastic/docs/plans/017-splitpane-component.md` |
+
+---
+
+## 19. 의존성 영향
+
+신규 런타임 의존 없음. React 18.3 (기존) + DOM API (`ResizeObserver`, `matchMedia`, `requestAnimationFrame`, `useId`) 만 사용.
+
+번들 영향:
+- Accordion 자체 예상 크기: ~2.8 KB (min), ~1.2 KB (min+gzip).
+- plastic 전체 dist 거의 영향 없음.
+
+Browser 지원:
+- ResizeObserver: Chrome 64+, Firefox 69+, Safari 13.1+.
+- `matchMedia`: 전 브라우저.
+- `useId` (React 18): 이미 사용 중.
+- CSS `transition`/`transform`: 전 브라우저.
+- `prefers-reduced-motion`: Safari 10.1+, Chrome 74+, Firefox 63+.
+
+---
+
+## 20. 구현 완료 정의 (Definition of Done)
+
+- [ ] `npm run typecheck` 통과.
+- [ ] `npx tsup` 통과 (타입 선언 포함).
+- [ ] demo 에 `/#/accordion` 라우트 동작.
+- [ ] §13.2 수동 체크리스트 항목 전부 눈으로 확인.
+- [ ] §13.3 엣지 케이스 항목 전부 눈으로 확인 또는 "v1 범위 밖" 이유 기재.
+- [ ] CommandPalette / PipelineGraph / DataTable / Dialog / Popover / Tooltip / Toast / 기타 페이지 리그레션 없음.
+- [ ] `src/components/index.ts` 배럴에 `export * from "./Accordion";` 추가됨.
+- [ ] `package.json` dependencies 변경 없음 (신규 의존 없음).
+- [ ] Props 문서 섹션에 Root/Item/Header/Trigger/Content 다섯 개 표 채움.
+- [ ] Usage 섹션에 최소 4 개 스니펫 (basic single / multiple / nested / custom trigger + dark).
+- [ ] 데모 Playground 에서 모든 prop 토글 가능.
+- [ ] Light/Dark 테마 전환 시 시각 이상 없음.
+- [ ] 키보드 단독으로 (마우스 없이) Trigger 순회 + 토글 가능.
+- [ ] `prefers-reduced-motion: reduce` 시 transition 없이 즉시 open/close.
+- [ ] Nested Accordion 의 안쪽 Arrow 가 바깥 Root 로 누출되지 않음.
+- [ ] discriminated union (`type="single"` 에만 `collapsible` 허용) 이 타입 수준에서 검증됨.
+- [ ] 스크린리더(VoiceOver) 에서 Trigger 의 expanded/collapsed 상태가 읽히고 Content 가 region 으로 안내됨.
+
+---
+
+**끝.**


### PR DESCRIPTION
## Summary
- plastic 컴포넌트 라이브러리 로드맵 013~022 에 대한 상세 설계 문서 10건 추가
- 각 문서는 017 SplitPane 플랜 템플릿(20 섹션: TL;DR / Goals / 공개 API / 도메인 / 시각 / 핵심 로직 / 제약 / 키보드 / 상태 / 고유 기능 / 파일 구조 / 구현 단계 / 데모 / 검증 / 성능 / 접근성 / 트레이드오프 / 후속 / 인벤토리 / DoD) 구조를 따름
- 총 **14,847 lines**

## Components

| # | 컴포넌트 | Lines |
|---|---|--:|
| 013 | Select | 1,397 |
| 014 | Combobox | 1,544 |
| 015 | DatePicker | 1,541 |
| 016 | Tabs | 1,557 |
| 017 | SplitPane | 1,207 |
| 018 | Tree | 1,715 |
| 019 | ContextMenu | 1,653 |
| 020 | Progress | 1,483 |
| 021 | Skeleton | 1,432 |
| 022 | Accordion | 1,318 |

## Test plan
- [x] 10개 문서 모두 20 섹션 구조 일관성 확인
- [x] 파일 인벤토리(§18) 참조 경로 유효성 스팟체크
- [x] tsconfig 제약(exactOptionalPropertyTypes / noUncheckedIndexedAccess / verbatimModuleSyntax) 명시 여부
- [x] 각 문서 §11 구현 단계가 독립 커밋 가능한 단위로 쪼개져 있는지
- [x] docs-only 변경 — 런타임 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)