### PR TITLE
feat(Select): 컴포넌트 + 데모 추가 (#222-#246)

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -12,8 +12,9 @@ import { StepperPage } from "./pages/StepperPage";
 import CommandPalettePage from "./pages/CommandPalettePage";
 import HexViewPage from "./pages/HexViewPage";
 import { PipelineGraphPage } from "./pages/PipelineGraphPage";
+import SelectPage from "./pages/SelectPage";
 
-type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph";
+type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select";
 
 interface SubItem { label: string; id: string }
 
@@ -166,6 +167,19 @@ const NAV: { id: Page; label: string; description: string; sections: SubItem[] }
     { label: "Custom node render", id: "custom-node" },
     { label: "Dark theme", id: "dark" },
     { label: "Large graph", id: "large" },
+    { label: "Props", id: "props" },
+    { label: "Usage", id: "usage" },
+    { label: "Playground", id: "playground" },
+  ]},
+  { id: "select", label: "Select", description: "단일 값 드롭다운", sections: [
+    { label: "Basic", id: "basic" },
+    { label: "Grouped", id: "grouped" },
+    { label: "Disabled", id: "disabled" },
+    { label: "Controlled", id: "controlled" },
+    { label: "Form", id: "form" },
+    { label: "Custom Render", id: "custom-render" },
+    { label: "Long List", id: "long-list" },
+    { label: "Dark Theme", id: "dark" },
     { label: "Props", id: "props" },
     { label: "Usage", id: "usage" },
     { label: "Playground", id: "playground" },
@@ -421,6 +435,7 @@ export function App() {
         {current === "commandpalette" && <CommandPalettePage />}
         {current === "hexview" && <HexViewPage />}
         {current === "pipelinegraph" && <PipelineGraphPage />}
+        {current === "select" && <SelectPage />}
       </main>
     </div>
   );

--- a/demo/src/pages/SelectPage.tsx
+++ b/demo/src/pages/SelectPage.tsx
@@ -162,6 +162,195 @@ function ControlledDemo() {
   );
 }
 
+function CustomRenderDemo() {
+  const languages = [
+    { value: "ts", label: "TypeScript", ext: ".ts", badge: "TS", color: "#3178c6" },
+    { value: "js", label: "JavaScript", ext: ".js", badge: "JS", color: "#f7df1e" },
+    { value: "py", label: "Python", ext: ".py", badge: "Py", color: "#306998" },
+    { value: "go", label: "Go", ext: ".go", badge: "Go", color: "#00add8" },
+    { value: "rs", label: "Rust", ext: ".rs", badge: "Rs", color: "#dea584" },
+  ];
+  return (
+    <Select.Root defaultValue="ts" placeholder="언어">
+      <Select.Trigger aria-label="언어" style={{ minWidth: 260 }}>
+        <Select.Value />
+        <Select.Icon />
+      </Select.Trigger>
+      <Select.Content minWidth={260}>
+        {languages.map((l) => (
+          <Select.Item key={l.value} value={l.value} textValue={l.label}>
+            <span
+              style={{
+                width: 18,
+                height: 18,
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                background: l.color,
+                color: l.value === "js" ? "#000" : "#fff",
+                fontSize: 10,
+                fontWeight: 700,
+                borderRadius: 3,
+                flexShrink: 0,
+              }}
+            >
+              {l.badge}
+            </span>
+            <span style={{ flex: 1 }}>{l.label}</span>
+            <span style={{ fontSize: 11, color: "#9ca3af", marginLeft: "auto" }}>
+              {l.ext}
+            </span>
+          </Select.Item>
+        ))}
+      </Select.Content>
+    </Select.Root>
+  );
+}
+
+const TIMEZONES = [
+  "Africa/Cairo",
+  "Africa/Johannesburg",
+  "Africa/Lagos",
+  "Africa/Nairobi",
+  "America/Anchorage",
+  "America/Argentina/Buenos_Aires",
+  "America/Bogota",
+  "America/Chicago",
+  "America/Denver",
+  "America/Halifax",
+  "America/Lima",
+  "America/Los_Angeles",
+  "America/Mexico_City",
+  "America/New_York",
+  "America/Phoenix",
+  "America/Santiago",
+  "America/Sao_Paulo",
+  "America/Toronto",
+  "America/Vancouver",
+  "Asia/Bangkok",
+  "Asia/Dhaka",
+  "Asia/Dubai",
+  "Asia/Ho_Chi_Minh",
+  "Asia/Hong_Kong",
+  "Asia/Jakarta",
+  "Asia/Jerusalem",
+  "Asia/Kolkata",
+  "Asia/Kuala_Lumpur",
+  "Asia/Manila",
+  "Asia/Riyadh",
+  "Asia/Seoul",
+  "Asia/Shanghai",
+  "Asia/Singapore",
+  "Asia/Taipei",
+  "Asia/Tehran",
+  "Asia/Tokyo",
+  "Atlantic/Azores",
+  "Atlantic/Reykjavik",
+  "Australia/Adelaide",
+  "Australia/Brisbane",
+  "Australia/Melbourne",
+  "Australia/Perth",
+  "Australia/Sydney",
+  "Europe/Amsterdam",
+  "Europe/Athens",
+  "Europe/Berlin",
+  "Europe/Brussels",
+  "Europe/Dublin",
+  "Europe/Helsinki",
+  "Europe/Istanbul",
+  "Europe/Lisbon",
+  "Europe/London",
+  "Europe/Madrid",
+  "Europe/Moscow",
+  "Europe/Oslo",
+  "Europe/Paris",
+  "Europe/Prague",
+  "Europe/Rome",
+  "Europe/Stockholm",
+  "Europe/Vienna",
+  "Europe/Warsaw",
+  "Europe/Zurich",
+  "Pacific/Auckland",
+  "Pacific/Fiji",
+  "Pacific/Honolulu",
+  "UTC",
+];
+
+function LongListDemo() {
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      <Select.Root defaultValue="Asia/Seoul" placeholder="타임존">
+        <Select.Trigger aria-label="타임존" style={{ minWidth: 260 }}>
+          <Select.Value />
+          <Select.Icon />
+        </Select.Trigger>
+        <Select.Content maxHeight={320}>
+          {TIMEZONES.map((tz) => (
+            <Select.Item key={tz} value={tz}>
+              {tz}
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select.Root>
+      <span className="text-sm text-gray-500">
+        팝업 open 상태에서 <code className="font-mono">"as"</code> 타이핑 → Asia 로 점프
+      </span>
+    </div>
+  );
+}
+
+function DarkDemo() {
+  return (
+    <div
+      style={{
+        background: "#0f172a",
+        padding: 24,
+        borderRadius: 8,
+        display: "flex",
+        gap: 16,
+        alignItems: "center",
+        flexWrap: "wrap",
+      }}
+    >
+      <Select.Root theme="dark" defaultValue="ts" placeholder="언어">
+        <Select.Trigger aria-label="언어" style={{ minWidth: 200 }}>
+          <Select.Value />
+          <Select.Icon />
+        </Select.Trigger>
+        <Select.Content>
+          <Select.Group label="프론트엔드">
+            <Select.Item value="ts">
+              <Select.ItemIndicator />
+              <span>TypeScript</span>
+            </Select.Item>
+            <Select.Item value="js">
+              <Select.ItemIndicator />
+              <span>JavaScript</span>
+            </Select.Item>
+          </Select.Group>
+          <Select.Separator />
+          <Select.Group label="백엔드">
+            <Select.Item value="py">
+              <Select.ItemIndicator />
+              <span>Python</span>
+            </Select.Item>
+            <Select.Item value="go">
+              <Select.ItemIndicator />
+              <span>Go</span>
+            </Select.Item>
+            <Select.Item value="rs" disabled>
+              Rust (준비 중)
+            </Select.Item>
+          </Select.Group>
+        </Select.Content>
+      </Select.Root>
+      <span style={{ color: "#94a3b8", fontSize: 13 }}>
+        dark theme — Trigger/Content/Item 전체 색상 전환
+      </span>
+    </div>
+  );
+}
+
 function FormDemo() {
   const [submitted, setSubmitted] = useState<string | null>(null);
   return (
@@ -250,6 +439,34 @@ export default function SelectPage() {
         <Card>
           <FormDemo />
         </Card>
+      </Section>
+
+      <Section
+        id="custom-render"
+        title="Custom Render"
+        desc="Item 에 임의 children. textValue prop 으로 type-ahead 문자열 명시."
+      >
+        <Card>
+          <CustomRenderDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="long-list"
+        title="Long List + Type-ahead"
+        desc="많은 옵션 + maxHeight 스크롤. 팝업 open 중 문자 타이핑 → startsWith 매칭으로 점프. 500ms 미입력 시 버퍼 리셋."
+      >
+        <Card>
+          <LongListDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="dark"
+        title="Dark Theme"
+        desc="theme='dark' — Trigger / Content / Item / Group label 전체가 어두운 팔레트로 전환."
+      >
+        <DarkDemo />
       </Section>
     </div>
   );

--- a/demo/src/pages/SelectPage.tsx
+++ b/demo/src/pages/SelectPage.tsx
@@ -351,6 +351,155 @@ function DarkDemo() {
   );
 }
 
+type Side = "top" | "right" | "bottom" | "left";
+type Align = "start" | "center" | "end";
+
+function PlaygroundDemo() {
+  const [placeholder, setPlaceholder] = useState("선택하세요…");
+  const [side, setSide] = useState<Side>("bottom");
+  const [align, setAlign] = useState<Align>("start");
+  const [sideOffset, setSideOffset] = useState(4);
+  const [maxHeight, setMaxHeight] = useState(320);
+  const [matchTriggerWidth, setMatchTriggerWidth] = useState(true);
+  const [disabled, setDisabled] = useState(false);
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const [value, setValue] = useState<string | undefined>(undefined);
+
+  const demoBg = theme === "dark" ? "#0f172a" : "#f9fafb";
+  const demoFg = theme === "dark" ? "#e5e7eb" : "#374151";
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 p-4 bg-gray-50 rounded-md border border-gray-200">
+        <label className="flex flex-col gap-1 text-xs text-gray-600">
+          placeholder
+          <input
+            type="text"
+            value={placeholder}
+            onChange={(e) => setPlaceholder(e.target.value)}
+            className="px-2 py-1 border border-gray-300 rounded text-sm"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-gray-600">
+          side
+          <select
+            value={side}
+            onChange={(e) => setSide(e.target.value as Side)}
+            className="px-2 py-1 border border-gray-300 rounded text-sm"
+          >
+            <option value="top">top</option>
+            <option value="right">right</option>
+            <option value="bottom">bottom</option>
+            <option value="left">left</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-gray-600">
+          align
+          <select
+            value={align}
+            onChange={(e) => setAlign(e.target.value as Align)}
+            className="px-2 py-1 border border-gray-300 rounded text-sm"
+          >
+            <option value="start">start</option>
+            <option value="center">center</option>
+            <option value="end">end</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-gray-600">
+          sideOffset
+          <input
+            type="number"
+            value={sideOffset}
+            onChange={(e) => setSideOffset(Number(e.target.value))}
+            className="px-2 py-1 border border-gray-300 rounded text-sm"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-gray-600">
+          maxHeight
+          <input
+            type="number"
+            value={maxHeight}
+            onChange={(e) => setMaxHeight(Number(e.target.value))}
+            className="px-2 py-1 border border-gray-300 rounded text-sm"
+          />
+        </label>
+        <label className="flex items-center gap-2 text-xs text-gray-600 pt-4">
+          <input
+            type="checkbox"
+            checked={matchTriggerWidth}
+            onChange={(e) => setMatchTriggerWidth(e.target.checked)}
+          />
+          matchTriggerWidth
+        </label>
+        <label className="flex items-center gap-2 text-xs text-gray-600 pt-4">
+          <input
+            type="checkbox"
+            checked={disabled}
+            onChange={(e) => setDisabled(e.target.checked)}
+          />
+          disabled
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-gray-600">
+          theme
+          <select
+            value={theme}
+            onChange={(e) => setTheme(e.target.value as "light" | "dark")}
+            className="px-2 py-1 border border-gray-300 rounded text-sm"
+          >
+            <option value="light">light</option>
+            <option value="dark">dark</option>
+          </select>
+        </label>
+      </div>
+
+      <div
+        style={{
+          background: demoBg,
+          color: demoFg,
+          padding: 40,
+          borderRadius: 8,
+          display: "flex",
+          gap: 16,
+          alignItems: "center",
+          flexWrap: "wrap",
+        }}
+      >
+        <Select.Root
+          value={value}
+          onValueChange={setValue}
+          placeholder={placeholder}
+          disabled={disabled}
+          theme={theme}
+        >
+          <Select.Trigger aria-label="Playground" style={{ minWidth: 220 }}>
+            <Select.Value />
+            <Select.Icon />
+          </Select.Trigger>
+          <Select.Content
+            side={side}
+            align={align}
+            sideOffset={sideOffset}
+            maxHeight={maxHeight}
+            matchTriggerWidth={matchTriggerWidth}
+          >
+            <Select.Item value="ts">TypeScript</Select.Item>
+            <Select.Item value="js">JavaScript</Select.Item>
+            <Select.Item value="py">Python</Select.Item>
+            <Select.Item value="go">Go</Select.Item>
+            <Select.Item value="rs">Rust</Select.Item>
+            <Select.Item value="java">Java</Select.Item>
+            <Select.Item value="kt">Kotlin</Select.Item>
+            <Select.Item value="swift">Swift</Select.Item>
+          </Select.Content>
+        </Select.Root>
+        <span style={{ fontSize: 13 }}>
+          value: <code className="font-mono">{value ?? "(없음)"}</code>
+        </span>
+      </div>
+    </div>
+  );
+}
+
 function FormDemo() {
   const [submitted, setSubmitted] = useState<string | null>(null);
   return (
@@ -467,6 +616,14 @@ export default function SelectPage() {
         desc="theme='dark' — Trigger / Content / Item / Group label 전체가 어두운 팔레트로 전환."
       >
         <DarkDemo />
+      </Section>
+
+      <Section
+        id="playground"
+        title="Playground"
+        desc="모든 제어 가능한 옵션을 실시간으로 조합해 볼 수 있는 섹션."
+      >
+        <PlaygroundDemo />
       </Section>
     </div>
   );

--- a/demo/src/pages/SelectPage.tsx
+++ b/demo/src/pages/SelectPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from "react";
-import { Select } from "plastic";
+import { Button, Select } from "plastic";
 
 function Section({
   id,
@@ -131,6 +131,70 @@ function DisabledDemo() {
   );
 }
 
+function ControlledDemo() {
+  const [value, setValue] = useState<string>("ts");
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      <Button variant="outline" onClick={() => setValue("ts")}>
+        TS
+      </Button>
+      <Button variant="outline" onClick={() => setValue("py")}>
+        Python
+      </Button>
+      <Button variant="outline" onClick={() => setValue("go")}>
+        Go
+      </Button>
+      <Select.Root value={value} onValueChange={setValue}>
+        <Select.Trigger aria-label="언어" style={{ minWidth: 200 }}>
+          <Select.Value />
+          <Select.Icon />
+        </Select.Trigger>
+        <Select.Content>
+          <Select.Item value="ts">TypeScript</Select.Item>
+          <Select.Item value="py">Python</Select.Item>
+          <Select.Item value="go">Go</Select.Item>
+        </Select.Content>
+      </Select.Root>
+      <span className="text-sm text-gray-500">
+        현재: <code className="font-mono">{value}</code>
+      </span>
+    </div>
+  );
+}
+
+function FormDemo() {
+  const [submitted, setSubmitted] = useState<string | null>(null);
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const data = new FormData(e.currentTarget);
+        setSubmitted(String(data.get("lang") ?? ""));
+      }}
+      className="flex items-center gap-3 flex-wrap"
+    >
+      <Select.Root name="lang" required defaultValue="ts">
+        <Select.Trigger aria-label="언어" style={{ minWidth: 200 }}>
+          <Select.Value />
+          <Select.Icon />
+        </Select.Trigger>
+        <Select.Content>
+          <Select.Item value="ts">TypeScript</Select.Item>
+          <Select.Item value="js">JavaScript</Select.Item>
+          <Select.Item value="py">Python</Select.Item>
+          <Select.Item value="go">Go</Select.Item>
+        </Select.Content>
+      </Select.Root>
+      <Button type="submit">제출</Button>
+      {submitted !== null && (
+        <span className="text-sm text-gray-600">
+          제출됨: <code className="font-mono">lang={submitted}</code>
+        </span>
+      )}
+    </form>
+  );
+}
+
 export default function SelectPage() {
   return (
     <div className="max-w-4xl">
@@ -165,6 +229,26 @@ export default function SelectPage() {
       >
         <Card>
           <DisabledDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="controlled"
+        title="Controlled"
+        desc="외부 state 로 value 제어. 외부 버튼 변경 → Trigger 라벨 즉시 갱신."
+      >
+        <Card>
+          <ControlledDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="form"
+        title="Form"
+        desc="name prop 을 주면 hidden input 으로 값이 form submit 에 포함됨."
+      >
+        <Card>
+          <FormDemo />
         </Card>
       </Section>
     </div>

--- a/demo/src/pages/SelectPage.tsx
+++ b/demo/src/pages/SelectPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from "react";
-import { Button, Select } from "plastic";
+import { Button, CodeView, Select } from "plastic";
 
 function Section({
   id,
@@ -30,6 +30,174 @@ function Card({ children }: { children: ReactNode }) {
     </div>
   );
 }
+
+function PropsTable({
+  rows,
+}: {
+  rows: Array<[string, string, string, string]>;
+}) {
+  return (
+    <table className="w-full text-left text-sm border border-gray-200 rounded-lg overflow-hidden">
+      <thead className="bg-gray-50">
+        <tr>
+          <th className="px-4 py-2 border-b border-gray-200 font-semibold">
+            Prop
+          </th>
+          <th className="px-4 py-2 border-b border-gray-200 font-semibold">
+            Type
+          </th>
+          <th className="px-4 py-2 border-b border-gray-200 font-semibold">
+            Default
+          </th>
+          <th className="px-4 py-2 border-b border-gray-200 font-semibold">
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(([prop, type, def, desc]) => (
+          <tr key={prop} className="border-t border-gray-100">
+            <td className="px-4 py-2 font-mono text-xs">{prop}</td>
+            <td className="px-4 py-2 font-mono text-xs text-gray-600">
+              {type}
+            </td>
+            <td className="px-4 py-2 font-mono text-xs text-gray-600">{def}</td>
+            <td className="px-4 py-2 text-gray-700">{desc}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+const ROOT_PROPS: Array<[string, string, string, string]> = [
+  ["value", "string", "—", "선택값 (controlled)"],
+  ["defaultValue", "string", "—", "초기 선택값 (uncontrolled)"],
+  ["onValueChange", "(value: string) => void", "—", "선택값 변경 콜백"],
+  ["open", "boolean", "—", "열림 상태 (controlled)"],
+  ["defaultOpen", "boolean", "false", "초기 열림 상태"],
+  ["onOpenChange", "(open: boolean) => void", "—", "열림 상태 변경 콜백"],
+  ["placeholder", "string", "—", "선택값 없을 때 Trigger 표시 문구"],
+  ["disabled", "boolean", "false", "전체 비활성"],
+  ["name", "string", "—", "form hidden input name (있으면 hidden input 렌더)"],
+  ["required", "boolean", "false", "form required"],
+  ["theme", "'light' | 'dark'", "'light'", "테마"],
+];
+
+const TRIGGER_PROPS: Array<[string, string, string, string]> = [
+  [
+    "...ButtonHTMLAttributes",
+    "—",
+    "—",
+    "type / onClick 제외한 button 속성 전부 전달",
+  ],
+  ["style / className", "—", "—", "스타일 오버라이드"],
+];
+
+const CONTENT_PROPS: Array<[string, string, string, string]> = [
+  ["side", "'top' | 'right' | 'bottom' | 'left'", "'bottom'", "팝업 배치 면"],
+  ["align", "'start' | 'center' | 'end'", "'start'", "Trigger 기준 정렬"],
+  ["sideOffset", "number", "4", "Trigger ↔ 팝업 간격 (px)"],
+  ["maxHeight", "number", "320", "팝업 최대 높이 (px)"],
+  ["matchTriggerWidth", "boolean", "true", "Trigger 너비에 맞춤"],
+  ["minWidth", "number", "—", "matchTriggerWidth=false 일 때 최소 너비"],
+  ["closeOnOutsideClick", "boolean", "true", "바깥 클릭 시 닫힘"],
+  ["closeOnEscape", "boolean", "true", "Escape 시 닫힘"],
+];
+
+const ITEM_PROPS: Array<[string, string, string, string]> = [
+  ["value", "string", "—", "아이템 값 (필수, 고유)"],
+  ["disabled", "boolean", "false", "비활성 — 마우스/키보드 선택 불가"],
+  [
+    "textValue",
+    "string",
+    "(textContent)",
+    "type-ahead 매칭용 문자열. 커스텀 render 시 명시 권장",
+  ],
+];
+
+const GROUP_PROPS: Array<[string, string, string, string]> = [
+  ["label", "ReactNode", "—", "그룹 헤더 — 내부에 Label 자동 렌더"],
+];
+
+const VALUE_PROPS: Array<[string, string, string, string]> = [
+  ["placeholder", "string", "—", "ctx.placeholder 대신 로컬 override"],
+  [
+    "children",
+    "ReactNode | (value) => ReactNode",
+    "—",
+    "커스텀 표시. 함수 형태면 render-prop",
+  ],
+];
+
+const USAGE_BASIC = `import { Select } from "plastic";
+
+function App() {
+  return (
+    <Select.Root placeholder="언어 선택…">
+      <Select.Trigger>
+        <Select.Value />
+        <Select.Icon />
+      </Select.Trigger>
+      <Select.Content>
+        <Select.Item value="ts">TypeScript</Select.Item>
+        <Select.Item value="js">JavaScript</Select.Item>
+        <Select.Item value="py">Python</Select.Item>
+      </Select.Content>
+    </Select.Root>
+  );
+}`;
+
+const USAGE_GROUPED = `<Select.Root defaultValue="ts">
+  <Select.Trigger>
+    <Select.Value />
+    <Select.Icon />
+  </Select.Trigger>
+  <Select.Content>
+    <Select.Group label="프론트엔드">
+      <Select.Item value="ts">
+        <Select.ItemIndicator />
+        <span>TypeScript</span>
+      </Select.Item>
+      <Select.Item value="js">
+        <Select.ItemIndicator />
+        <span>JavaScript</span>
+      </Select.Item>
+    </Select.Group>
+    <Select.Separator />
+    <Select.Group label="백엔드">
+      <Select.Item value="py">
+        <Select.ItemIndicator />
+        <span>Python</span>
+      </Select.Item>
+    </Select.Group>
+  </Select.Content>
+</Select.Root>`;
+
+const USAGE_CONTROLLED_FORM = `function FormSelect() {
+  const [lang, setLang] = useState("ts");
+  return (
+    <form onSubmit={handleSubmit}>
+      <Select.Root name="lang" required value={lang} onValueChange={setLang}>
+        <Select.Trigger>
+          <Select.Value />
+          <Select.Icon />
+        </Select.Trigger>
+        <Select.Content>
+          <Select.Item value="ts">TypeScript</Select.Item>
+          <Select.Item value="py">Python</Select.Item>
+        </Select.Content>
+      </Select.Root>
+      <button type="submit">제출</button>
+    </form>
+  );
+}`;
+
+const USAGE_CUSTOM = `<Select.Item value="ts" textValue="TypeScript">
+  <TSBadge />
+  <span style={{ flex: 1 }}>TypeScript</span>
+  <span style={{ marginLeft: "auto", color: "#9ca3af" }}>.ts</span>
+</Select.Item>`;
 
 function BasicDemo() {
   const [value, setValue] = useState<string | undefined>(undefined);
@@ -616,6 +784,56 @@ export default function SelectPage() {
         desc="theme='dark' — Trigger / Content / Item / Group label 전체가 어두운 팔레트로 전환."
       >
         <DarkDemo />
+      </Section>
+
+      <Section id="props" title="Props">
+        <div className="flex flex-col gap-6">
+          <div>
+            <p className="text-sm font-semibold mb-2">Select.Root</p>
+            <PropsTable rows={ROOT_PROPS} />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">Select.Trigger</p>
+            <PropsTable rows={TRIGGER_PROPS} />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">Select.Value</p>
+            <PropsTable rows={VALUE_PROPS} />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">Select.Content</p>
+            <PropsTable rows={CONTENT_PROPS} />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">Select.Item</p>
+            <PropsTable rows={ITEM_PROPS} />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">Select.Group</p>
+            <PropsTable rows={GROUP_PROPS} />
+          </div>
+        </div>
+      </Section>
+
+      <Section id="usage" title="Usage">
+        <div className="flex flex-col gap-6">
+          <div>
+            <p className="text-sm font-semibold mb-2">1. 기본 Select</p>
+            <CodeView code={USAGE_BASIC} language="tsx" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">2. 그룹 + 구분선 + ✓</p>
+            <CodeView code={USAGE_GROUPED} language="tsx" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">3. Controlled + form</p>
+            <CodeView code={USAGE_CONTROLLED_FORM} language="tsx" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">4. Custom render</p>
+            <CodeView code={USAGE_CUSTOM} language="tsx" />
+          </div>
+        </div>
       </Section>
 
       <Section

--- a/demo/src/pages/SelectPage.tsx
+++ b/demo/src/pages/SelectPage.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
+import { Select } from "plastic";
 
 function Section({
   id,
@@ -30,6 +31,106 @@ function Card({ children }: { children: ReactNode }) {
   );
 }
 
+function BasicDemo() {
+  const [value, setValue] = useState<string | undefined>(undefined);
+  return (
+    <div className="flex items-center gap-4">
+      <Select.Root
+        value={value}
+        onValueChange={setValue}
+        placeholder="언어 선택…"
+      >
+        <Select.Trigger aria-label="언어" style={{ minWidth: 180 }}>
+          <Select.Value />
+          <Select.Icon />
+        </Select.Trigger>
+        <Select.Content>
+          <Select.Item value="ts">TypeScript</Select.Item>
+          <Select.Item value="js">JavaScript</Select.Item>
+          <Select.Item value="py">Python</Select.Item>
+          <Select.Item value="go">Go</Select.Item>
+          <Select.Item value="rs">Rust</Select.Item>
+        </Select.Content>
+      </Select.Root>
+      <span className="text-sm text-gray-500">
+        현재: <code className="font-mono">{value ?? "(없음)"}</code>
+      </span>
+    </div>
+  );
+}
+
+function GroupedDemo() {
+  return (
+    <Select.Root defaultValue="ts" placeholder="언어">
+      <Select.Trigger aria-label="언어" style={{ minWidth: 220 }}>
+        <Select.Value />
+        <Select.Icon />
+      </Select.Trigger>
+      <Select.Content>
+        <Select.Group label="프론트엔드">
+          <Select.Item value="ts">
+            <Select.ItemIndicator />
+            <span>TypeScript</span>
+          </Select.Item>
+          <Select.Item value="js">
+            <Select.ItemIndicator />
+            <span>JavaScript</span>
+          </Select.Item>
+        </Select.Group>
+        <Select.Separator />
+        <Select.Group label="백엔드">
+          <Select.Item value="py">
+            <Select.ItemIndicator />
+            <span>Python</span>
+          </Select.Item>
+          <Select.Item value="go">
+            <Select.ItemIndicator />
+            <span>Go</span>
+          </Select.Item>
+          <Select.Item value="rs">
+            <Select.ItemIndicator />
+            <span>Rust</span>
+          </Select.Item>
+        </Select.Group>
+      </Select.Content>
+    </Select.Root>
+  );
+}
+
+function DisabledDemo() {
+  return (
+    <div className="flex items-center gap-4">
+      <Select.Root defaultValue="ts" placeholder="언어">
+        <Select.Trigger aria-label="언어 (Item 일부 disabled)" style={{ minWidth: 220 }}>
+          <Select.Value />
+          <Select.Icon />
+        </Select.Trigger>
+        <Select.Content>
+          <Select.Item value="ts">TypeScript</Select.Item>
+          <Select.Item value="js">JavaScript</Select.Item>
+          <Select.Item value="rs" disabled>
+            Rust (준비 중)
+          </Select.Item>
+          <Select.Item value="ko" disabled>
+            Kotlin (준비 중)
+          </Select.Item>
+          <Select.Item value="py">Python</Select.Item>
+        </Select.Content>
+      </Select.Root>
+      <Select.Root disabled defaultValue="ts" placeholder="비활성">
+        <Select.Trigger aria-label="Select 전체 disabled" style={{ minWidth: 180 }}>
+          <Select.Value />
+          <Select.Icon />
+        </Select.Trigger>
+        <Select.Content>
+          <Select.Item value="ts">TypeScript</Select.Item>
+          <Select.Item value="js">JavaScript</Select.Item>
+        </Select.Content>
+      </Select.Root>
+    </div>
+  );
+}
+
 export default function SelectPage() {
   return (
     <div className="max-w-4xl">
@@ -42,7 +143,29 @@ export default function SelectPage() {
       </header>
 
       <Section id="basic" title="Basic" desc="Trigger + Content + Item 기본 구조.">
-        <Card>TODO</Card>
+        <Card>
+          <BasicDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="grouped"
+        title="Grouped + ItemIndicator"
+        desc="Group/Label/Separator. 선택된 항목에 ✓ 인디케이터."
+      >
+        <Card>
+          <GroupedDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="disabled"
+        title="Disabled"
+        desc="개별 Item 과 Select 전체 disabled. 키보드 이동 시 disabled Item 은 건너뜀."
+      >
+        <Card>
+          <DisabledDemo />
+        </Card>
       </Section>
     </div>
   );

--- a/demo/src/pages/SelectPage.tsx
+++ b/demo/src/pages/SelectPage.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+
+function Section({
+  id,
+  title,
+  desc,
+  children,
+}: {
+  id?: string;
+  title: string;
+  desc?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} className="mb-10">
+      <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-2">
+        {title}
+      </p>
+      {desc && <p className="text-sm text-gray-500 mb-3">{desc}</p>}
+      {children}
+    </section>
+  );
+}
+
+function Card({ children }: { children: ReactNode }) {
+  return (
+    <div className="p-6 bg-white rounded-lg border border-gray-200">
+      {children}
+    </div>
+  );
+}
+
+export default function SelectPage() {
+  return (
+    <div className="max-w-4xl">
+      <header className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">Select</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          옵션이 유한한 enumerable 값 중 하나를 선택하는 폼 컨트롤. Radix Select
+          와 동일한 compound API.
+        </p>
+      </header>
+
+      <Section id="basic" title="Basic" desc="Trigger + Content + Item 기본 구조.">
+        <Card>TODO</Card>
+      </Section>
+    </div>
+  );
+}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,8 +1,3 @@
-import type {
-  SelectGroupProps,
-  SelectLabelProps,
-  SelectSeparatorProps,
-} from "./Select.types";
 import { SelectRoot } from "./SelectRoot";
 import { SelectTrigger } from "./SelectTrigger";
 import { SelectValue } from "./SelectValue";
@@ -10,10 +5,9 @@ import { SelectIcon } from "./SelectIcon";
 import { SelectContent } from "./SelectContent";
 import { SelectItem } from "./SelectItem";
 import { SelectItemIndicator } from "./SelectItemIndicator";
-
-const SelectGroup = (_p: SelectGroupProps) => null;
-const SelectLabel = (_p: SelectLabelProps) => null;
-const SelectSeparator = (_p: SelectSeparatorProps) => null;
+import { SelectGroup } from "./SelectGroup";
+import { SelectLabel } from "./SelectLabel";
+import { SelectSeparator } from "./SelectSeparator";
 
 export const Select = {
   Root: SelectRoot,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,5 +1,4 @@
 import type {
-  SelectContentProps,
   SelectGroupProps,
   SelectLabelProps,
   SelectItemProps,
@@ -10,8 +9,8 @@ import { SelectRoot } from "./SelectRoot";
 import { SelectTrigger } from "./SelectTrigger";
 import { SelectValue } from "./SelectValue";
 import { SelectIcon } from "./SelectIcon";
+import { SelectContent } from "./SelectContent";
 
-const SelectContent = (_p: SelectContentProps) => null;
 const SelectGroup = (_p: SelectGroupProps) => null;
 const SelectLabel = (_p: SelectLabelProps) => null;
 const SelectItem = (_p: SelectItemProps) => null;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,0 +1,42 @@
+import type {
+  SelectRootProps,
+  SelectTriggerProps,
+  SelectValueProps,
+  SelectIconProps,
+  SelectContentProps,
+  SelectGroupProps,
+  SelectLabelProps,
+  SelectItemProps,
+  SelectItemIndicatorProps,
+  SelectSeparatorProps,
+} from "./Select.types";
+
+function Noop(_props: { children?: unknown }) {
+  return null;
+}
+
+const SelectRoot = (_p: SelectRootProps) => null;
+const SelectTrigger = (_p: SelectTriggerProps) => null;
+const SelectValue = (_p: SelectValueProps) => null;
+const SelectIcon = (_p: SelectIconProps) => null;
+const SelectContent = (_p: SelectContentProps) => null;
+const SelectGroup = (_p: SelectGroupProps) => null;
+const SelectLabel = (_p: SelectLabelProps) => null;
+const SelectItem = (_p: SelectItemProps) => null;
+const SelectItemIndicator = (_p: SelectItemIndicatorProps) => null;
+const SelectSeparator = (_p: SelectSeparatorProps) => null;
+
+void Noop;
+
+export const Select = {
+  Root: SelectRoot,
+  Trigger: SelectTrigger,
+  Value: SelectValue,
+  Icon: SelectIcon,
+  Content: SelectContent,
+  Group: SelectGroup,
+  Label: SelectLabel,
+  Item: SelectItem,
+  ItemIndicator: SelectItemIndicator,
+  Separator: SelectSeparator,
+};

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,7 +1,4 @@
 import type {
-  SelectTriggerProps,
-  SelectValueProps,
-  SelectIconProps,
   SelectContentProps,
   SelectGroupProps,
   SelectLabelProps,
@@ -10,10 +7,10 @@ import type {
   SelectSeparatorProps,
 } from "./Select.types";
 import { SelectRoot } from "./SelectRoot";
+import { SelectTrigger } from "./SelectTrigger";
+import { SelectValue } from "./SelectValue";
+import { SelectIcon } from "./SelectIcon";
 
-const SelectTrigger = (_p: SelectTriggerProps) => null;
-const SelectValue = (_p: SelectValueProps) => null;
-const SelectIcon = (_p: SelectIconProps) => null;
 const SelectContent = (_p: SelectContentProps) => null;
 const SelectGroup = (_p: SelectGroupProps) => null;
 const SelectLabel = (_p: SelectLabelProps) => null;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,8 +1,6 @@
 import type {
   SelectGroupProps,
   SelectLabelProps,
-  SelectItemProps,
-  SelectItemIndicatorProps,
   SelectSeparatorProps,
 } from "./Select.types";
 import { SelectRoot } from "./SelectRoot";
@@ -10,11 +8,11 @@ import { SelectTrigger } from "./SelectTrigger";
 import { SelectValue } from "./SelectValue";
 import { SelectIcon } from "./SelectIcon";
 import { SelectContent } from "./SelectContent";
+import { SelectItem } from "./SelectItem";
+import { SelectItemIndicator } from "./SelectItemIndicator";
 
 const SelectGroup = (_p: SelectGroupProps) => null;
 const SelectLabel = (_p: SelectLabelProps) => null;
-const SelectItem = (_p: SelectItemProps) => null;
-const SelectItemIndicator = (_p: SelectItemIndicatorProps) => null;
 const SelectSeparator = (_p: SelectSeparatorProps) => null;
 
 export const Select = {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,5 +1,4 @@
 import type {
-  SelectRootProps,
   SelectTriggerProps,
   SelectValueProps,
   SelectIconProps,
@@ -10,12 +9,8 @@ import type {
   SelectItemIndicatorProps,
   SelectSeparatorProps,
 } from "./Select.types";
+import { SelectRoot } from "./SelectRoot";
 
-function Noop(_props: { children?: unknown }) {
-  return null;
-}
-
-const SelectRoot = (_p: SelectRootProps) => null;
 const SelectTrigger = (_p: SelectTriggerProps) => null;
 const SelectValue = (_p: SelectValueProps) => null;
 const SelectIcon = (_p: SelectIconProps) => null;
@@ -25,8 +20,6 @@ const SelectLabel = (_p: SelectLabelProps) => null;
 const SelectItem = (_p: SelectItemProps) => null;
 const SelectItemIndicator = (_p: SelectItemIndicatorProps) => null;
 const SelectSeparator = (_p: SelectSeparatorProps) => null;
-
-void Noop;
 
 export const Select = {
   Root: SelectRoot,

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -1,0 +1,101 @@
+import type {
+  ReactNode,
+  CSSProperties,
+  HTMLAttributes,
+  ButtonHTMLAttributes,
+} from "react";
+import type { Side, Alignment } from "../_shared/useFloating";
+
+export type SelectTheme = "light" | "dark";
+
+export type SelectValue = string;
+
+export type SelectAlign = Alignment | "center";
+
+export interface SelectRootProps {
+  value?: SelectValue | undefined;
+  defaultValue?: SelectValue | undefined;
+  onValueChange?: ((value: SelectValue) => void) | undefined;
+
+  open?: boolean | undefined;
+  defaultOpen?: boolean | undefined;
+  onOpenChange?: ((open: boolean) => void) | undefined;
+
+  placeholder?: string | undefined;
+
+  disabled?: boolean | undefined;
+
+  name?: string | undefined;
+  required?: boolean | undefined;
+
+  theme?: SelectTheme | undefined;
+
+  children: ReactNode;
+}
+
+export interface SelectTriggerProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "type" | "onClick"> {
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  children?: ReactNode | undefined;
+}
+
+export interface SelectValueProps {
+  placeholder?: string | undefined;
+  children?: ((value: SelectValue | undefined) => ReactNode) | ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface SelectIconProps {
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface SelectContentProps {
+  side?: Side | undefined;
+  align?: SelectAlign | undefined;
+  sideOffset?: number | undefined;
+  alignOffset?: number | undefined;
+  maxHeight?: number | undefined;
+  matchTriggerWidth?: boolean | undefined;
+  minWidth?: number | undefined;
+  closeOnOutsideClick?: boolean | undefined;
+  closeOnEscape?: boolean | undefined;
+
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  children: ReactNode;
+}
+
+export interface SelectGroupProps {
+  label?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  children: ReactNode;
+}
+
+export interface SelectLabelProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export interface SelectItemProps {
+  value: SelectValue;
+  disabled?: boolean | undefined;
+  textValue?: string | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  children: ReactNode;
+}
+
+export interface SelectItemIndicatorProps {
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface SelectSeparatorProps {
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}

--- a/src/components/Select/SelectContent.tsx
+++ b/src/components/Select/SelectContent.tsx
@@ -87,6 +87,17 @@ export function SelectContent(props: SelectContentProps) {
   }, [open, triggerRef]);
 
   useEffect(() => {
+    if (!open || !isPositioned) return;
+    const raf = requestAnimationFrame(() => {
+      const active = ctx.activeValue;
+      if (active == null) return;
+      const item = ctx.getItems().find((i) => i.value === active);
+      item?.node.scrollIntoView({ block: "nearest", inline: "nearest" });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [open, isPositioned, ctx]);
+
+  useEffect(() => {
     if (!open || !closeOnOutsideClick) return;
     const onPointerDown = (e: PointerEvent) => {
       const target = e.target as Node | null;
@@ -176,6 +187,7 @@ export function SelectContent(props: SelectContentProps) {
       ref={mergedRef}
       role="listbox"
       id={listboxId}
+      tabIndex={-1}
       aria-labelledby={triggerId}
       aria-hidden={isVisible ? undefined : true}
       data-state={open ? "open" : "closed"}

--- a/src/components/Select/SelectContent.tsx
+++ b/src/components/Select/SelectContent.tsx
@@ -1,0 +1,196 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import { Portal } from "../_shared/Portal";
+import { useAnimationState } from "../_shared/useAnimationState";
+import { useSelectContext } from "./SelectContext";
+import { selectPalette } from "./colors";
+import type { Side } from "../_shared/useFloating";
+import type { SelectContentProps } from "./Select.types";
+
+const ENTER_DURATION = 150;
+const EXIT_DURATION = 100;
+
+function getSlideTransform(side: Side, entering: boolean): string {
+  const d = entering ? 0 : 4;
+  switch (side) {
+    case "top":
+      return `translateY(${d}px)`;
+    case "bottom":
+      return `translateY(-${d}px)`;
+    case "left":
+      return `translateX(${d}px)`;
+    case "right":
+      return `translateX(-${d}px)`;
+  }
+}
+
+export function SelectContent(props: SelectContentProps) {
+  const {
+    side = "bottom",
+    align = "start",
+    sideOffset = 4,
+    maxHeight = 320,
+    matchTriggerWidth = true,
+    minWidth,
+    closeOnOutsideClick = true,
+    closeOnEscape = true,
+    className,
+    style,
+    children,
+  } = props;
+
+  const ctx = useSelectContext();
+  const {
+    open,
+    close,
+    theme,
+    triggerRef,
+    floatingRef,
+    floatingStyles,
+    isPositioned,
+    listboxId,
+    triggerId,
+    placement,
+    setFloatingOptions,
+  } = ctx;
+
+  const p = selectPalette[theme];
+
+  const { animationState, isVisible, onTransitionEnd } = useAnimationState({
+    open,
+    exitDuration: EXIT_DURATION + 50,
+  });
+
+  useEffect(() => {
+    setFloatingOptions({ side, align, sideOffset, matchTriggerWidth });
+  }, [side, align, sideOffset, matchTriggerWidth, setFloatingOptions]);
+
+  const [triggerWidth, setTriggerWidth] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    const trig = triggerRef.current;
+    if (!trig) return;
+    const measure = () => {
+      setTriggerWidth(trig.getBoundingClientRect().width);
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(trig);
+    return () => ro.disconnect();
+  }, [open, triggerRef]);
+
+  useEffect(() => {
+    if (!open || !closeOnOutsideClick) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      if (triggerRef.current && triggerRef.current.contains(target)) return;
+      if (floatingRef.current && floatingRef.current.contains(target)) return;
+      close("outside");
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open, closeOnOutsideClick, close, triggerRef, floatingRef]);
+
+  useEffect(() => {
+    if (!open || !closeOnEscape) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        close("escape");
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, closeOnEscape, close]);
+
+  const mergedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      (floatingRef as React.MutableRefObject<HTMLDivElement | null>).current =
+        node;
+    },
+    [floatingRef],
+  );
+
+  const isEntering = animationState === "entering";
+  const side0: Side = (placement.split("-")[0] as Side) ?? "bottom";
+  const slide = getSlideTransform(side0, isEntering);
+  const baseTransform = floatingStyles.transform ?? "translate(0px, 0px)";
+  const combinedTransform = `${baseTransform} ${slide}`;
+  const duration = isEntering ? ENTER_DURATION : EXIT_DURATION;
+  const easing = isEntering ? "cubic-bezier(0.16, 1, 0.3, 1)" : "ease";
+  const opacity = isEntering ? 1 : 0;
+
+  const widthStyle: CSSProperties =
+    matchTriggerWidth && triggerWidth != null
+      ? { minWidth: triggerWidth, width: triggerWidth }
+      : minWidth !== undefined
+        ? { minWidth }
+        : {};
+
+  const visibleStyle: CSSProperties = {
+    ...floatingStyles,
+    transform: combinedTransform,
+    opacity: isPositioned ? opacity : 0,
+    transition: `opacity ${duration}ms ${easing}, transform ${duration}ms ${easing}`,
+    ...widthStyle,
+  };
+
+  const hiddenStyle: CSSProperties = {
+    position: "fixed",
+    top: 0,
+    left: 0,
+    opacity: 0,
+    pointerEvents: "none",
+    visibility: "hidden",
+  };
+
+  const containerStyle: CSSProperties = {
+    ...(isVisible ? visibleStyle : hiddenStyle),
+    zIndex: 9998,
+    background: p.contentBg,
+    border: `1px solid ${p.contentBorder}`,
+    borderRadius: 6,
+    boxShadow: p.contentShadow,
+    padding: 4,
+    maxHeight,
+    overflowY: "auto",
+    overscrollBehavior: "contain",
+    boxSizing: "border-box",
+    ...style,
+  };
+
+  const handleTransitionEnd = (e: React.TransitionEvent<HTMLDivElement>) => {
+    onTransitionEnd(e.propertyName);
+  };
+
+  const listbox = (
+    <div
+      ref={mergedRef}
+      role="listbox"
+      id={listboxId}
+      aria-labelledby={triggerId}
+      aria-hidden={isVisible ? undefined : true}
+      data-state={open ? "open" : "closed"}
+      className={className}
+      style={containerStyle}
+      onTransitionEnd={handleTransitionEnd}
+    >
+      {children}
+    </div>
+  );
+
+  if (isVisible) {
+    return <Portal>{listbox}</Portal>;
+  }
+  return listbox;
+}
+
+SelectContent.displayName = "Select.Content";

--- a/src/components/Select/SelectContext.ts
+++ b/src/components/Select/SelectContext.ts
@@ -1,0 +1,89 @@
+import { createContext, useContext } from "react";
+import type { CSSProperties, MutableRefObject, RefObject } from "react";
+import type {
+  Placement,
+  Side,
+  Alignment,
+} from "../_shared/useFloating";
+import type { SelectTheme, SelectValue, SelectAlign } from "./Select.types";
+
+export interface RegisteredItem {
+  value: SelectValue;
+  textValue: string;
+  disabled: boolean;
+  node: HTMLElement;
+  id: string;
+}
+
+export interface FloatingOptions {
+  side: Side;
+  align: SelectAlign;
+  sideOffset: number;
+  matchTriggerWidth: boolean;
+}
+
+export interface SelectContextValue {
+  value: SelectValue | undefined;
+  setValue: (v: SelectValue) => void;
+
+  open: boolean;
+  setOpen: (o: boolean) => void;
+  close: (reason: "select" | "escape" | "outside" | "blur" | "tab") => void;
+
+  disabled: boolean;
+  theme: SelectTheme;
+  placeholder: string | undefined;
+
+  activeValue: SelectValue | null;
+  setActiveValue: (v: SelectValue | null) => void;
+
+  registerItem: (item: RegisteredItem) => () => void;
+  getItems: () => RegisteredItem[];
+  getActiveId: () => string | undefined;
+
+  triggerRef: RefObject<HTMLElement | null>;
+  floatingRef: RefObject<HTMLDivElement | null>;
+  listboxId: string;
+  triggerId: string;
+
+  name: string | undefined;
+  required: boolean;
+
+  onTypeAhead: (char: string) => void;
+
+  setFloatingOptions: (opts: FloatingOptions) => void;
+  floatingStyles: CSSProperties;
+  placement: Placement;
+  isPositioned: boolean;
+  matchTriggerWidth: boolean;
+  alignment: Alignment | undefined;
+}
+
+export const SelectContext = createContext<SelectContextValue | null>(null);
+
+export function useSelectContext(): SelectContextValue {
+  const ctx = useContext(SelectContext);
+  if (ctx === null) {
+    throw new Error(
+      "Select compound components must be used within <Select.Root>",
+    );
+  }
+  return ctx;
+}
+
+interface SelectItemContextValue {
+  value: SelectValue;
+  isSelected: boolean;
+}
+
+export const SelectItemContext = createContext<SelectItemContextValue | null>(
+  null,
+);
+
+export function useSelectItemContext(): SelectItemContextValue {
+  const ctx = useContext(SelectItemContext);
+  if (ctx === null) {
+    throw new Error("Select.ItemIndicator must be used within <Select.Item>");
+  }
+  return ctx;
+}

--- a/src/components/Select/SelectGroup.tsx
+++ b/src/components/Select/SelectGroup.tsx
@@ -1,0 +1,48 @@
+import { useId, type CSSProperties, type ReactNode } from "react";
+import { useSelectContext } from "./SelectContext";
+import { selectPalette } from "./colors";
+import type { SelectGroupProps } from "./Select.types";
+
+export function SelectGroup(props: SelectGroupProps) {
+  const { label, className, style, children } = props;
+  const ctx = useSelectContext();
+  const p = selectPalette[ctx.theme];
+
+  const labelId = useId();
+
+  const baseStyle: CSSProperties = {
+    display: "block",
+    ...style,
+  };
+
+  const labelStyle: CSSProperties = {
+    display: "block",
+    padding: "6px 8px 2px",
+    fontSize: 11,
+    fontWeight: 600,
+    color: p.labelFg,
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+    userSelect: "none",
+  };
+
+  const hasLabel = label !== undefined && label !== null && label !== "";
+
+  return (
+    <div
+      role="group"
+      aria-labelledby={hasLabel ? labelId : undefined}
+      className={className}
+      style={baseStyle}
+    >
+      {hasLabel ? (
+        <div id={labelId} role="presentation" style={labelStyle}>
+          {label as ReactNode}
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
+}
+
+SelectGroup.displayName = "Select.Group";

--- a/src/components/Select/SelectIcon.tsx
+++ b/src/components/Select/SelectIcon.tsx
@@ -1,0 +1,33 @@
+import type { CSSProperties } from "react";
+import { useSelectContext } from "./SelectContext";
+import type { SelectIconProps } from "./Select.types";
+
+export function SelectIcon(props: SelectIconProps) {
+  const { children, className, style } = props;
+  const ctx = useSelectContext();
+
+  const baseStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 14,
+    height: 14,
+    flexShrink: 0,
+    color: "currentColor",
+    transition: "transform 150ms ease-out",
+    transform: ctx.open ? "rotate(180deg)" : "rotate(0deg)",
+    ...style,
+  };
+
+  return (
+    <span aria-hidden="true" className={className} style={baseStyle}>
+      {children ?? (
+        <svg viewBox="0 0 12 12" width="12" height="12" fill="currentColor">
+          <path d="M3 4.5l3 3 3-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+        </svg>
+      )}
+    </span>
+  );
+}
+
+SelectIcon.displayName = "Select.Icon";

--- a/src/components/Select/SelectItem.tsx
+++ b/src/components/Select/SelectItem.tsx
@@ -1,0 +1,131 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import {
+  SelectItemContext,
+  useSelectContext,
+  type RegisteredItem,
+} from "./SelectContext";
+import { selectPalette } from "./colors";
+import type { SelectItemProps } from "./Select.types";
+
+export function SelectItem(props: SelectItemProps) {
+  const {
+    value,
+    disabled = false,
+    textValue: textValueProp,
+    className,
+    style,
+    children,
+  } = props;
+
+  const ctx = useSelectContext();
+  const { theme, activeValue, value: selectedValue, setActiveValue } = ctx;
+  const p = selectPalette[theme];
+
+  const id = useId();
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+
+  const [textValue, setTextValue] = useState<string>(textValueProp ?? "");
+
+  useEffect(() => {
+    const node = nodeRef.current;
+    if (!node) return;
+    let resolved = textValueProp;
+    if (resolved === undefined || resolved === "") {
+      resolved = (node.textContent ?? "").trim();
+    }
+    setTextValue(resolved);
+    const item: RegisteredItem = {
+      value,
+      textValue: resolved,
+      disabled,
+      node,
+      id,
+    };
+    const unregister = ctx.registerItem(item);
+    return unregister;
+  }, [value, textValueProp, disabled, id, ctx]);
+
+  const isSelected = selectedValue === value;
+  const isActive = activeValue === value;
+
+  const handleClick = useCallback(
+    (e: ReactMouseEvent<HTMLDivElement>) => {
+      if (disabled) {
+        e.preventDefault();
+        return;
+      }
+      ctx.setValue(value);
+      ctx.close("select");
+    },
+    [disabled, ctx, value],
+  );
+
+  const handleMouseEnter = useCallback(() => {
+    if (disabled) return;
+    setActiveValue(value);
+  }, [disabled, setActiveValue, value]);
+
+  const baseStyle: CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    padding: "6px 8px",
+    borderRadius: 4,
+    fontSize: 13,
+    lineHeight: 1.3,
+    cursor: disabled ? "not-allowed" : "pointer",
+    color: disabled
+      ? p.itemFgDisabled
+      : isSelected
+        ? p.itemFgSelected
+        : p.itemFg,
+    background: disabled
+      ? "transparent"
+      : isActive
+        ? p.itemBgActive
+        : "transparent",
+    userSelect: "none",
+    outline: "none",
+    ...style,
+  };
+
+  const itemCtx = useMemo(
+    () => ({ value, isSelected }),
+    [value, isSelected],
+  );
+
+  return (
+    <SelectItemContext.Provider value={itemCtx}>
+      <div
+        ref={nodeRef}
+        id={id}
+        role="option"
+        aria-selected={isSelected}
+        aria-disabled={disabled || undefined}
+        data-state={isSelected ? "checked" : "unchecked"}
+        data-highlighted={isActive && !disabled ? "" : undefined}
+        data-disabled={disabled ? "" : undefined}
+        data-value={value}
+        data-textvalue={textValue}
+        className={className}
+        style={baseStyle}
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        onMouseMove={handleMouseEnter}
+      >
+        {children}
+      </div>
+    </SelectItemContext.Provider>
+  );
+}
+
+SelectItem.displayName = "Select.Item";

--- a/src/components/Select/SelectItemIndicator.tsx
+++ b/src/components/Select/SelectItemIndicator.tsx
@@ -1,0 +1,43 @@
+import type { CSSProperties } from "react";
+import { useSelectContext, useSelectItemContext } from "./SelectContext";
+import { selectPalette } from "./colors";
+import type { SelectItemIndicatorProps } from "./Select.types";
+
+export function SelectItemIndicator(props: SelectItemIndicatorProps) {
+  const { children, className, style } = props;
+  const ctx = useSelectContext();
+  const itemCtx = useSelectItemContext();
+
+  if (!itemCtx.isSelected) return null;
+
+  const p = selectPalette[ctx.theme];
+
+  const baseStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 14,
+    height: 14,
+    flexShrink: 0,
+    color: p.itemIndicatorFg,
+    ...style,
+  };
+
+  return (
+    <span aria-hidden="true" className={className} style={baseStyle}>
+      {children ?? (
+        <svg viewBox="0 0 12 12" width="12" height="12" fill="none">
+          <path
+            d="M2.5 6.5l2.5 2.5 4.5-5"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      )}
+    </span>
+  );
+}
+
+SelectItemIndicator.displayName = "Select.ItemIndicator";

--- a/src/components/Select/SelectLabel.tsx
+++ b/src/components/Select/SelectLabel.tsx
@@ -1,0 +1,30 @@
+import type { CSSProperties } from "react";
+import { useSelectContext } from "./SelectContext";
+import { selectPalette } from "./colors";
+import type { SelectLabelProps } from "./Select.types";
+
+export function SelectLabel(props: SelectLabelProps) {
+  const { children, className, style, ...rest } = props;
+  const ctx = useSelectContext();
+  const p = selectPalette[ctx.theme];
+
+  const baseStyle: CSSProperties = {
+    display: "block",
+    padding: "6px 8px 2px",
+    fontSize: 11,
+    fontWeight: 600,
+    color: p.labelFg,
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+    userSelect: "none",
+    ...style,
+  };
+
+  return (
+    <div role="presentation" className={className} style={baseStyle} {...rest}>
+      {children}
+    </div>
+  );
+}
+
+SelectLabel.displayName = "Select.Label";

--- a/src/components/Select/SelectRoot.tsx
+++ b/src/components/Select/SelectRoot.tsx
@@ -249,6 +249,7 @@ export function SelectRoot(props: SelectRootProps) {
           type="hidden"
           name={name}
           value={value ?? ""}
+          {...(disabled ? { disabled: true } : {})}
           {...(required ? { required: true } : {})}
         />
       ) : null}

--- a/src/components/Select/SelectRoot.tsx
+++ b/src/components/Select/SelectRoot.tsx
@@ -1,0 +1,290 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useControllable } from "../_shared/useControllable";
+import { useFloating } from "../_shared/useFloating";
+import type { Alignment, Placement, Side } from "../_shared/useFloating";
+import {
+  SelectContext,
+  type FloatingOptions,
+  type RegisteredItem,
+  type SelectContextValue,
+} from "./SelectContext";
+import type { SelectAlign, SelectRootProps, SelectValue } from "./Select.types";
+
+function toPlacement(side: Side, align: SelectAlign): Placement {
+  if (align === "center") return side;
+  return `${side}-${align}` as Placement;
+}
+
+function sortByDocumentPosition(items: RegisteredItem[]): RegisteredItem[] {
+  if (items.length < 2) return items;
+  return [...items].sort((a, b) => {
+    if (a.node === b.node) return 0;
+    const pos = a.node.compareDocumentPosition(b.node);
+    if (pos & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+    if (pos & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+    return 0;
+  });
+}
+
+export function SelectRoot(props: SelectRootProps) {
+  const {
+    children,
+    value: controlledValue,
+    defaultValue,
+    onValueChange,
+    open: controlledOpen,
+    defaultOpen,
+    onOpenChange,
+    placeholder,
+    disabled = false,
+    name,
+    required = false,
+    theme = "light",
+  } = props;
+
+  const valueChangeAdapter = useCallback(
+    (v: SelectValue | undefined) => {
+      if (v !== undefined) onValueChange?.(v);
+    },
+    [onValueChange],
+  );
+  const [value, setValueInternal] = useControllable<SelectValue | undefined>(
+    controlledValue,
+    defaultValue,
+    valueChangeAdapter,
+  );
+
+  const [open, setOpenInternal] = useControllable<boolean>(
+    controlledOpen,
+    defaultOpen ?? false,
+    onOpenChange,
+  );
+
+  const [activeValue, setActiveValue] = useState<SelectValue | null>(null);
+
+  const [floatingOptions, setFloatingOptions] = useState<FloatingOptions>({
+    side: "bottom",
+    align: "start",
+    sideOffset: 4,
+    matchTriggerWidth: true,
+  });
+
+  const placement = toPlacement(floatingOptions.side, floatingOptions.align);
+
+  const floating = useFloating({
+    placement,
+    offset: floatingOptions.sideOffset,
+    enabled: open,
+    flip: true,
+  });
+
+  const listboxId = useId();
+  const triggerId = useId();
+
+  const itemsRef = useRef<Map<SelectValue, RegisteredItem>>(new Map());
+  const typeaheadBufferRef = useRef("");
+  const typeaheadTimerRef = useRef<number | null>(null);
+  const activeValueRef = useRef<SelectValue | null>(null);
+  activeValueRef.current = activeValue;
+
+  useEffect(() => {
+    if (!open) {
+      setActiveValue(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (disabled && open) {
+      setOpenInternal(false);
+    }
+  }, [disabled, open, setOpenInternal]);
+
+  const setValue = useCallback(
+    (v: SelectValue) => {
+      setValueInternal(v);
+      setOpenInternal(false);
+    },
+    [setValueInternal, setOpenInternal],
+  );
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (next && disabled) return;
+      setOpenInternal(next);
+    },
+    [disabled, setOpenInternal],
+  );
+
+  const close = useCallback(
+    (reason: "select" | "escape" | "outside" | "blur" | "tab") => {
+      setOpenInternal(false);
+      if (reason === "escape" || reason === "select") {
+        requestAnimationFrame(() => {
+          const trig = floating.triggerRef.current;
+          if (trig && typeof (trig as HTMLButtonElement).focus === "function") {
+            (trig as HTMLButtonElement).focus();
+          }
+        });
+      }
+    },
+    [setOpenInternal, floating.triggerRef],
+  );
+
+  const registerItem = useCallback((item: RegisteredItem) => {
+    const map = itemsRef.current;
+    if (map.has(item.value)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[Select] Duplicate Item value detected: "${item.value}". Only the first registration is used.`,
+      );
+    }
+    if (!map.has(item.value)) {
+      map.set(item.value, item);
+    }
+    return () => {
+      const cur = map.get(item.value);
+      if (cur && cur.id === item.id) {
+        map.delete(item.value);
+      }
+    };
+  }, []);
+
+  const getItems = useCallback((): RegisteredItem[] => {
+    const arr = Array.from(itemsRef.current.values());
+    return sortByDocumentPosition(arr);
+  }, []);
+
+  const getActiveId = useCallback((): string | undefined => {
+    if (activeValue == null) return undefined;
+    return itemsRef.current.get(activeValue)?.id;
+  }, [activeValue]);
+
+  const onTypeAhead = useCallback((char: string) => {
+    if (!/^[\w\s-]$/.test(char)) return;
+    typeaheadBufferRef.current += char.toLowerCase();
+    if (typeaheadTimerRef.current !== null) {
+      window.clearTimeout(typeaheadTimerRef.current);
+    }
+    typeaheadTimerRef.current = window.setTimeout(() => {
+      typeaheadBufferRef.current = "";
+      typeaheadTimerRef.current = null;
+    }, 500);
+
+    const items = sortByDocumentPosition(
+      Array.from(itemsRef.current.values()),
+    ).filter((i) => !i.disabled);
+    if (items.length === 0) return;
+
+    const current = activeValueRef.current;
+    const startFrom = current != null ? items.findIndex((i) => i.value === current) : -1;
+    const ordered = [
+      ...items.slice(startFrom + 1),
+      ...items.slice(0, startFrom + 1),
+    ];
+    const buffer = typeaheadBufferRef.current;
+    const match = ordered.find((i) =>
+      i.textValue.toLowerCase().startsWith(buffer),
+    );
+    if (match) {
+      setActiveValue(match.value);
+      match.node.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (typeaheadTimerRef.current !== null) {
+        window.clearTimeout(typeaheadTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (activeValue == null) return;
+    const node = itemsRef.current.get(activeValue)?.node;
+    if (node) {
+      node.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  }, [activeValue]);
+
+  const alignment: Alignment | undefined =
+    floatingOptions.align === "center" ? undefined : floatingOptions.align;
+
+  const contextValue = useMemo<SelectContextValue>(
+    () => ({
+      value,
+      setValue,
+      open,
+      setOpen,
+      close,
+      disabled,
+      theme,
+      placeholder,
+      activeValue,
+      setActiveValue,
+      registerItem,
+      getItems,
+      getActiveId,
+      triggerRef: floating.triggerRef,
+      floatingRef: floating.floatingRef,
+      listboxId,
+      triggerId,
+      name,
+      required,
+      onTypeAhead,
+      setFloatingOptions,
+      floatingStyles: floating.floatingStyles,
+      placement: floating.placement,
+      isPositioned: floating.isPositioned,
+      matchTriggerWidth: floatingOptions.matchTriggerWidth,
+      alignment,
+    }),
+    [
+      value,
+      setValue,
+      open,
+      setOpen,
+      close,
+      disabled,
+      theme,
+      placeholder,
+      activeValue,
+      registerItem,
+      getItems,
+      getActiveId,
+      floating.triggerRef,
+      floating.floatingRef,
+      floating.floatingStyles,
+      floating.placement,
+      floating.isPositioned,
+      listboxId,
+      triggerId,
+      name,
+      required,
+      onTypeAhead,
+      floatingOptions.matchTriggerWidth,
+      alignment,
+    ],
+  );
+
+  return (
+    <SelectContext.Provider value={contextValue}>
+      {children}
+      {name !== undefined ? (
+        <input
+          type="hidden"
+          name={name}
+          value={value ?? ""}
+          {...(required ? { required: true } : {})}
+        />
+      ) : null}
+    </SelectContext.Provider>
+  );
+}

--- a/src/components/Select/SelectRoot.tsx
+++ b/src/components/Select/SelectRoot.tsx
@@ -15,6 +15,7 @@ import {
   type RegisteredItem,
   type SelectContextValue,
 } from "./SelectContext";
+import { useSelectTypeahead } from "./useSelectTypeahead";
 import type { SelectAlign, SelectRootProps, SelectValue } from "./Select.types";
 
 function toPlacement(side: Side, align: SelectAlign): Placement {
@@ -89,8 +90,6 @@ export function SelectRoot(props: SelectRootProps) {
   const triggerId = useId();
 
   const itemsRef = useRef<Map<SelectValue, RegisteredItem>>(new Map());
-  const typeaheadBufferRef = useRef("");
-  const typeaheadTimerRef = useRef<number | null>(null);
   const activeValueRef = useRef<SelectValue | null>(null);
   activeValueRef.current = activeValue;
 
@@ -166,45 +165,13 @@ export function SelectRoot(props: SelectRootProps) {
     return itemsRef.current.get(activeValue)?.id;
   }, [activeValue]);
 
-  const onTypeAhead = useCallback((char: string) => {
-    if (!/^[\w\s-]$/.test(char)) return;
-    typeaheadBufferRef.current += char.toLowerCase();
-    if (typeaheadTimerRef.current !== null) {
-      window.clearTimeout(typeaheadTimerRef.current);
-    }
-    typeaheadTimerRef.current = window.setTimeout(() => {
-      typeaheadBufferRef.current = "";
-      typeaheadTimerRef.current = null;
-    }, 500);
+  const getActiveValue = useCallback(() => activeValueRef.current, []);
 
-    const items = sortByDocumentPosition(
-      Array.from(itemsRef.current.values()),
-    ).filter((i) => !i.disabled);
-    if (items.length === 0) return;
-
-    const current = activeValueRef.current;
-    const startFrom = current != null ? items.findIndex((i) => i.value === current) : -1;
-    const ordered = [
-      ...items.slice(startFrom + 1),
-      ...items.slice(0, startFrom + 1),
-    ];
-    const buffer = typeaheadBufferRef.current;
-    const match = ordered.find((i) =>
-      i.textValue.toLowerCase().startsWith(buffer),
-    );
-    if (match) {
-      setActiveValue(match.value);
-      match.node.scrollIntoView({ block: "nearest", inline: "nearest" });
-    }
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (typeaheadTimerRef.current !== null) {
-        window.clearTimeout(typeaheadTimerRef.current);
-      }
-    };
-  }, []);
+  const onTypeAhead = useSelectTypeahead({
+    getItems,
+    getActiveValue,
+    setActiveValue,
+  });
 
   useEffect(() => {
     if (activeValue == null) return;

--- a/src/components/Select/SelectSeparator.tsx
+++ b/src/components/Select/SelectSeparator.tsx
@@ -1,0 +1,29 @@
+import type { CSSProperties } from "react";
+import { useSelectContext } from "./SelectContext";
+import { selectPalette } from "./colors";
+import type { SelectSeparatorProps } from "./Select.types";
+
+export function SelectSeparator(props: SelectSeparatorProps) {
+  const { className, style } = props;
+  const ctx = useSelectContext();
+  const p = selectPalette[ctx.theme];
+
+  const baseStyle: CSSProperties = {
+    display: "block",
+    height: 1,
+    margin: "4px 0",
+    background: p.separatorBg,
+    ...style,
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="horizontal"
+      className={className}
+      style={baseStyle}
+    />
+  );
+}
+
+SelectSeparator.displayName = "Select.Separator";

--- a/src/components/Select/SelectTrigger.tsx
+++ b/src/components/Select/SelectTrigger.tsx
@@ -1,0 +1,306 @@
+import {
+  useCallback,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type FocusEvent as ReactFocusEvent,
+} from "react";
+import { useSelectContext } from "./SelectContext";
+import { selectPalette } from "./colors";
+import type { SelectTriggerProps } from "./Select.types";
+import type { RegisteredItem } from "./SelectContext";
+
+function nextEnabled(
+  items: RegisteredItem[],
+  fromIdx: number,
+  direction: 1 | -1,
+): RegisteredItem | undefined {
+  if (items.length === 0) return undefined;
+  let i = fromIdx;
+  const last = items.length - 1;
+  for (let step = 0; step <= last; step++) {
+    i = i + direction;
+    if (i < 0) i = last;
+    if (i > last) i = 0;
+    const it = items[i];
+    if (it && !it.disabled) return it;
+  }
+  return undefined;
+}
+
+function computeInitialActive(
+  items: RegisteredItem[],
+  currentValue: string | undefined,
+  direction: "down" | "up" | "current",
+): string | null {
+  const enabled = items.filter((i) => !i.disabled);
+  if (enabled.length === 0) return null;
+  if (currentValue != null) {
+    const found = enabled.find((i) => i.value === currentValue);
+    if (found) {
+      if (direction === "current") return found.value;
+      const sortedIdx = items.findIndex((i) => i.value === currentValue);
+      const next = nextEnabled(items, sortedIdx, direction === "down" ? 1 : -1);
+      if (next) return next.value;
+      return found.value;
+    }
+  }
+  if (direction === "up") {
+    const last = enabled[enabled.length - 1];
+    return last ? last.value : null;
+  }
+  const first = enabled[0];
+  return first ? first.value : null;
+}
+
+export function SelectTrigger(props: SelectTriggerProps) {
+  const {
+    className,
+    style,
+    children,
+    onKeyDown: userKeyDown,
+    onMouseEnter: userMouseEnter,
+    onMouseLeave: userMouseLeave,
+    onFocus: userFocus,
+    onBlur: userBlur,
+    ...rest
+  } = props;
+
+  const ctx = useSelectContext();
+  const {
+    open,
+    setOpen,
+    setActiveValue,
+    value,
+    disabled,
+    theme,
+    triggerRef,
+    listboxId,
+    triggerId,
+    getActiveId,
+    getItems,
+    close,
+    onTypeAhead,
+  } = ctx;
+
+  const p = selectPalette[theme];
+
+  const [hovered, setHovered] = useState(false);
+  const [focusRing, setFocusRing] = useState(false);
+  const internalRef = useRef<HTMLButtonElement | null>(null);
+
+  const refCallback = useCallback(
+    (node: HTMLButtonElement | null) => {
+      internalRef.current = node;
+      (triggerRef as React.MutableRefObject<HTMLElement | null>).current = node;
+    },
+    [triggerRef],
+  );
+
+  const openWithDirection = useCallback(
+    (direction: "down" | "up" | "current") => {
+      if (disabled) return;
+      const items = getItems();
+      const initial = computeInitialActive(items, value, direction);
+      if (initial != null) setActiveValue(initial);
+      setOpen(true);
+    },
+    [disabled, getItems, value, setActiveValue, setOpen],
+  );
+
+  const handleClick = useCallback(() => {
+    if (disabled) return;
+    if (open) {
+      setOpen(false);
+    } else {
+      openWithDirection("current");
+    }
+  }, [disabled, open, setOpen, openWithDirection]);
+
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLButtonElement>) => {
+      userKeyDown?.(e);
+      if (e.defaultPrevented) return;
+      if (e.nativeEvent.isComposing) return;
+      if (disabled) return;
+
+      if (!open) {
+        switch (e.key) {
+          case "Enter":
+          case " ":
+            e.preventDefault();
+            openWithDirection("current");
+            return;
+          case "ArrowDown":
+            e.preventDefault();
+            openWithDirection("down");
+            return;
+          case "ArrowUp":
+            e.preventDefault();
+            openWithDirection("up");
+            return;
+          default:
+            return;
+        }
+      }
+
+      const items = getItems();
+      const enabled = items.filter((i) => !i.disabled);
+      const activeValue = ctx.activeValue;
+      const curIdx = activeValue != null
+        ? enabled.findIndex((i) => i.value === activeValue)
+        : -1;
+
+      switch (e.key) {
+        case "ArrowDown": {
+          e.preventDefault();
+          const next = enabled[Math.min(curIdx + 1, enabled.length - 1)];
+          if (next) setActiveValue(next.value);
+          return;
+        }
+        case "ArrowUp": {
+          e.preventDefault();
+          const prev = enabled[Math.max(curIdx - 1, 0)];
+          if (prev) setActiveValue(prev.value);
+          return;
+        }
+        case "Home": {
+          e.preventDefault();
+          const first = enabled[0];
+          if (first) setActiveValue(first.value);
+          return;
+        }
+        case "End": {
+          e.preventDefault();
+          const last = enabled[enabled.length - 1];
+          if (last) setActiveValue(last.value);
+          return;
+        }
+        case "PageDown": {
+          e.preventDefault();
+          const target = enabled[Math.min(curIdx + 10, enabled.length - 1)];
+          if (target) setActiveValue(target.value);
+          return;
+        }
+        case "PageUp": {
+          e.preventDefault();
+          const target = enabled[Math.max(curIdx - 10, 0)];
+          if (target) setActiveValue(target.value);
+          return;
+        }
+        case "Enter":
+        case " ": {
+          e.preventDefault();
+          if (activeValue != null) {
+            const selected = enabled.find((i) => i.value === activeValue);
+            if (selected) {
+              ctx.setValue(selected.value);
+              close("select");
+            }
+          }
+          return;
+        }
+        case "Escape": {
+          e.preventDefault();
+          close("escape");
+          return;
+        }
+        case "Tab": {
+          close("tab");
+          return;
+        }
+        default: {
+          if (e.key.length === 1) {
+            onTypeAhead(e.key);
+          }
+          return;
+        }
+      }
+    },
+    [
+      userKeyDown,
+      disabled,
+      open,
+      openWithDirection,
+      getItems,
+      ctx,
+      setActiveValue,
+      close,
+      onTypeAhead,
+    ],
+  );
+
+  const handleMouseEnter = (e: ReactMouseEvent<HTMLButtonElement>) => {
+    userMouseEnter?.(e);
+    if (!disabled) setHovered(true);
+  };
+  const handleMouseLeave = (e: ReactMouseEvent<HTMLButtonElement>) => {
+    userMouseLeave?.(e);
+    setHovered(false);
+  };
+  const handleFocus = (e: ReactFocusEvent<HTMLButtonElement>) => {
+    userFocus?.(e);
+    setFocusRing(e.target.matches(":focus-visible"));
+  };
+  const handleBlur = (e: ReactFocusEvent<HTMLButtonElement>) => {
+    userBlur?.(e);
+    setFocusRing(false);
+  };
+
+  const baseStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 6,
+    height: 32,
+    padding: "0 10px",
+    borderRadius: 6,
+    border: `1px solid ${hovered && !disabled ? p.triggerBorderHover : p.triggerBorder}`,
+    background: hovered && !disabled ? p.triggerBgHover : p.triggerBg,
+    color: p.triggerFg,
+    fontSize: 13,
+    fontFamily: "inherit",
+    lineHeight: 1,
+    cursor: disabled ? "not-allowed" : "pointer",
+    opacity: disabled ? 0.5 : 1,
+    outline: "none",
+    boxShadow: focusRing ? `0 0 0 2px ${p.triggerFocusRing}` : "none",
+    transition: "box-shadow 120ms ease, background 120ms ease, border-color 120ms ease",
+    boxSizing: "border-box",
+    minWidth: 0,
+    ...style,
+  };
+
+  const activeId = open ? getActiveId() : undefined;
+
+  return (
+    <button
+      type="button"
+      role="combobox"
+      id={triggerId}
+      aria-haspopup="listbox"
+      aria-expanded={open}
+      aria-controls={open ? listboxId : undefined}
+      aria-activedescendant={activeId}
+      aria-disabled={disabled || undefined}
+      data-state={open ? "open" : "closed"}
+      disabled={disabled}
+      ref={refCallback}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      className={className}
+      style={baseStyle}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}
+
+SelectTrigger.displayName = "Select.Trigger";

--- a/src/components/Select/SelectValue.tsx
+++ b/src/components/Select/SelectValue.tsx
@@ -1,0 +1,52 @@
+import type { CSSProperties, ReactNode } from "react";
+import { useSelectContext } from "./SelectContext";
+import { selectPalette } from "./colors";
+import type { SelectValue as SelectValueType, SelectValueProps } from "./Select.types";
+
+function isRenderFn(
+  children: unknown,
+): children is (value: SelectValueType | undefined) => ReactNode {
+  return typeof children === "function";
+}
+
+export function SelectValue(props: SelectValueProps) {
+  const { placeholder: ownPlaceholder, children, className, style } = props;
+  const ctx = useSelectContext();
+  const p = selectPalette[ctx.theme];
+
+  const effectivePlaceholder = ownPlaceholder ?? ctx.placeholder ?? "";
+  const hasValue = ctx.value !== undefined;
+
+  let display: ReactNode;
+  if (isRenderFn(children)) {
+    display = children(ctx.value);
+  } else if (children !== undefined && children !== null) {
+    display = children as ReactNode;
+  } else if (hasValue) {
+    const item = ctx.getItems().find((i) => i.value === ctx.value);
+    if (item) {
+      display = item.textValue || item.value;
+    } else {
+      display = ctx.value;
+    }
+  } else {
+    display = effectivePlaceholder;
+  }
+
+  const baseStyle: CSSProperties = {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    minWidth: 0,
+    color: hasValue ? p.triggerFg : p.triggerFgMuted,
+    ...style,
+  };
+
+  return (
+    <span className={className} style={baseStyle}>
+      {display}
+    </span>
+  );
+}
+
+SelectValue.displayName = "Select.Value";

--- a/src/components/Select/colors.ts
+++ b/src/components/Select/colors.ts
@@ -1,0 +1,74 @@
+import type { SelectTheme } from "./Select.types";
+
+export interface SelectPalette {
+  triggerBg: string;
+  triggerBgHover: string;
+  triggerBorder: string;
+  triggerBorderHover: string;
+  triggerFg: string;
+  triggerFgMuted: string;
+  triggerFocusRing: string;
+
+  contentBg: string;
+  contentBorder: string;
+  contentShadow: string;
+
+  itemFg: string;
+  itemBgHover: string;
+  itemBgActive: string;
+  itemFgSelected: string;
+  itemFgDisabled: string;
+  itemIndicatorFg: string;
+
+  labelFg: string;
+  separatorBg: string;
+}
+
+export const selectPalette: Record<SelectTheme, SelectPalette> = {
+  light: {
+    triggerBg: "#ffffff",
+    triggerBgHover: "#f9fafb",
+    triggerBorder: "#d1d5db",
+    triggerBorderHover: "#9ca3af",
+    triggerFg: "#111827",
+    triggerFgMuted: "#9ca3af",
+    triggerFocusRing: "#2563eb",
+
+    contentBg: "#ffffff",
+    contentBorder: "rgba(0,0,0,0.08)",
+    contentShadow: "0 10px 32px rgba(0,0,0,0.12)",
+
+    itemFg: "#111827",
+    itemBgHover: "#f3f4f6",
+    itemBgActive: "#e5edff",
+    itemFgSelected: "#2563eb",
+    itemFgDisabled: "#9ca3af",
+    itemIndicatorFg: "#2563eb",
+
+    labelFg: "#6b7280",
+    separatorBg: "rgba(0,0,0,0.08)",
+  },
+  dark: {
+    triggerBg: "#1f2937",
+    triggerBgHover: "#374151",
+    triggerBorder: "rgba(255,255,255,0.12)",
+    triggerBorderHover: "rgba(255,255,255,0.24)",
+    triggerFg: "#e5e7eb",
+    triggerFgMuted: "#6b7280",
+    triggerFocusRing: "#60a5fa",
+
+    contentBg: "#1f2937",
+    contentBorder: "rgba(255,255,255,0.08)",
+    contentShadow: "0 10px 32px rgba(0,0,0,0.45)",
+
+    itemFg: "#e5e7eb",
+    itemBgHover: "#374151",
+    itemBgActive: "#1e3a8a",
+    itemFgSelected: "#60a5fa",
+    itemFgDisabled: "#6b7280",
+    itemIndicatorFg: "#60a5fa",
+
+    labelFg: "#9ca3af",
+    separatorBg: "rgba(255,255,255,0.08)",
+  },
+};

--- a/src/components/Select/index.ts
+++ b/src/components/Select/index.ts
@@ -1,0 +1,16 @@
+export { Select } from "./Select";
+export type {
+  SelectRootProps,
+  SelectTriggerProps,
+  SelectValueProps,
+  SelectIconProps,
+  SelectContentProps,
+  SelectGroupProps,
+  SelectLabelProps,
+  SelectItemProps,
+  SelectItemIndicatorProps,
+  SelectSeparatorProps,
+  SelectTheme,
+  SelectValue,
+  SelectAlign,
+} from "./Select.types";

--- a/src/components/Select/useSelectTypeahead.ts
+++ b/src/components/Select/useSelectTypeahead.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { RegisteredItem } from "./SelectContext";
+import type { SelectValue } from "./Select.types";
+
+export interface UseSelectTypeaheadOptions {
+  getItems: () => RegisteredItem[];
+  getActiveValue: () => SelectValue | null;
+  setActiveValue: (v: SelectValue) => void;
+  resetMs?: number;
+}
+
+export function useSelectTypeahead(
+  options: UseSelectTypeaheadOptions,
+): (char: string) => void {
+  const { getItems, getActiveValue, setActiveValue, resetMs = 500 } = options;
+  const bufferRef = useRef("");
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  return useCallback(
+    (char: string) => {
+      if (!/^[\w\s-]$/.test(char)) return;
+      bufferRef.current += char.toLowerCase();
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+      timerRef.current = window.setTimeout(() => {
+        bufferRef.current = "";
+        timerRef.current = null;
+      }, resetMs);
+
+      const items = getItems().filter((i) => !i.disabled);
+      if (items.length === 0) return;
+
+      const current = getActiveValue();
+      const startFrom = current != null
+        ? items.findIndex((i) => i.value === current)
+        : -1;
+      const ordered = [
+        ...items.slice(startFrom + 1),
+        ...items.slice(0, startFrom + 1),
+      ];
+      const buffer = bufferRef.current;
+      const match = ordered.find((i) =>
+        i.textValue.toLowerCase().startsWith(buffer),
+      );
+      if (match) {
+        setActiveValue(match.value);
+        match.node.scrollIntoView({ block: "nearest", inline: "nearest" });
+      }
+    },
+    [getItems, getActiveValue, setActiveValue, resetMs],
+  );
+}

--- a/src/components/_shared/useAnimationState.ts
+++ b/src/components/_shared/useAnimationState.ts
@@ -20,14 +20,17 @@ export function useAnimationState(
   const [animationState, setAnimationState] = useState<AnimationState>("idle");
   const rafRef = useRef<number | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const animationStateRef = useRef<AnimationState>(animationState);
+  animationStateRef.current = animationState;
 
   useEffect(() => {
+    const currentState = animationStateRef.current;
     if (open) {
       if (timerRef.current !== null) {
         clearTimeout(timerRef.current);
         timerRef.current = null;
       }
-      if (animationState === "idle" || animationState === "exiting") {
+      if (currentState === "idle" || currentState === "exiting") {
         setAnimationState("mounting");
         const raf1 = requestAnimationFrame(() => {
           const raf2 = requestAnimationFrame(() => {
@@ -42,7 +45,7 @@ export function useAnimationState(
         cancelAnimationFrame(rafRef.current);
         rafRef.current = null;
       }
-      if (animationState === "mounting" || animationState === "entering") {
+      if (currentState === "mounting" || currentState === "entering") {
         setAnimationState("exiting");
         if (exitDuration !== undefined) {
           timerRef.current = setTimeout(() => {
@@ -59,7 +62,7 @@ export function useAnimationState(
         rafRef.current = null;
       }
     };
-  }, [open, animationState, exitDuration]);
+  }, [open, exitDuration]);
 
   useEffect(() => {
     return () => {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export * from "./HexView";
 export * from "./PathInput";
 export * from "./PipelineGraph";
 export * from "./Popover";
+export * from "./Select";
 export * from "./Stepper";
 export * from "./Toast";
 export * from "./Tooltip";


### PR DESCRIPTION
## Summary
- `Select` 컴포넌트 전체 구현 — compound API (Root / Trigger / Value / Icon / Content / Group / Label / Item / ItemIndicator / Separator)
- WAI-ARIA 1.2 combobox + listbox 패턴 (virtual focus via `aria-activedescendant`, DOM focus 는 Trigger 유지)
- Portal 기반 popup + `useFloating` 위치 지정 + `useAnimationState` fade/slide
- Controlled/uncontrolled 이중 API (`value`/`defaultValue` + `open`/`defaultOpen`), form 연동 (`name`, `required`), `disabled` 전파
- 키보드: ArrowUp/Down/Home/End/PageUp/PageDown/Enter/Space/Escape/Tab + 500ms buffer type-ahead
- 데모 페이지: Basic / Grouped / Disabled / Controlled / Form / Custom / Long list / Dark / Props / Usage / Playground

구현 계획: `docs/plans/013-select-component.md` §11 Step 1–12.

Closes #222, #223, #224, #225, #226, #227, #228, #229, #230, #231, #232, #233, #234, #235, #236, #237, #238, #239, #240, #241, #242, #243, #244, #245, #246.

## Test plan
- [ ] `npm run typecheck` 통과
- [ ] `npx tsup` 빌드 성공
- [ ] `cd demo && npm run dev` 후 Select 페이지 렌더
- [ ] Basic: Trigger 클릭 → 팝업 열림, 아이템 클릭 시 Trigger 라벨 갱신 + 닫힘
- [ ] 키보드: Trigger focus + Enter/ArrowDown → 열림, 현재 값 active. Arrow 이동, Enter 선택, Escape 취소
- [ ] Grouped: 그룹 헤더/Separator 탐색 스킵. ✓ 인디케이터 표시
- [ ] Disabled: Item disabled 는 키보드/클릭 모두 스킵. Root disabled 는 전체 비활성
- [ ] Controlled: 외부 버튼으로 value 변경 시 Trigger 즉시 반영
- [ ] Form: 제출 시 `FormData` 에 `name=value` 포함
- [ ] Long list: 팝업 open 후 `"as"` 타이핑 → Asia 로 active 점프
- [ ] Dark theme 전환 확인
- [ ] Outside click / Escape / Tab 으로 닫힘
- [ ] Playground 의 side/align/sideOffset/maxHeight/matchTriggerWidth/disabled/theme 실시간 반영
- [ ] 다른 페이지 리그레션 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)