### PR TITLE
feat(SplitPane): 컴포넌트 + 데모 추가 (#336-#355)

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -13,8 +13,9 @@ import CommandPalettePage from "./pages/CommandPalettePage";
 import HexViewPage from "./pages/HexViewPage";
 import { PipelineGraphPage } from "./pages/PipelineGraphPage";
 import SelectPage from "./pages/SelectPage";
+import { SplitPanePage } from "./pages/SplitPanePage";
 
-type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select";
+type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select" | "splitpane";
 
 interface SubItem { label: string; id: string }
 
@@ -183,6 +184,20 @@ const NAV: { id: Page; label: string; description: string; sections: SubItem[] }
     { label: "Props", id: "props" },
     { label: "Usage", id: "usage" },
     { label: "Playground", id: "playground" },
+  ]},
+  { id: "splitpane", label: "SplitPane", description: "드래그 분할 레이아웃", sections: [
+    { label: "Basic horizontal", id: "basic" },
+    { label: "Vertical", id: "vertical" },
+    { label: "Min / Max", id: "minmax" },
+    { label: "Collapsible", id: "collapsible" },
+    { label: "Nested (2×2)", id: "nested" },
+    { label: "Snap", id: "snap" },
+    { label: "Persist", id: "persist" },
+    { label: "Dark", id: "dark" },
+    { label: "Controlled", id: "controlled" },
+    { label: "Playground", id: "playground" },
+    { label: "Props", id: "props" },
+    { label: "Usage", id: "usage" },
   ]},
   { id: "dialog", label: "Dialog", description: "모달 다이얼로그", sections: [
     { label: "Basic", id: "basic" },
@@ -436,6 +451,7 @@ export function App() {
         {current === "hexview" && <HexViewPage />}
         {current === "pipelinegraph" && <PipelineGraphPage />}
         {current === "select" && <SelectPage />}
+        {current === "splitpane" && <SplitPanePage />}
       </main>
     </div>
   );

--- a/demo/src/pages/SplitPanePage.tsx
+++ b/demo/src/pages/SplitPanePage.tsx
@@ -1,0 +1,863 @@
+import { useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { Button, CodeView, SplitPane } from "plastic";
+import type { SplitPaneCollapsible, SplitPaneSize, SplitPaneTheme } from "plastic";
+
+function Section({
+  id,
+  title,
+  desc,
+  children,
+}: {
+  id?: string;
+  title: string;
+  desc?: string;
+  children: ReactNode;
+}) {
+  const sectionProps = id !== undefined ? { id } : {};
+  return (
+    <section {...sectionProps} className="mb-10">
+      <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-2">
+        {title}
+      </p>
+      {desc !== undefined ? (
+        <p className="text-sm text-gray-500 mb-3">{desc}</p>
+      ) : null}
+      {children}
+    </section>
+  );
+}
+
+function Frame({
+  height = 240,
+  children,
+  dark = false,
+  style,
+}: {
+  height?: number;
+  children: ReactNode;
+  dark?: boolean;
+  style?: CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        height,
+        border: dark
+          ? "1px solid rgba(255,255,255,0.1)"
+          : "1px solid #e5e7eb",
+        borderRadius: 8,
+        background: dark ? "#0f172a" : "#fff",
+        overflow: "hidden",
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function FakeFileTree({ dark = false }: { dark?: boolean }) {
+  const items = [
+    "src/",
+    "  components/",
+    "    Button.tsx",
+    "    Dialog.tsx",
+    "    SplitPane.tsx",
+    "  pages/",
+    "    index.tsx",
+    "  main.tsx",
+    "package.json",
+    "tsconfig.json",
+    "README.md",
+  ];
+  return (
+    <div
+      style={{
+        height: "100%",
+        overflow: "auto",
+        padding: 12,
+        fontFamily:
+          "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+        fontSize: 12,
+        color: dark ? "#e5e7eb" : "#111827",
+        background: dark ? "#111827" : "#f9fafb",
+      }}
+    >
+      {items.map((line) => (
+        <div key={line} style={{ lineHeight: "20px", whiteSpace: "pre" }}>
+          {line}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FakeEditor({ dark = false }: { dark?: boolean }) {
+  const lines = [
+    "import { SplitPane } from 'plastic';",
+    "",
+    "export function IDELayout() {",
+    "  return (",
+    "    <SplitPane.Root defaultSize=\"30%\">",
+    "      <SplitPane.Pane>",
+    "        <FileTree />",
+    "      </SplitPane.Pane>",
+    "      <SplitPane.Divider />",
+    "      <SplitPane.Pane>",
+    "        <Editor />",
+    "      </SplitPane.Pane>",
+    "    </SplitPane.Root>",
+    "  );",
+    "}",
+  ];
+  return (
+    <div
+      style={{
+        height: "100%",
+        overflow: "auto",
+        padding: 16,
+        fontFamily:
+          "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+        fontSize: 13,
+        color: dark ? "#e5e7eb" : "#111827",
+        background: dark ? "#0b1220" : "#ffffff",
+      }}
+    >
+      {lines.map((line, i) => (
+        <div
+          key={i}
+          style={{
+            display: "flex",
+            gap: 12,
+            whiteSpace: "pre",
+            lineHeight: "20px",
+          }}
+        >
+          <span style={{ color: dark ? "#475569" : "#9ca3af", width: 24, textAlign: "right" }}>
+            {i + 1}
+          </span>
+          <span>{line}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FakeTerminal({ dark = false }: { dark?: boolean }) {
+  return (
+    <div
+      style={{
+        height: "100%",
+        overflow: "auto",
+        padding: 12,
+        fontFamily:
+          "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+        fontSize: 12,
+        color: dark ? "#d1fae5" : "#065f46",
+        background: dark ? "#0b1220" : "#f0fdf4",
+      }}
+    >
+      <div>$ npm run dev</div>
+      <div>&gt; plastic-demo dev</div>
+      <div>&gt; vite</div>
+      <div>  VITE v5  ready in 120 ms</div>
+      <div>  ➜ Local:   http://localhost:5173/</div>
+      <div>  ➜ Network: use --host to expose</div>
+      <div>  ➜ press h to show help</div>
+    </div>
+  );
+}
+
+function PaneLabel({
+  title,
+  sub,
+  dark = false,
+}: {
+  title: string;
+  sub?: string;
+  dark?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexDirection: "column",
+        gap: 4,
+        color: dark ? "#e5e7eb" : "#374151",
+        background: dark ? "#111827" : "#f9fafb",
+        fontSize: 13,
+      }}
+    >
+      <span style={{ fontWeight: 600 }}>{title}</span>
+      {sub !== undefined ? (
+        <span style={{ fontSize: 11, color: dark ? "#9ca3af" : "#9ca3af" }}>
+          {sub}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function PropsTable({
+  rows,
+}: {
+  rows: Array<[string, string, string, string]>;
+}) {
+  return (
+    <table className="w-full text-left text-sm border border-gray-200 rounded-lg overflow-hidden">
+      <thead className="bg-gray-50">
+        <tr>
+          <th className="px-4 py-2 border-b border-gray-200 font-semibold">Prop</th>
+          <th className="px-4 py-2 border-b border-gray-200 font-semibold">Type</th>
+          <th className="px-4 py-2 border-b border-gray-200 font-semibold">Default</th>
+          <th className="px-4 py-2 border-b border-gray-200 font-semibold">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(([p, t, d, desc]) => (
+          <tr key={p} className="border-t border-gray-100">
+            <td className="px-4 py-2 font-mono text-xs">{p}</td>
+            <td className="px-4 py-2 font-mono text-xs text-gray-600">{t}</td>
+            <td className="px-4 py-2 font-mono text-xs text-gray-600">{d}</td>
+            <td className="px-4 py-2 text-gray-700">{desc}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+const ROOT_PROPS: Array<[string, string, string, string]> = [
+  ["direction", "'horizontal' | 'vertical'", "'horizontal'", "분할 방향"],
+  ["defaultSize", "number | `${number}%`", "'50%'", "초기 사이즈(첫 번째 pane 기준), uncontrolled"],
+  ["size", "number | `${number}%`", "—", "사이즈(controlled). 지정 시 내부 상태 무시"],
+  ["onSizeChange", "(px: number, pct: number) => void", "—", "사이즈 변경 (매 프레임)"],
+  ["onSizeChangeEnd", "(px: number, pct: number) => void", "—", "pointerup 시 1회"],
+  ["minSize", "number | `${number}%`", "48", "최소 사이즈"],
+  ["maxSize", "number | `${number}%`", "'90%'", "최대 사이즈"],
+  ["snapSize", "number | `${number}%`", "—", "드래그 중 이 근처 통과 시 snap"],
+  ["snapThreshold", "number", "8", "snap 활성 거리 (px)"],
+  ["collapsible", "'start' | 'end' | 'both' | 'none'", "'none'", "접기 대상"],
+  ["collapsedSize", "number", "0", "접힘 상태 크기 (px)"],
+  ["collapseThreshold", "number", "minPx * 0.5", "드래그 중 이 값 미만이면 자동 접힘"],
+  ["storageKey", "string", "—", "localStorage persist key (uncontrolled 전용)"],
+  ["theme", "'light' | 'dark'", "'light'", "테마"],
+  ["disabled", "boolean", "false", "드래그/키보드 전부 차단"],
+  ["aria-label", "string", "—", "root group 라벨 (Divider 기본 라벨과는 별개)"],
+];
+
+const PANE_PROPS: Array<[string, string, string, string]> = [
+  ["label", "string", "—", "ARIA label, 기본은 'Pane 1' / 'Pane 2'"],
+  ["className / style", "—", "—", "pane 래퍼 스타일"],
+  ["children", "ReactNode", "—", "pane 내용"],
+];
+
+const DIVIDER_PROPS: Array<[string, string, string, string]> = [
+  ["aria-label", "string", "'Resize panes'", "divider ARIA label"],
+  ["children", "ReactNode", "기본 핸들", "divider 내부 affordance override"],
+  ["className / style", "—", "—", "divider 스타일"],
+];
+
+const COLLAPSE_BTN_PROPS: Array<[string, string, string, string]> = [
+  ["which", "'start' | 'end'", "—", "접기 대상"],
+  ["aria-label", "string", "자동", "버튼 ARIA label"],
+  ["children", "ReactNode", "자동 아이콘", "아이콘 override"],
+  ["className / style", "—", "—", "버튼 스타일"],
+];
+
+function BasicHorizontalSection() {
+  return (
+    <Section id="basic" title="Basic horizontal" desc="기본 수평 분할 (40% start).">
+      <Frame>
+        <SplitPane.Root defaultSize="40%">
+          <SplitPane.Pane label="File tree">
+            <FakeFileTree />
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane label="Editor">
+            <FakeEditor />
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </Frame>
+    </Section>
+  );
+}
+
+function VerticalSection() {
+  return (
+    <Section id="vertical" title="Vertical" desc="상/하 분할, cursor=row-resize.">
+      <Frame height={320}>
+        <SplitPane.Root direction="vertical" defaultSize="60%">
+          <SplitPane.Pane label="Editor">
+            <FakeEditor />
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane label="Terminal">
+            <FakeTerminal />
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </Frame>
+    </Section>
+  );
+}
+
+function MinMaxSection() {
+  return (
+    <Section
+      id="minmax"
+      title="Min / Max"
+      desc="defaultSize=240, minSize=160, maxSize=520."
+    >
+      <Frame>
+        <SplitPane.Root defaultSize={240} minSize={160} maxSize={520}>
+          <SplitPane.Pane>
+            <PaneLabel title="min 160 / max 520" sub="드래그해도 이 범위를 벗어나지 않음" />
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane>
+            <PaneLabel title="End pane" sub="flex: 1" />
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </Frame>
+    </Section>
+  );
+}
+
+function CollapsibleSection() {
+  return (
+    <Section
+      id="collapsible"
+      title="Collapsible"
+      desc="collapsible='start' + CollapseButton. 드래그로 80px 미만 → 0 으로 자동 접힘."
+    >
+      <Frame>
+        <SplitPane.Root
+          defaultSize="30%"
+          collapsible="start"
+          collapsedSize={0}
+          collapseThreshold={80}
+        >
+          <SplitPane.Pane label="Sidebar">
+            <div
+              style={{
+                height: "100%",
+                display: "flex",
+                flexDirection: "column",
+                background: "#f9fafb",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: 8,
+                  borderBottom: "1px solid #e5e7eb",
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: "#374151",
+                }}
+              >
+                <span>Sidebar</span>
+                <SplitPane.CollapseButton which="start" />
+              </div>
+              <div style={{ flex: 1, overflow: "auto" }}>
+                <FakeFileTree />
+              </div>
+            </div>
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane label="Editor">
+            <FakeEditor />
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </Frame>
+    </Section>
+  );
+}
+
+function NestedSection() {
+  return (
+    <Section
+      id="nested"
+      title="Nested (2×2)"
+      desc="좌/우 분할 + 우측의 상/하 분할 (SplitPane 중첩)."
+    >
+      <Frame height={360}>
+        <SplitPane.Root defaultSize="30%">
+          <SplitPane.Pane>
+            <FakeFileTree />
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane>
+            <SplitPane.Root direction="vertical" defaultSize="65%">
+              <SplitPane.Pane>
+                <FakeEditor />
+              </SplitPane.Pane>
+              <SplitPane.Divider />
+              <SplitPane.Pane>
+                <FakeTerminal />
+              </SplitPane.Pane>
+            </SplitPane.Root>
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </Frame>
+    </Section>
+  );
+}
+
+function SnapSection() {
+  return (
+    <Section
+      id="snap"
+      title="Snap"
+      desc="snapSize='50%' + snapThreshold=12. 드래그 중 중앙 근처 12px 내 진입 시 고정."
+    >
+      <Frame>
+        <SplitPane.Root defaultSize="30%" snapSize="50%" snapThreshold={12}>
+          <SplitPane.Pane>
+            <PaneLabel title="Start" sub="50% 근처에서 snap" />
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane>
+            <PaneLabel title="End" />
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </Frame>
+    </Section>
+  );
+}
+
+function PersistSection() {
+  const clear = () => {
+    try {
+      localStorage.removeItem("demo:splitpane:persist");
+      location.reload();
+    } catch {
+      /* noop */
+    }
+  };
+  return (
+    <Section
+      id="persist"
+      title="Persist"
+      desc="storageKey 지정 시 드래그 결과가 새로고침 후에도 유지된다."
+    >
+      <div className="mb-2 flex gap-2 text-sm">
+        <Button variant="ghost" size="sm" onClick={clear}>
+          Clear storage
+        </Button>
+        <span className="text-gray-500 self-center">
+          새로고침해도 드래그한 크기가 그대로 유지됩니다.
+        </span>
+      </div>
+      <Frame>
+        <SplitPane.Root storageKey="demo:splitpane:persist" defaultSize="40%">
+          <SplitPane.Pane>
+            <PaneLabel title="Persist start" />
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane>
+            <PaneLabel title="End" />
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </Frame>
+    </Section>
+  );
+}
+
+function DarkSection() {
+  return (
+    <Section
+      id="dark"
+      title="Dark theme"
+      desc="theme='dark' 시 divider/handle 색상 톤이 다크로 전환."
+    >
+      <Frame dark>
+        <SplitPane.Root theme="dark" defaultSize="35%">
+          <SplitPane.Pane>
+            <FakeFileTree dark />
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane>
+            <FakeEditor dark />
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </Frame>
+    </Section>
+  );
+}
+
+function ControlledSection() {
+  const [size, setSize] = useState<SplitPaneSize>("50%");
+  return (
+    <Section
+      id="controlled"
+      title="Controlled size"
+      desc="외부 state 로 size 제어. 드래그 시 onSizeChange 로 역동기화."
+    >
+      <div className="mb-2 flex gap-2">
+        <Button variant={size === "30%" ? "primary" : "ghost"} size="sm" onClick={() => setSize("30%")}>30%</Button>
+        <Button variant={size === "50%" ? "primary" : "ghost"} size="sm" onClick={() => setSize("50%")}>50%</Button>
+        <Button variant={size === "70%" ? "primary" : "ghost"} size="sm" onClick={() => setSize("70%")}>70%</Button>
+        <span className="text-sm text-gray-500 self-center">current: {size}</span>
+      </div>
+      <Frame>
+        <SplitPane.Root
+          size={size}
+          onSizeChange={(_, pct) => setSize(`${Math.round(pct)}%`)}
+        >
+          <SplitPane.Pane>
+            <PaneLabel title="Start" sub={String(size)} />
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane>
+            <PaneLabel title="End" />
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </Frame>
+    </Section>
+  );
+}
+
+function PlaygroundSection() {
+  const [direction, setDirection] = useState<"horizontal" | "vertical">("horizontal");
+  const [defaultSize, setDefaultSize] = useState<string>("50%");
+  const [minSize, setMinSize] = useState<number>(48);
+  const [maxSize, setMaxSize] = useState<string>("90%");
+  const [collapsible, setCollapsible] = useState<SplitPaneCollapsible>("none");
+  const [snapEnabled, setSnapEnabled] = useState(false);
+  const [snapVal, setSnapVal] = useState<string>("50%");
+  const [storageEnabled, setStorageEnabled] = useState(false);
+  const [theme, setTheme] = useState<SplitPaneTheme>("light");
+  const [disabled, setDisabled] = useState(false);
+  const [key, setKey] = useState(0);
+  const [liveSize, setLiveSize] = useState<{ px: number; pct: number }>({
+    px: 0,
+    pct: 0,
+  });
+
+  const parsedDefault: SplitPaneSize = /^\d+$/.test(defaultSize)
+    ? Number(defaultSize)
+    : (defaultSize as `${number}%`);
+  const parsedMax: SplitPaneSize = /^\d+$/.test(maxSize)
+    ? Number(maxSize)
+    : (maxSize as `${number}%`);
+  const parsedSnap: SplitPaneSize | undefined = snapEnabled
+    ? /^\d+$/.test(snapVal)
+      ? Number(snapVal)
+      : (snapVal as `${number}%`)
+    : undefined;
+
+  return (
+    <Section id="playground" title="Playground" desc="모든 prop 조합을 실시간으로 시험.">
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4 p-4 border border-gray-200 rounded-lg bg-gray-50 text-sm">
+        <label className="flex flex-col gap-1">
+          <span className="text-gray-600">direction</span>
+          <select
+            value={direction}
+            onChange={(e) => setDirection(e.target.value as "horizontal" | "vertical")}
+            className="border border-gray-300 rounded px-2 py-1"
+          >
+            <option value="horizontal">horizontal</option>
+            <option value="vertical">vertical</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-gray-600">defaultSize</span>
+          <select
+            value={defaultSize}
+            onChange={(e) => setDefaultSize(e.target.value)}
+            className="border border-gray-300 rounded px-2 py-1"
+          >
+            <option value="25%">25%</option>
+            <option value="50%">50%</option>
+            <option value="75%">75%</option>
+            <option value="200">200 (px)</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-gray-600">minSize (px)</span>
+          <input
+            type="number"
+            value={minSize}
+            onChange={(e) => setMinSize(Number(e.target.value))}
+            className="border border-gray-300 rounded px-2 py-1"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-gray-600">maxSize</span>
+          <input
+            type="text"
+            value={maxSize}
+            onChange={(e) => setMaxSize(e.target.value)}
+            className="border border-gray-300 rounded px-2 py-1 font-mono text-xs"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-gray-600">collapsible</span>
+          <select
+            value={collapsible}
+            onChange={(e) => setCollapsible(e.target.value as SplitPaneCollapsible)}
+            className="border border-gray-300 rounded px-2 py-1"
+          >
+            <option value="none">none</option>
+            <option value="start">start</option>
+            <option value="end">end</option>
+            <option value="both">both</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-gray-600">snapSize</span>
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={snapEnabled}
+              onChange={(e) => setSnapEnabled(e.target.checked)}
+            />
+            <input
+              type="text"
+              value={snapVal}
+              onChange={(e) => setSnapVal(e.target.value)}
+              disabled={!snapEnabled}
+              className="border border-gray-300 rounded px-2 py-1 font-mono text-xs flex-1"
+            />
+          </div>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={storageEnabled}
+            onChange={(e) => setStorageEnabled(e.target.checked)}
+          />
+          <span className="text-gray-600">storageKey</span>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-gray-600">theme</span>
+          <select
+            value={theme}
+            onChange={(e) => setTheme(e.target.value as SplitPaneTheme)}
+            className="border border-gray-300 rounded px-2 py-1"
+          >
+            <option value="light">light</option>
+            <option value="dark">dark</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={disabled}
+            onChange={(e) => setDisabled(e.target.checked)}
+          />
+          <span className="text-gray-600">disabled</span>
+        </label>
+        <div className="flex items-end">
+          <Button variant="ghost" size="sm" onClick={() => setKey((k) => k + 1)}>
+            Reset
+          </Button>
+        </div>
+      </div>
+      <Frame height={400} dark={theme === "dark"}>
+        <SplitPane.Root
+          key={key}
+          direction={direction}
+          defaultSize={parsedDefault}
+          minSize={minSize}
+          maxSize={parsedMax}
+          collapsible={collapsible}
+          theme={theme}
+          disabled={disabled}
+          onSizeChange={(px, pct) => setLiveSize({ px: Math.round(px), pct: Math.round(pct) })}
+          {...(parsedSnap !== undefined ? { snapSize: parsedSnap } : {})}
+          {...(storageEnabled ? { storageKey: "demo:splitpane:playground" } : {})}
+        >
+          <SplitPane.Pane>
+            <PaneLabel
+              title="Start"
+              sub={`${liveSize.px} px / ${liveSize.pct}%`}
+              dark={theme === "dark"}
+            />
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane>
+            <PaneLabel title="End" dark={theme === "dark"} />
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </Frame>
+    </Section>
+  );
+}
+
+function PropsSection() {
+  return (
+    <Section id="props" title="Props">
+      <div className="mb-6">
+        <h4 className="text-sm font-semibold mb-2">SplitPane.Root</h4>
+        <PropsTable rows={ROOT_PROPS} />
+      </div>
+      <div className="mb-6">
+        <h4 className="text-sm font-semibold mb-2">SplitPane.Pane</h4>
+        <PropsTable rows={PANE_PROPS} />
+      </div>
+      <div className="mb-6">
+        <h4 className="text-sm font-semibold mb-2">SplitPane.Divider</h4>
+        <PropsTable rows={DIVIDER_PROPS} />
+      </div>
+      <div className="mb-6">
+        <h4 className="text-sm font-semibold mb-2">SplitPane.CollapseButton</h4>
+        <PropsTable rows={COLLAPSE_BTN_PROPS} />
+      </div>
+    </Section>
+  );
+}
+
+const USAGE_BASIC = `import { SplitPane } from "plastic";
+
+export function Basic() {
+  return (
+    <div style={{ height: 300 }}>
+      <SplitPane.Root defaultSize="40%">
+        <SplitPane.Pane>
+          <FileTree />
+        </SplitPane.Pane>
+        <SplitPane.Divider />
+        <SplitPane.Pane>
+          <Editor />
+        </SplitPane.Pane>
+      </SplitPane.Root>
+    </div>
+  );
+}`;
+
+const USAGE_IDE = `import { SplitPane } from "plastic";
+
+export function IDELayout() {
+  return (
+    <SplitPane.Root
+      defaultSize={240}
+      minSize={160}
+      maxSize="40%"
+      collapsible="start"
+      collapsedSize={32}
+      storageKey="ide:sidebar"
+    >
+      <SplitPane.Pane label="File tree">
+        <aside>
+          <FileTree />
+        </aside>
+      </SplitPane.Pane>
+      <SplitPane.Divider />
+      <SplitPane.Pane label="Editor">
+        <SplitPane.Root direction="vertical" defaultSize="70%" minSize={80}>
+          <SplitPane.Pane>
+            <Editor />
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane>
+            <Terminal />
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </SplitPane.Pane>
+    </SplitPane.Root>
+  );
+}`;
+
+const USAGE_CONTROLLED = `import { useState } from "react";
+import { SplitPane, type SplitPaneSize } from "plastic";
+
+export function ControlledSplit() {
+  const [size, setSize] = useState<SplitPaneSize>("50%");
+  return (
+    <SplitPane.Root
+      size={size}
+      onSizeChange={(_, pct) => setSize(\`\${Math.round(pct)}%\`)}
+      storageKey="app:layout"
+    >
+      <SplitPane.Pane>
+        <Left />
+      </SplitPane.Pane>
+      <SplitPane.Divider />
+      <SplitPane.Pane>
+        <Right />
+      </SplitPane.Pane>
+    </SplitPane.Root>
+  );
+}`;
+
+const USAGE_NESTED = `import { SplitPane } from "plastic";
+
+export function Quadrant() {
+  return (
+    <SplitPane.Root defaultSize="30%">
+      <SplitPane.Pane>
+        <Left />
+      </SplitPane.Pane>
+      <SplitPane.Divider />
+      <SplitPane.Pane>
+        <SplitPane.Root direction="vertical" defaultSize="70%">
+          <SplitPane.Pane>
+            <Editor />
+          </SplitPane.Pane>
+          <SplitPane.Divider />
+          <SplitPane.Pane>
+            <Terminal />
+          </SplitPane.Pane>
+        </SplitPane.Root>
+      </SplitPane.Pane>
+    </SplitPane.Root>
+  );
+}`;
+
+function UsageSection() {
+  return (
+    <Section id="usage" title="Usage">
+      <div className="space-y-6">
+        <div>
+          <p className="text-sm text-gray-600 mb-2">기본 2-pane</p>
+          <CodeView code={USAGE_BASIC} language="tsx" />
+        </div>
+        <div>
+          <p className="text-sm text-gray-600 mb-2">IDE 스타일 (sidebar + editor + terminal)</p>
+          <CodeView code={USAGE_IDE} language="tsx" />
+        </div>
+        <div>
+          <p className="text-sm text-gray-600 mb-2">Controlled + persist</p>
+          <CodeView code={USAGE_CONTROLLED} language="tsx" />
+        </div>
+        <div>
+          <p className="text-sm text-gray-600 mb-2">Nested 2×2</p>
+          <CodeView code={USAGE_NESTED} language="tsx" />
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+export function SplitPanePage() {
+  return (
+    <div className="max-w-5xl">
+      <h2 className="text-2xl font-bold mb-2">SplitPane</h2>
+      <p className="text-sm text-gray-500 mb-8">
+        드래그 가능한 divider 로 두 영역을 분할하는 레이아웃 프리미티브.
+      </p>
+      <BasicHorizontalSection />
+      <VerticalSection />
+      <MinMaxSection />
+      <CollapsibleSection />
+      <NestedSection />
+      <SnapSection />
+      <PersistSection />
+      <DarkSection />
+      <ControlledSection />
+      <PlaygroundSection />
+      <PropsSection />
+      <UsageSection />
+    </div>
+  );
+}
+
+export default SplitPanePage;

--- a/src/components/SplitPane/SplitPane.tsx
+++ b/src/components/SplitPane/SplitPane.tsx
@@ -1,8 +1,626 @@
-const noop = () => null;
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { CSSProperties, ReactElement, ReactNode } from "react";
+import {
+  SplitPaneContext,
+  useSplitPaneContext,
+} from "./SplitPaneContext";
+import type { SplitPaneContextValue } from "./SplitPaneContext";
+import { usePaneResize } from "./usePaneResize";
+import {
+  DIVIDER_PX,
+  clamp,
+  isSizeString,
+  toPct,
+  toPx,
+} from "./SplitPane.utils";
+import { splitPanePalette } from "./theme";
+import type {
+  SplitPaneCollapseButtonProps,
+  SplitPaneDividerProps,
+  SplitPaneProps,
+  SplitPaneRootProps,
+  SplitPaneSize,
+} from "./SplitPane.types";
+
+interface PaneIndexProps {
+  "data-sp-pane-index"?: 0 | 1;
+}
+
+function readStorage(
+  key: string,
+): { unit: "px" | "pct"; value: number } | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "unit" in parsed &&
+      "value" in parsed &&
+      (parsed.unit === "px" || parsed.unit === "pct") &&
+      typeof parsed.value === "number" &&
+      Number.isFinite(parsed.value)
+    ) {
+      return { unit: parsed.unit, value: parsed.value };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(
+  key: string,
+  payload: { unit: "px" | "pct"; value: number },
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(payload));
+  } catch {
+    /* ignore quota */
+  }
+}
+
+function SplitPaneRoot(props: SplitPaneRootProps) {
+  const {
+    direction = "horizontal",
+    defaultSize = "50%",
+    size: controlledSize,
+    onSizeChange,
+    onSizeChangeEnd,
+    minSize = 48,
+    maxSize = "90%",
+    snapSize,
+    snapThreshold = 8,
+    collapsible = "none",
+    collapsedSize = 0,
+    collapseThreshold,
+    storageKey,
+    theme = "light",
+    disabled = false,
+    className,
+    style,
+    "aria-label": ariaLabel,
+    children,
+  } = props;
+
+  const isControlled = controlledSize !== undefined;
+
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const dividerRef = useRef<HTMLDivElement | null>(null);
+
+  const [containerPx, setContainerPx] = useState<number>(0);
+  const [internalPx, setInternalPx] = useState<number | null>(null);
+  const [rtl, setRtl] = useState<boolean>(false);
+  const preCollapseRef = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    const axis = direction === "horizontal" ? el.offsetWidth : el.offsetHeight;
+    if (axis > 0) setContainerPx(axis);
+
+    if (typeof window !== "undefined") {
+      try {
+        const cssDir = window.getComputedStyle(el).direction;
+        setRtl(cssDir === "rtl");
+      } catch {
+        /* noop */
+      }
+    }
+  }, [direction]);
+
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const box = entry.contentBoxSize?.[0];
+      const w = box ? box.inlineSize : entry.contentRect.width;
+      const h = box ? box.blockSize : entry.contentRect.height;
+      const nextAxis = direction === "horizontal" ? w : h;
+      if (nextAxis > 0) setContainerPx(nextAxis);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [direction]);
+
+  const minPx = useMemo(() => {
+    if (containerPx <= 0) return 0;
+    const raw = toPx(minSize, containerPx);
+    return Math.max(0, Math.min(raw, containerPx / 2));
+  }, [minSize, containerPx]);
+
+  const maxPx = useMemo(() => {
+    if (containerPx <= 0) return 0;
+    const raw = toPx(maxSize, containerPx);
+    return Math.max(minPx, Math.min(raw, containerPx - DIVIDER_PX));
+  }, [maxSize, containerPx, minPx]);
+
+  const snapPx = useMemo<number | null>(() => {
+    if (snapSize === undefined) return null;
+    if (containerPx <= 0) return null;
+    return toPx(snapSize, containerPx);
+  }, [snapSize, containerPx]);
+
+  const effectiveCollapseThreshold = useMemo(() => {
+    if (collapseThreshold !== undefined) return collapseThreshold;
+    return Math.max(minPx * 0.5, 0);
+  }, [collapseThreshold, minPx]);
+
+  useLayoutEffect(() => {
+    if (containerPx <= 0) return;
+    if (isControlled) return;
+    if (internalPx != null) return;
+
+    if (storageKey) {
+      const loaded = readStorage(storageKey);
+      if (loaded) {
+        const initPx =
+          loaded.unit === "px" ? loaded.value : (loaded.value / 100) * containerPx;
+        setInternalPx(clamp(initPx, minPx, maxPx));
+        return;
+      }
+    }
+    const initial = toPx(defaultSize, containerPx);
+    setInternalPx(clamp(initial, minPx, maxPx));
+  }, [containerPx, isControlled, internalPx, storageKey, defaultSize, minPx, maxPx]);
+
+  const sizePx = useMemo<number>(() => {
+    if (isControlled) {
+      if (containerPx <= 0) return 0;
+      return clamp(toPx(controlledSize, containerPx), minPx, maxPx);
+    }
+    if (internalPx == null) return 0;
+    return internalPx;
+  }, [isControlled, controlledSize, containerPx, minPx, maxPx, internalPx]);
+
+  useEffect(() => {
+    if (isControlled) return;
+    if (internalPx == null) return;
+    if (containerPx <= 0) return;
+    if (internalPx < minPx || internalPx > maxPx) {
+      setInternalPx(clamp(internalPx, minPx, maxPx));
+    }
+  }, [isControlled, internalPx, minPx, maxPx, containerPx]);
+
+  useEffect(() => {
+    if (!storageKey) return;
+    if (isControlled) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[SplitPane] storageKey is ignored when `size` (controlled) is provided.",
+      );
+      return;
+    }
+    if (internalPx == null) return;
+    writeStorage(storageKey, { unit: "px", value: Math.round(internalPx) });
+  }, [storageKey, isControlled, internalPx]);
+
+  const commitSize = useCallback(
+    (next: number) => {
+      if (!isControlled) {
+        setInternalPx(next);
+      }
+      if (onSizeChange) {
+        onSizeChange(next, toPct(next, containerPx));
+      }
+    },
+    [isControlled, onSizeChange, containerPx],
+  );
+
+  const isCollapsedStart = sizePx <= collapsedSize + 0.5;
+  const isCollapsedEnd =
+    containerPx > 0 &&
+    containerPx - sizePx - DIVIDER_PX <= collapsedSize + 0.5;
+
+  const toggleCollapse = useCallback(
+    (which: "start" | "end") => {
+      if (containerPx <= 0) return;
+      if (which === "start") {
+        if (isCollapsedStart) {
+          const restore = preCollapseRef.current ?? toPx(defaultSize, containerPx);
+          preCollapseRef.current = null;
+          commitSize(clamp(restore, minPx, maxPx));
+        } else {
+          preCollapseRef.current = sizePx;
+          commitSize(collapsedSize);
+        }
+      } else {
+        if (isCollapsedEnd) {
+          const restore = preCollapseRef.current ?? toPx(defaultSize, containerPx);
+          preCollapseRef.current = null;
+          commitSize(clamp(restore, minPx, maxPx));
+        } else {
+          preCollapseRef.current = sizePx;
+          commitSize(containerPx - collapsedSize - DIVIDER_PX);
+        }
+      }
+    },
+    [
+      containerPx,
+      isCollapsedStart,
+      isCollapsedEnd,
+      sizePx,
+      collapsedSize,
+      minPx,
+      maxPx,
+      defaultSize,
+      commitSize,
+    ],
+  );
+
+  const { onDividerPointerDown, onDividerKeyDown, isDragging } = usePaneResize({
+    direction,
+    disabled,
+    rtl,
+    sizePx,
+    containerPx,
+    minPx,
+    maxPx,
+    snapPx,
+    snapThreshold,
+    collapsible,
+    collapsedSize,
+    collapseThreshold: effectiveCollapseThreshold,
+    dividerRef,
+    commitSize,
+    onSizeChangeEnd,
+    toggleCollapse,
+  });
+
+  const baseId = useId();
+  const startPaneId = `${baseId}-start`;
+  const endPaneId = `${baseId}-end`;
+  const dividerLabel = ariaLabel ?? "Resize panes";
+
+  const ctxValue = useMemo<SplitPaneContextValue>(
+    () => ({
+      direction,
+      sizePx,
+      containerPx,
+      minPx,
+      maxPx,
+      collapsible,
+      collapsedSize,
+      isCollapsedStart,
+      isCollapsedEnd,
+      disabled,
+      theme,
+      onDividerPointerDown,
+      onDividerKeyDown,
+      toggleCollapse,
+      isDragging,
+      rtl,
+      dividerRef,
+      startPaneId,
+      endPaneId,
+      dividerLabel,
+    }),
+    [
+      direction,
+      sizePx,
+      containerPx,
+      minPx,
+      maxPx,
+      collapsible,
+      collapsedSize,
+      isCollapsedStart,
+      isCollapsedEnd,
+      disabled,
+      theme,
+      onDividerPointerDown,
+      onDividerKeyDown,
+      toggleCollapse,
+      isDragging,
+      rtl,
+      startPaneId,
+      endPaneId,
+      dividerLabel,
+    ],
+  );
+
+  const palette = splitPanePalette[theme];
+
+  const rootStyle: CSSProperties = {
+    display: "flex",
+    flexDirection: direction === "horizontal" ? "row" : "column",
+    width: "100%",
+    height: "100%",
+    minWidth: 0,
+    minHeight: 0,
+    position: "relative",
+    ...style,
+  };
+
+  const mapped = useMemo(() => {
+    let paneIdx = 0;
+    const arr = Children.toArray(children);
+    return arr.map((child) => {
+      if (!isValidElement(child)) return child;
+      const type = (child.type as { displayName?: string }).displayName;
+      if (type === "SplitPane.Pane") {
+        const idx = paneIdx as 0 | 1;
+        paneIdx += 1;
+        return cloneElement(child as ReactElement<PaneIndexProps>, {
+          "data-sp-pane-index": idx,
+        });
+      }
+      return child;
+    });
+  }, [children]);
+
+  const cssVars: CSSProperties & Record<string, string> = {
+    ["--sp-divider-bg"]: palette.dividerBg,
+    ["--sp-divider-hover"]: palette.dividerHover,
+    ["--sp-divider-active"]: palette.dividerActive,
+    ["--sp-divider-handle-fg"]: palette.dividerHandleFg,
+    ["--sp-collapse-btn-bg"]: palette.collapseBtnBg,
+    ["--sp-collapse-btn-fg"]: palette.collapseBtnFg,
+    ["--sp-collapse-btn-border"]: palette.collapseBtnBorder,
+    ["--sp-focus-ring"]: palette.focusRing,
+  };
+
+  return (
+    <SplitPaneContext.Provider value={ctxValue}>
+      <div
+        ref={rootRef}
+        role="group"
+        {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
+        data-splitpane-root=""
+        data-direction={direction}
+        data-theme={theme}
+        data-dragging={isDragging ? "true" : "false"}
+        className={className}
+        style={{ ...cssVars, ...rootStyle }}
+      >
+        {mapped}
+        {isDragging ? (
+          <div
+            aria-hidden="true"
+            style={{
+              position: "fixed",
+              inset: 0,
+              zIndex: 9999,
+              cursor:
+                direction === "horizontal" ? "col-resize" : "row-resize",
+            }}
+          />
+        ) : null}
+      </div>
+    </SplitPaneContext.Provider>
+  );
+}
+SplitPaneRoot.displayName = "SplitPane.Root";
+
+function SplitPanePane(props: SplitPaneProps & PaneIndexProps) {
+  const {
+    children,
+    className,
+    style,
+    label,
+    "data-sp-pane-index": paneIndex,
+  } = props;
+  const ctx = useSplitPaneContext();
+  const isStart = paneIndex === 0;
+  const {
+    direction,
+    sizePx,
+    containerPx,
+    startPaneId,
+    endPaneId,
+  } = ctx;
+
+  const baseStyle: CSSProperties = isStart
+    ? {
+        flex: containerPx > 0 ? `0 0 ${Math.round(sizePx)}px` : "0 0 50%",
+        minWidth: 0,
+        minHeight: 0,
+        overflow: "hidden",
+      }
+    : {
+        flex: "1 1 0",
+        minWidth: 0,
+        minHeight: 0,
+        overflow: "hidden",
+      };
+
+  const paneId = isStart ? startPaneId : endPaneId;
+
+  return (
+    <div
+      id={paneId}
+      role="region"
+      aria-label={label ?? (isStart ? "Pane 1" : "Pane 2")}
+      data-splitpane-pane={isStart ? "start" : "end"}
+      data-direction={direction}
+      className={className}
+      style={{ ...baseStyle, ...style }}
+    >
+      {children}
+    </div>
+  );
+}
+SplitPanePane.displayName = "SplitPane.Pane";
+
+function SplitPaneDivider(props: SplitPaneDividerProps) {
+  const {
+    className,
+    style,
+    "aria-label": ariaLabel,
+    children,
+  } = props;
+  const ctx = useSplitPaneContext();
+  const {
+    direction,
+    sizePx,
+    containerPx,
+    minPx,
+    maxPx,
+    disabled,
+    isDragging,
+    onDividerPointerDown,
+    onDividerKeyDown,
+    dividerRef,
+    startPaneId,
+    endPaneId,
+    dividerLabel,
+  } = ctx;
+
+  const orientation = direction === "horizontal" ? "vertical" : "horizontal";
+  const pct = containerPx > 0 ? toPct(sizePx, containerPx) : 0;
+  const minPct = containerPx > 0 ? toPct(minPx, containerPx) : 0;
+  const maxPct = containerPx > 0 ? toPct(maxPx, containerPx) : 100;
+
+  const baseStyle: CSSProperties = {
+    flex:
+      direction === "horizontal"
+        ? `0 0 ${DIVIDER_PX}px`
+        : `0 0 ${DIVIDER_PX}px`,
+    width: direction === "horizontal" ? DIVIDER_PX : "100%",
+    height: direction === "horizontal" ? "100%" : DIVIDER_PX,
+    cursor: disabled
+      ? "default"
+      : direction === "horizontal"
+        ? "col-resize"
+        : "row-resize",
+    background: isDragging
+      ? "var(--sp-divider-active)"
+      : "var(--sp-divider-bg)",
+    transition: "background 120ms",
+    userSelect: "none",
+    touchAction: "none",
+    position: "relative",
+    outline: "none",
+  };
+
+  return (
+    <div
+      ref={dividerRef}
+      role="separator"
+      tabIndex={disabled ? -1 : 0}
+      aria-orientation={orientation}
+      aria-valuenow={Math.round(pct)}
+      aria-valuemin={Math.round(minPct)}
+      aria-valuemax={Math.round(maxPct)}
+      aria-label={ariaLabel ?? dividerLabel}
+      aria-controls={`${startPaneId} ${endPaneId}`}
+      aria-disabled={disabled || undefined}
+      data-splitpane-divider=""
+      data-direction={direction}
+      data-orientation={orientation}
+      data-dragging={isDragging ? "true" : "false"}
+      data-disabled={disabled ? "true" : undefined}
+      onPointerDown={onDividerPointerDown}
+      onKeyDown={onDividerKeyDown}
+      className={className}
+      style={{ ...baseStyle, ...style }}
+    >
+      {children ?? (
+        <span
+          aria-hidden="true"
+          data-splitpane-divider-handle=""
+          style={{
+            position: "absolute",
+            left: "50%",
+            top: "50%",
+            transform: "translate(-50%, -50%)",
+            width: direction === "horizontal" ? 2 : 18,
+            height: direction === "horizontal" ? 18 : 2,
+            background: "var(--sp-divider-handle-fg)",
+            borderRadius: 1,
+            opacity: isDragging ? 0.7 : 0,
+            transition: "opacity 120ms",
+            pointerEvents: "none",
+          }}
+        />
+      )}
+    </div>
+  );
+}
+SplitPaneDivider.displayName = "SplitPane.Divider";
+
+function SplitPaneCollapseButton(props: SplitPaneCollapseButtonProps) {
+  const {
+    which,
+    className,
+    style,
+    children,
+    "aria-label": ariaLabel,
+  } = props;
+  const ctx = useSplitPaneContext();
+  const { direction, isCollapsedStart, isCollapsedEnd, toggleCollapse, theme } =
+    ctx;
+
+  const isCollapsed = which === "start" ? isCollapsedStart : isCollapsedEnd;
+
+  const icon = useMemo<ReactNode>(() => {
+    if (children !== undefined) return children;
+    if (direction === "horizontal") {
+      if (which === "start") return isCollapsed ? "\u25B8" : "\u25C2";
+      return isCollapsed ? "\u25C2" : "\u25B8";
+    }
+    if (which === "start") return isCollapsed ? "\u25BE" : "\u25B4";
+    return isCollapsed ? "\u25B4" : "\u25BE";
+  }, [children, direction, which, isCollapsed]);
+
+  const paneId = which === "start" ? ctx.startPaneId : ctx.endPaneId;
+
+  const baseStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 22,
+    height: 22,
+    fontSize: 12,
+    lineHeight: 1,
+    padding: 0,
+    border: "1px solid var(--sp-collapse-btn-border)",
+    borderRadius: 4,
+    background: "var(--sp-collapse-btn-bg)",
+    color: "var(--sp-collapse-btn-fg)",
+    cursor: "pointer",
+    outline: "none",
+  };
+
+  return (
+    <button
+      type="button"
+      aria-expanded={!isCollapsed}
+      aria-controls={paneId}
+      aria-label={ariaLabel ?? (isCollapsed ? "Expand pane" : "Collapse pane")}
+      data-splitpane-collapse-button={which}
+      data-theme={theme}
+      onClick={() => toggleCollapse(which)}
+      className={className}
+      style={{ ...baseStyle, ...style }}
+    >
+      {icon}
+    </button>
+  );
+}
+SplitPaneCollapseButton.displayName = "SplitPane.CollapseButton";
 
 export const SplitPane = {
-  Root: noop,
-  Pane: noop,
-  Divider: noop,
-  CollapseButton: noop,
+  Root: SplitPaneRoot,
+  Pane: SplitPanePane,
+  Divider: SplitPaneDivider,
+  CollapseButton: SplitPaneCollapseButton,
 };
+
+export { isSizeString };

--- a/src/components/SplitPane/SplitPane.tsx
+++ b/src/components/SplitPane/SplitPane.tsx
@@ -1,0 +1,8 @@
+const noop = () => null;
+
+export const SplitPane = {
+  Root: noop,
+  Pane: noop,
+  Divider: noop,
+  CollapseButton: noop,
+};

--- a/src/components/SplitPane/SplitPane.types.ts
+++ b/src/components/SplitPane/SplitPane.types.ts
@@ -1,0 +1,59 @@
+import type { CSSProperties, ReactNode } from "react";
+
+export type SplitPaneTheme = "light" | "dark";
+export type SplitPaneDirection = "horizontal" | "vertical";
+export type SplitPaneSize = number | `${number}%`;
+export type SplitPaneCollapsible = "start" | "end" | "both" | "none";
+
+export interface SplitPaneRootProps {
+  direction?: SplitPaneDirection | undefined;
+  defaultSize?: SplitPaneSize | undefined;
+  size?: SplitPaneSize | undefined;
+  onSizeChange?: ((sizePx: number, sizePercent: number) => void) | undefined;
+  onSizeChangeEnd?: ((sizePx: number, sizePercent: number) => void) | undefined;
+
+  minSize?: SplitPaneSize | undefined;
+  maxSize?: SplitPaneSize | undefined;
+
+  snapSize?: SplitPaneSize | undefined;
+  snapThreshold?: number | undefined;
+
+  collapsible?: SplitPaneCollapsible | undefined;
+  collapsedSize?: number | undefined;
+  collapseThreshold?: number | undefined;
+
+  storageKey?: string | undefined;
+
+  theme?: SplitPaneTheme | undefined;
+
+  disabled?: boolean | undefined;
+
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+
+  "aria-label"?: string | undefined;
+
+  children: ReactNode;
+}
+
+export interface SplitPaneProps {
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  label?: string | undefined;
+}
+
+export interface SplitPaneDividerProps {
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  "aria-label"?: string | undefined;
+  children?: ReactNode | undefined;
+}
+
+export interface SplitPaneCollapseButtonProps {
+  which: "start" | "end";
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  children?: ReactNode | undefined;
+  "aria-label"?: string | undefined;
+}

--- a/src/components/SplitPane/SplitPane.utils.ts
+++ b/src/components/SplitPane/SplitPane.utils.ts
@@ -1,0 +1,30 @@
+import type { SplitPaneSize } from "./SplitPane.types";
+
+export const DIVIDER_PX = 6;
+
+export function isSizeString(x: unknown): x is `${number}%` {
+  return typeof x === "string" && /^-?\d+(\.\d+)?%$/.test(x);
+}
+
+export function parseSize(s: SplitPaneSize): { unit: "px" | "pct"; value: number } {
+  if (typeof s === "number") return { unit: "px", value: s };
+  const m = /^(-?\d+(\.\d+)?)%$/.exec(s);
+  if (!m || m[1] === undefined) {
+    throw new Error(`SplitPane: invalid size ${s}`);
+  }
+  return { unit: "pct", value: parseFloat(m[1]) };
+}
+
+export function toPx(s: SplitPaneSize, containerPx: number): number {
+  const p = parseSize(s);
+  return p.unit === "px" ? p.value : (p.value / 100) * containerPx;
+}
+
+export function toPct(px: number, containerPx: number): number {
+  if (containerPx <= 0) return 0;
+  return (px / containerPx) * 100;
+}
+
+export function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}

--- a/src/components/SplitPane/SplitPaneContext.ts
+++ b/src/components/SplitPane/SplitPaneContext.ts
@@ -1,0 +1,41 @@
+import { createContext, useContext } from "react";
+import type {
+  SplitPaneCollapsible,
+  SplitPaneDirection,
+  SplitPaneTheme,
+} from "./SplitPane.types";
+
+export interface SplitPaneContextValue {
+  direction: SplitPaneDirection;
+  sizePx: number;
+  containerPx: number;
+  minPx: number;
+  maxPx: number;
+  collapsible: SplitPaneCollapsible;
+  collapsedSize: number;
+  isCollapsedStart: boolean;
+  isCollapsedEnd: boolean;
+  disabled: boolean;
+  theme: SplitPaneTheme;
+  onDividerPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  onDividerKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  toggleCollapse: (which: "start" | "end") => void;
+  isDragging: boolean;
+  rtl: boolean;
+  dividerRef: React.MutableRefObject<HTMLDivElement | null>;
+  startPaneId: string;
+  endPaneId: string;
+  dividerLabel: string;
+}
+
+export const SplitPaneContext = createContext<SplitPaneContextValue | null>(null);
+
+export function useSplitPaneContext(): SplitPaneContextValue {
+  const ctx = useContext(SplitPaneContext);
+  if (ctx === null) {
+    throw new Error(
+      "SplitPane compound components must be used within <SplitPane.Root>",
+    );
+  }
+  return ctx;
+}

--- a/src/components/SplitPane/index.ts
+++ b/src/components/SplitPane/index.ts
@@ -1,0 +1,11 @@
+export { SplitPane } from "./SplitPane";
+export type {
+  SplitPaneRootProps,
+  SplitPaneProps,
+  SplitPaneDividerProps,
+  SplitPaneCollapseButtonProps,
+  SplitPaneSize,
+  SplitPaneTheme,
+  SplitPaneDirection,
+  SplitPaneCollapsible,
+} from "./SplitPane.types";

--- a/src/components/SplitPane/theme.ts
+++ b/src/components/SplitPane/theme.ts
@@ -1,0 +1,35 @@
+import type { SplitPaneTheme } from "./SplitPane.types";
+
+export interface SplitPanePalette {
+  dividerBg: string;
+  dividerHover: string;
+  dividerActive: string;
+  dividerHandleFg: string;
+  collapseBtnBg: string;
+  collapseBtnFg: string;
+  collapseBtnBorder: string;
+  focusRing: string;
+}
+
+export const splitPanePalette: Record<SplitPaneTheme, SplitPanePalette> = {
+  light: {
+    dividerBg: "rgba(0,0,0,0.08)",
+    dividerHover: "rgba(37,99,235,0.35)",
+    dividerActive: "#2563eb",
+    dividerHandleFg: "rgba(0,0,0,0.35)",
+    collapseBtnBg: "#ffffff",
+    collapseBtnFg: "#374151",
+    collapseBtnBorder: "rgba(0,0,0,0.12)",
+    focusRing: "#2563eb",
+  },
+  dark: {
+    dividerBg: "rgba(255,255,255,0.08)",
+    dividerHover: "rgba(96,165,250,0.35)",
+    dividerActive: "#60a5fa",
+    dividerHandleFg: "rgba(255,255,255,0.5)",
+    collapseBtnBg: "#1f2937",
+    collapseBtnFg: "#e5e7eb",
+    collapseBtnBorder: "rgba(255,255,255,0.08)",
+    focusRing: "#60a5fa",
+  },
+};

--- a/src/components/SplitPane/usePaneResize.ts
+++ b/src/components/SplitPane/usePaneResize.ts
@@ -1,0 +1,282 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { MutableRefObject } from "react";
+import type {
+  SplitPaneCollapsible,
+  SplitPaneDirection,
+} from "./SplitPane.types";
+import { DIVIDER_PX, clamp, toPct } from "./SplitPane.utils";
+
+interface DragState {
+  startClient: number;
+  startSize: number;
+  pointerId: number;
+}
+
+interface UsePaneResizeOptions {
+  direction: SplitPaneDirection;
+  disabled: boolean;
+  rtl: boolean;
+  sizePx: number;
+  containerPx: number;
+  minPx: number;
+  maxPx: number;
+  snapPx: number | null;
+  snapThreshold: number;
+  collapsible: SplitPaneCollapsible;
+  collapsedSize: number;
+  collapseThreshold: number;
+  dividerRef: MutableRefObject<HTMLDivElement | null>;
+  commitSize: (next: number) => void;
+  onSizeChangeEnd?: ((sizePx: number, sizePercent: number) => void) | undefined;
+  toggleCollapse: (which: "start" | "end") => void;
+}
+
+export interface UsePaneResizeResult {
+  onDividerPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  onDividerKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  isDragging: boolean;
+}
+
+export function usePaneResize(opts: UsePaneResizeOptions): UsePaneResizeResult {
+  const {
+    direction,
+    disabled,
+    rtl,
+    sizePx,
+    containerPx,
+    minPx,
+    maxPx,
+    snapPx,
+    snapThreshold,
+    collapsible,
+    collapsedSize,
+    collapseThreshold,
+    dividerRef,
+    commitSize,
+    onSizeChangeEnd,
+    toggleCollapse,
+  } = opts;
+
+  const [isDragging, setIsDragging] = useState(false);
+
+  const sizePxRef = useRef(sizePx);
+  sizePxRef.current = sizePx;
+  const containerPxRef = useRef(containerPx);
+  containerPxRef.current = containerPx;
+  const minPxRef = useRef(minPx);
+  minPxRef.current = minPx;
+  const maxPxRef = useRef(maxPx);
+  maxPxRef.current = maxPx;
+  const snapPxRef = useRef(snapPx);
+  snapPxRef.current = snapPx;
+  const snapThresholdRef = useRef(snapThreshold);
+  snapThresholdRef.current = snapThreshold;
+  const collapsibleRef = useRef(collapsible);
+  collapsibleRef.current = collapsible;
+  const collapsedSizeRef = useRef(collapsedSize);
+  collapsedSizeRef.current = collapsedSize;
+  const collapseThresholdRef = useRef(collapseThreshold);
+  collapseThresholdRef.current = collapseThreshold;
+  const directionRef = useRef(direction);
+  directionRef.current = direction;
+  const rtlRef = useRef(rtl);
+  rtlRef.current = rtl;
+  const disabledRef = useRef(disabled);
+  disabledRef.current = disabled;
+  const commitSizeRef = useRef(commitSize);
+  commitSizeRef.current = commitSize;
+  const onSizeChangeEndRef = useRef(onSizeChangeEnd);
+  onSizeChangeEndRef.current = onSizeChangeEnd;
+  const toggleCollapseRef = useRef(toggleCollapse);
+  toggleCollapseRef.current = toggleCollapse;
+
+  const dragRef = useRef<DragState | null>(null);
+  const rafRef = useRef<number>(0);
+  const pendingNextRef = useRef<number | null>(null);
+
+  const computeClamped = useCallback((raw: number): number => {
+    const curMin = minPxRef.current;
+    const curMax = maxPxRef.current;
+    const curSnap = snapPxRef.current;
+    const curSnapThr = snapThresholdRef.current;
+    const curCollapsible = collapsibleRef.current;
+    const curCollapsed = collapsedSizeRef.current;
+    const curCollapseThr = collapseThresholdRef.current;
+    const curContainer = containerPxRef.current;
+
+    let next = raw;
+
+    if (curSnap != null && Math.abs(next - curSnap) < curSnapThr) {
+      next = curSnap;
+    }
+
+    if (curCollapsible === "start" || curCollapsible === "both") {
+      if (next < curCollapseThr) {
+        return curCollapsed;
+      }
+    }
+    if (curCollapsible === "end" || curCollapsible === "both") {
+      const endSize = curContainer - next - DIVIDER_PX;
+      if (endSize < curCollapseThr) {
+        return curContainer - curCollapsed - DIVIDER_PX;
+      }
+    }
+
+    return clamp(next, curMin, curMax);
+  }, []);
+
+  const onDividerPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (disabledRef.current) return;
+      e.preventDefault();
+      e.stopPropagation();
+
+      const startClient =
+        directionRef.current === "horizontal" ? e.clientX : e.clientY;
+      dragRef.current = {
+        startClient,
+        startSize: sizePxRef.current,
+        pointerId: e.pointerId,
+      };
+      const div = dividerRef.current;
+      if (div && typeof div.setPointerCapture === "function") {
+        try {
+          div.setPointerCapture(e.pointerId);
+        } catch {
+          /* noop */
+        }
+      }
+      setIsDragging(true);
+      document.body.style.cursor =
+        directionRef.current === "horizontal" ? "col-resize" : "row-resize";
+      document.body.style.userSelect = "none";
+
+      const onMove = (ev: PointerEvent) => {
+        if (!dragRef.current) return;
+        const cur =
+          directionRef.current === "horizontal" ? ev.clientX : ev.clientY;
+        const signFlip =
+          rtlRef.current && directionRef.current === "horizontal" ? -1 : 1;
+        const delta = (cur - dragRef.current.startClient) * signFlip;
+        const raw = dragRef.current.startSize + delta;
+        const next = computeClamped(raw);
+
+        pendingNextRef.current = next;
+        if (!rafRef.current) {
+          rafRef.current = requestAnimationFrame(() => {
+            rafRef.current = 0;
+            if (pendingNextRef.current != null) {
+              commitSizeRef.current(pendingNextRef.current);
+              pendingNextRef.current = null;
+            }
+          });
+        }
+      };
+
+      const finish = (ev: PointerEvent) => {
+        if (rafRef.current) {
+          cancelAnimationFrame(rafRef.current);
+          rafRef.current = 0;
+          if (pendingNextRef.current != null) {
+            commitSizeRef.current(pendingNextRef.current);
+            pendingNextRef.current = null;
+          }
+        }
+        dragRef.current = null;
+        const d = dividerRef.current;
+        if (d && typeof d.releasePointerCapture === "function") {
+          try {
+            d.releasePointerCapture(ev.pointerId);
+          } catch {
+            /* noop */
+          }
+        }
+        setIsDragging(false);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        document.removeEventListener("pointermove", onMove);
+        document.removeEventListener("pointerup", finish);
+        document.removeEventListener("pointercancel", finish);
+
+        const finalPx = sizePxRef.current;
+        const pct = toPct(finalPx, containerPxRef.current);
+        onSizeChangeEndRef.current?.(finalPx, pct);
+      };
+
+      document.addEventListener("pointermove", onMove);
+      document.addEventListener("pointerup", finish);
+      document.addEventListener("pointercancel", finish);
+    },
+    [dividerRef, computeClamped],
+  );
+
+  const onDividerKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (disabledRef.current) return;
+      const step = e.shiftKey ? 100 : 10;
+      const horz = directionRef.current === "horizontal";
+      let sign = 0;
+      if (horz) {
+        if (e.key === "ArrowRight") sign = 1;
+        else if (e.key === "ArrowLeft") sign = -1;
+        if (rtlRef.current) sign = -sign;
+      } else {
+        if (e.key === "ArrowDown") sign = 1;
+        else if (e.key === "ArrowUp") sign = -1;
+      }
+      if (sign !== 0) {
+        e.preventDefault();
+        const next = clamp(
+          sizePxRef.current + sign * step,
+          minPxRef.current,
+          maxPxRef.current,
+        );
+        commitSizeRef.current(next);
+        return;
+      }
+      if (e.key === "Home") {
+        e.preventDefault();
+        commitSizeRef.current(minPxRef.current);
+        return;
+      }
+      if (e.key === "End") {
+        e.preventDefault();
+        commitSizeRef.current(maxPxRef.current);
+        return;
+      }
+      if (e.key === "Enter" || e.key === " ") {
+        if (collapsibleRef.current === "none") return;
+        e.preventDefault();
+        const which: "start" | "end" =
+          collapsibleRef.current === "both"
+            ? sizePxRef.current < containerPxRef.current / 2
+              ? "start"
+              : "end"
+            : collapsibleRef.current;
+        toggleCollapseRef.current(which);
+        return;
+      }
+      if (e.key === "Escape" && dragRef.current) {
+        e.preventDefault();
+        const start = dragRef.current.startSize;
+        commitSizeRef.current(start);
+        dragRef.current = null;
+        setIsDragging(false);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = 0;
+      }
+    };
+  }, []);
+
+  return { onDividerPointerDown, onDividerKeyDown, isDragging };
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,6 +10,7 @@ export * from "./PathInput";
 export * from "./PipelineGraph";
 export * from "./Popover";
 export * from "./Select";
+export * from "./SplitPane";
 export * from "./Stepper";
 export * from "./Toast";
 export * from "./Tooltip";


### PR DESCRIPTION
## Summary
- SplitPane 컴포넌트 전체 구현 (#336~#355)
- 데모 페이지 추가
- Plan: docs/plans/017-splitpane-component.md

## Test plan
- [x] npx tsc --noEmit 통과
- [x] npm run build 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)