### PR TITLE
feat(Accordion): 컴포넌트 + 데모 추가 (#429-#441)

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -13,8 +13,9 @@ import CommandPalettePage from "./pages/CommandPalettePage";
 import HexViewPage from "./pages/HexViewPage";
 import { PipelineGraphPage } from "./pages/PipelineGraphPage";
 import SelectPage from "./pages/SelectPage";
+import AccordionPage from "./pages/AccordionPage";
 
-type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select";
+type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select" | "accordion";
 
 interface SubItem { label: string; id: string }
 
@@ -183,6 +184,15 @@ const NAV: { id: Page; label: string; description: string; sections: SubItem[] }
     { label: "Props", id: "props" },
     { label: "Usage", id: "usage" },
     { label: "Playground", id: "playground" },
+  ]},
+  { id: "accordion", label: "Accordion", description: "접고 펼치는 패널 그룹", sections: [
+    { label: "Basic", id: "basic" },
+    { label: "Multiple", id: "multiple" },
+    { label: "Disabled", id: "disabled" },
+    { label: "Controlled", id: "controlled" },
+    { label: "Dark Theme", id: "dark" },
+    { label: "Props", id: "props" },
+    { label: "Usage", id: "usage" },
   ]},
   { id: "dialog", label: "Dialog", description: "모달 다이얼로그", sections: [
     { label: "Basic", id: "basic" },
@@ -436,6 +446,7 @@ export function App() {
         {current === "hexview" && <HexViewPage />}
         {current === "pipelinegraph" && <PipelineGraphPage />}
         {current === "select" && <SelectPage />}
+        {current === "accordion" && <AccordionPage />}
       </main>
     </div>
   );

--- a/demo/src/pages/AccordionPage.tsx
+++ b/demo/src/pages/AccordionPage.tsx
@@ -1,0 +1,344 @@
+import { useState, type ReactNode } from "react";
+import { Accordion, CodeView } from "plastic";
+
+function Section({
+  id,
+  title,
+  desc,
+  children,
+}: {
+  id?: string;
+  title: string;
+  desc?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} className="mb-10">
+      <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-2">
+        {title}
+      </p>
+      {desc && <p className="text-sm text-gray-500 mb-3">{desc}</p>}
+      {children}
+    </section>
+  );
+}
+
+function Card({ children }: { children: ReactNode }) {
+  return (
+    <div className="p-6 bg-white rounded-lg border border-gray-200">
+      {children}
+    </div>
+  );
+}
+
+function DarkCard({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="p-6 rounded-lg border"
+      style={{ background: "#0b0c10", borderColor: "#23262d" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+const FAQ: { q: string; a: string }[] = [
+  {
+    q: "What is plastic?",
+    a: "A runtime-zero, headless React component library focused on accessible primitives.",
+  },
+  {
+    q: "How is theming handled?",
+    a: "Each component exposes light/dark palettes injected as CSS custom properties on the root element.",
+  },
+  {
+    q: "Can I bring my own styles?",
+    a: "Yes — every Accordion subcomponent accepts className and style props for full customization.",
+  },
+];
+
+function BasicSection() {
+  return (
+    <Card>
+      <Accordion.Root type="single" collapsible defaultValue="item-1">
+        {FAQ.map((it, i) => (
+          <Accordion.Item key={i} value={`item-${i + 1}`}>
+            <Accordion.Header>
+              <Accordion.Trigger>{it.q}</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Content>
+              <p className="text-sm text-gray-600 px-4 pb-3">{it.a}</p>
+            </Accordion.Content>
+          </Accordion.Item>
+        ))}
+      </Accordion.Root>
+    </Card>
+  );
+}
+
+function MultipleSection() {
+  return (
+    <Card>
+      <Accordion.Root
+        type="multiple"
+        defaultValue={["item-1", "item-3"]}
+      >
+        {FAQ.map((it, i) => (
+          <Accordion.Item key={i} value={`item-${i + 1}`}>
+            <Accordion.Header>
+              <Accordion.Trigger>{it.q}</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Content>
+              <p className="text-sm text-gray-600 px-4 pb-3">{it.a}</p>
+            </Accordion.Content>
+          </Accordion.Item>
+        ))}
+      </Accordion.Root>
+    </Card>
+  );
+}
+
+function DisabledSection() {
+  return (
+    <Card>
+      <Accordion.Root type="single" collapsible defaultValue="enabled-1">
+        <Accordion.Item value="enabled-1">
+          <Accordion.Header>
+            <Accordion.Trigger>Enabled item</Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content>
+            <p className="text-sm text-gray-600 px-4 pb-3">
+              This item can be toggled normally.
+            </p>
+          </Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="disabled-1" disabled>
+          <Accordion.Header>
+            <Accordion.Trigger>Disabled item</Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content>
+            <p className="text-sm text-gray-600 px-4 pb-3">
+              This panel cannot be opened.
+            </p>
+          </Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item value="enabled-2">
+          <Accordion.Header>
+            <Accordion.Trigger>Another enabled item</Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content>
+            <p className="text-sm text-gray-600 px-4 pb-3">
+              Tab/Arrow navigation skips disabled items by default.
+            </p>
+          </Accordion.Content>
+        </Accordion.Item>
+      </Accordion.Root>
+    </Card>
+  );
+}
+
+function ControlledSection() {
+  const [value, setValue] = useState<string | null>("item-1");
+  return (
+    <Card>
+      <div className="flex items-center gap-2 mb-3 text-xs text-gray-500">
+        <span>open:</span>
+        <code className="px-1.5 py-0.5 bg-gray-100 rounded">
+          {value ?? "null"}
+        </code>
+      </div>
+      <Accordion.Root
+        type="single"
+        collapsible
+        value={value}
+        onValueChange={setValue}
+      >
+        {FAQ.map((it, i) => (
+          <Accordion.Item key={i} value={`item-${i + 1}`}>
+            <Accordion.Header>
+              <Accordion.Trigger>{it.q}</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Content>
+              <p className="text-sm text-gray-600 px-4 pb-3">{it.a}</p>
+            </Accordion.Content>
+          </Accordion.Item>
+        ))}
+      </Accordion.Root>
+    </Card>
+  );
+}
+
+function DarkSection() {
+  return (
+    <DarkCard>
+      <Accordion.Root
+        type="single"
+        collapsible
+        defaultValue="item-1"
+        theme="dark"
+      >
+        {FAQ.map((it, i) => (
+          <Accordion.Item key={i} value={`item-${i + 1}`}>
+            <Accordion.Header>
+              <Accordion.Trigger>{it.q}</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Content>
+              <p
+                className="text-sm px-4 pb-3"
+                style={{ color: "#9ba3af" }}
+              >
+                {it.a}
+              </p>
+            </Accordion.Content>
+          </Accordion.Item>
+        ))}
+      </Accordion.Root>
+    </DarkCard>
+  );
+}
+
+function PropsSection() {
+  return (
+    <Card>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-xs text-gray-400 uppercase">
+            <th className="py-2 pr-4">Prop</th>
+            <th className="py-2 pr-4">Type</th>
+            <th className="py-2 pr-4">Default</th>
+            <th className="py-2">Notes</th>
+          </tr>
+        </thead>
+        <tbody className="text-gray-700">
+          <tr className="border-t border-gray-100">
+            <td className="py-2 pr-4 font-mono">type</td>
+            <td className="py-2 pr-4 font-mono">"single" | "multiple"</td>
+            <td className="py-2 pr-4 font-mono">"single"</td>
+            <td className="py-2">Single allows one open item; multiple allows many.</td>
+          </tr>
+          <tr className="border-t border-gray-100">
+            <td className="py-2 pr-4 font-mono">collapsible</td>
+            <td className="py-2 pr-4 font-mono">boolean</td>
+            <td className="py-2 pr-4 font-mono">false</td>
+            <td className="py-2">single 모드에서만; 열린 항목 재클릭 시 닫힘.</td>
+          </tr>
+          <tr className="border-t border-gray-100">
+            <td className="py-2 pr-4 font-mono">value / defaultValue</td>
+            <td className="py-2 pr-4 font-mono">string | string[] | null</td>
+            <td className="py-2 pr-4">—</td>
+            <td className="py-2">Controlled / uncontrolled selected value(s).</td>
+          </tr>
+          <tr className="border-t border-gray-100">
+            <td className="py-2 pr-4 font-mono">disabled</td>
+            <td className="py-2 pr-4 font-mono">boolean</td>
+            <td className="py-2 pr-4 font-mono">false</td>
+            <td className="py-2">Root 또는 Item 별로 비활성화.</td>
+          </tr>
+          <tr className="border-t border-gray-100">
+            <td className="py-2 pr-4 font-mono">disabledFocus</td>
+            <td className="py-2 pr-4 font-mono">"skip" | "stay"</td>
+            <td className="py-2 pr-4 font-mono">"skip"</td>
+            <td className="py-2">키보드 포커스 시 disabled 항목 건너뛰기 여부.</td>
+          </tr>
+          <tr className="border-t border-gray-100">
+            <td className="py-2 pr-4 font-mono">theme</td>
+            <td className="py-2 pr-4 font-mono">"light" | "dark"</td>
+            <td className="py-2 pr-4 font-mono">"light"</td>
+            <td className="py-2">CSS 변수 팔레트 토글.</td>
+          </tr>
+        </tbody>
+      </table>
+    </Card>
+  );
+}
+
+const USAGE_BASIC = `import { Accordion } from "plastic";
+
+<Accordion.Root type="single" collapsible defaultValue="a">
+  <Accordion.Item value="a">
+    <Accordion.Header>
+      <Accordion.Trigger>Question A</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>Answer A</Accordion.Content>
+  </Accordion.Item>
+</Accordion.Root>`;
+
+const USAGE_MULTIPLE = `<Accordion.Root type="multiple" defaultValue={["a", "b"]}>
+  {/* multiple panels can be open simultaneously */}
+</Accordion.Root>`;
+
+const USAGE_CONTROLLED = `const [value, setValue] = useState<string | null>("a");
+
+<Accordion.Root
+  type="single"
+  collapsible
+  value={value}
+  onValueChange={setValue}
+>
+  {/* ... */}
+</Accordion.Root>`;
+
+function UsageSection() {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <p className="text-xs text-gray-500 mb-2">Basic</p>
+        <CodeView code={USAGE_BASIC} language="tsx" showLineNumbers={false} />
+      </Card>
+      <Card>
+        <p className="text-xs text-gray-500 mb-2">Multiple</p>
+        <CodeView code={USAGE_MULTIPLE} language="tsx" showLineNumbers={false} />
+      </Card>
+      <Card>
+        <p className="text-xs text-gray-500 mb-2">Controlled</p>
+        <CodeView
+          code={USAGE_CONTROLLED}
+          language="tsx"
+          showLineNumbers={false}
+        />
+      </Card>
+    </div>
+  );
+}
+
+export default function AccordionPage() {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <header className="mb-10">
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">Accordion</h1>
+        <p className="text-sm text-gray-500">
+          접고 펼치는 패널 그룹. single/multiple, collapsible, controlled,
+          키보드 내비게이션, dark theme 지원.
+        </p>
+      </header>
+
+      <Section id="basic" title="Basic" desc="single + collapsible. 한 번에 하나만 열림.">
+        <BasicSection />
+      </Section>
+
+      <Section id="multiple" title="Multiple" desc="여러 항목을 동시에 열 수 있음.">
+        <MultipleSection />
+      </Section>
+
+      <Section id="disabled" title="Disabled" desc="Item 단위로 비활성화. 키보드는 기본적으로 건너뜀.">
+        <DisabledSection />
+      </Section>
+
+      <Section id="controlled" title="Controlled" desc="value/onValueChange로 외부 상태 제어.">
+        <ControlledSection />
+      </Section>
+
+      <Section id="dark" title="Dark Theme">
+        <DarkSection />
+      </Section>
+
+      <Section id="props" title="Props">
+        <PropsSection />
+      </Section>
+
+      <Section id="usage" title="Usage">
+        <UsageSection />
+      </Section>
+    </div>
+  );
+}

--- a/src/components/Accordion/Accordion.css.ts
+++ b/src/components/Accordion/Accordion.css.ts
@@ -1,0 +1,98 @@
+export const ACCORDION_CSS = `
+.acc-root {
+  background: var(--acc-root-bg);
+  border-top: 1px solid var(--acc-item-border);
+  border-bottom: 1px solid var(--acc-item-border);
+}
+.acc-item {
+  background: var(--acc-item-bg);
+  border-bottom: 1px solid var(--acc-item-border);
+}
+.acc-item:last-child {
+  border-bottom: none;
+}
+.acc-header {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  font-weight: 500;
+}
+.acc-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 16px;
+  background: var(--acc-header-bg);
+  color: var(--acc-trigger-fg);
+  border: 0;
+  outline: none;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition: background 120ms ease;
+  touch-action: manipulation;
+}
+.acc-trigger:hover:not([disabled]) {
+  background: var(--acc-header-bg-hover);
+}
+.acc-trigger[data-state="open"]:not([disabled]) {
+  background: var(--acc-header-bg-active);
+}
+.acc-trigger:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--acc-focus-ring);
+}
+.acc-trigger[disabled],
+.acc-trigger[aria-disabled="true"] {
+  color: var(--acc-trigger-fg-disabled);
+  cursor: not-allowed;
+}
+.acc-trigger-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.acc-chevron {
+  flex-shrink: 0;
+  color: var(--acc-chevron-fg);
+  transition: transform 180ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.acc-trigger[data-state="open"] .acc-chevron {
+  transform: rotate(180deg);
+}
+.acc-content {
+  overflow: hidden;
+  background: var(--acc-content-bg);
+  color: var(--acc-content-fg);
+  contain: layout paint;
+}
+.acc-content-inner {
+  padding: 12px 16px 16px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .acc-chevron,
+  .acc-content {
+    transition: none !important;
+  }
+}
+`;
+
+let injected = false;
+
+export function injectAccordionStyles(): void {
+  if (injected) return;
+  if (typeof document === "undefined") return;
+  const styleId = "plastic-accordion-styles";
+  if (document.getElementById(styleId)) {
+    injected = true;
+    return;
+  }
+  const styleEl = document.createElement("style");
+  styleEl.id = styleId;
+  styleEl.textContent = ACCORDION_CSS;
+  document.head.appendChild(styleEl);
+  injected = true;
+}

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,17 +1,32 @@
 import {
+  createElement,
   useCallback,
+  useEffect,
+  useId,
   useMemo,
   useRef,
   type CSSProperties,
+  type MouseEvent,
 } from "react";
 import { useReducedMotion } from "../_shared/useReducedMotion";
+import { injectAccordionStyles } from "./Accordion.css";
 import {
+  AccordionItemContext,
   AccordionRootContext,
+  useAccordionItemContext,
+  useAccordionRootContext,
+  type AccordionItemContextValue,
   type AccordionRootContextValue,
   type AccordionTriggerEntry,
 } from "./AccordionContext";
 import { paletteToCssVars } from "./theme";
-import type { AccordionRootProps } from "./Accordion.types";
+import type {
+  AccordionContentProps,
+  AccordionHeaderProps,
+  AccordionItemProps,
+  AccordionRootProps,
+  AccordionTriggerProps,
+} from "./Accordion.types";
 import { useAccordionState } from "./useAccordionState";
 
 function AccordionRoot(props: AccordionRootProps) {
@@ -24,6 +39,7 @@ function AccordionRoot(props: AccordionRootProps) {
     children,
   } = props;
 
+  injectAccordionStyles();
   const state = useAccordionState(props);
   const reducedMotion = useReducedMotion();
 
@@ -124,12 +140,154 @@ function AccordionRoot(props: AccordionRootProps) {
 }
 AccordionRoot.displayName = "Accordion.Root";
 
-const Noop = () => null;
+function AccordionItem(props: AccordionItemProps) {
+  const { value, disabled: itemDisabled = false, className, style, children } =
+    props;
+  const root = useAccordionRootContext();
+  const itemId = useId();
+  const triggerId = `${itemId}-trigger`;
+  const contentId = `${itemId}-content`;
+
+  const isOpen =
+    root.type === "multiple"
+      ? Array.isArray(root.value) && root.value.includes(value)
+      : root.value === value;
+  const isDisabled = root.disabled || itemDisabled;
+
+  const ctx = useMemo<AccordionItemContextValue>(
+    () => ({
+      value,
+      itemId,
+      triggerId,
+      contentId,
+      isOpen,
+      isDisabled,
+    }),
+    [value, itemId, triggerId, contentId, isOpen, isDisabled],
+  );
+
+  const itemClass = ["acc-item", className].filter(Boolean).join(" ");
+
+  return (
+    <AccordionItemContext.Provider value={ctx}>
+      <div
+        className={itemClass}
+        data-state={isOpen ? "open" : "closed"}
+        {...(isDisabled ? { "data-disabled": "true" } : {})}
+        style={style}
+      >
+        {children}
+      </div>
+    </AccordionItemContext.Provider>
+  );
+}
+AccordionItem.displayName = "Accordion.Item";
+
+function AccordionHeader(props: AccordionHeaderProps) {
+  const { as = "h3", className, style, children } = props;
+  const cls = ["acc-header", className].filter(Boolean).join(" ");
+  return createElement(
+    as,
+    { className: cls, style },
+    children,
+  );
+}
+AccordionHeader.displayName = "Accordion.Header";
+
+function Chevron() {
+  return (
+    <svg
+      className="acc-chevron"
+      aria-hidden="true"
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+    >
+      <path
+        d="M3 4.5 L6 7.5 L9 4.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function AccordionTrigger(props: AccordionTriggerProps) {
+  const { children, className, style, onClick, hideChevron, ...rest } = props;
+  const root = useAccordionRootContext();
+  const item = useAccordionItemContext();
+  const ref = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    root.registerTrigger(item.value, ref.current, item.isDisabled);
+    return () => root.registerTrigger(item.value, null, false);
+  }, [root, item.value, item.isDisabled]);
+
+  const cls = ["acc-trigger", className].filter(Boolean).join(" ");
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (item.isDisabled) return;
+    root.toggle(item.value);
+    onClick?.(e);
+  };
+
+  const tabIndex =
+    item.isDisabled && root.disabledFocus === "skip" ? -1 : undefined;
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      id={item.triggerId}
+      aria-expanded={item.isOpen}
+      aria-controls={item.contentId}
+      {...(item.isDisabled ? { "aria-disabled": true } : {})}
+      {...(item.isDisabled ? { disabled: true } : {})}
+      {...(tabIndex !== undefined ? { tabIndex } : {})}
+      data-state={item.isOpen ? "open" : "closed"}
+      className={cls}
+      style={style}
+      onClick={handleClick}
+      {...rest}
+    >
+      <span className="acc-trigger-label">{children}</span>
+      {!hideChevron && <Chevron />}
+    </button>
+  );
+}
+AccordionTrigger.displayName = "Accordion.Trigger";
+
+function AccordionContent(props: AccordionContentProps) {
+  const { children, className, style, forceMount, ...rest } = props;
+  const item = useAccordionItemContext();
+  const cls = ["acc-content", className].filter(Boolean).join(" ");
+
+  if (!item.isOpen && !forceMount) return null;
+
+  return (
+    <div
+      role="region"
+      id={item.contentId}
+      aria-labelledby={item.triggerId}
+      data-state={item.isOpen ? "open" : "closed"}
+      className={cls}
+      style={style}
+      {...(!item.isOpen ? { hidden: true } : {})}
+      {...rest}
+    >
+      <div className="acc-content-inner">{children}</div>
+    </div>
+  );
+}
+AccordionContent.displayName = "Accordion.Content";
 
 export const Accordion = {
   Root: AccordionRoot,
-  Item: Noop,
-  Header: Noop,
-  Trigger: Noop,
-  Content: Noop,
+  Item: AccordionItem,
+  Header: AccordionHeader,
+  Trigger: AccordionTrigger,
+  Content: AccordionContent,
 };

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type KeyboardEvent,
   type MouseEvent,
 } from "react";
 import { useContentHeight } from "./useContentHeight";
@@ -218,7 +219,8 @@ function Chevron() {
 }
 
 function AccordionTrigger(props: AccordionTriggerProps) {
-  const { children, className, style, onClick, hideChevron, ...rest } = props;
+  const { children, className, style, onClick, onKeyDown, hideChevron, ...rest } =
+    props;
   const root = useAccordionRootContext();
   const item = useAccordionItemContext();
   const ref = useRef<HTMLButtonElement>(null);
@@ -234,6 +236,38 @@ function AccordionTrigger(props: AccordionTriggerProps) {
     if (item.isDisabled) return;
     root.toggle(item.value);
     onClick?.(e);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    const all = root.getTriggers();
+    const candidates =
+      root.disabledFocus === "skip" ? all.filter((t) => !t.disabled) : all;
+    const idx = candidates.findIndex((t) => t.id === item.value);
+
+    const moveTo = (targetIdx: number) => {
+      if (candidates.length === 0) return;
+      const safeIdx =
+        ((targetIdx % candidates.length) + candidates.length) %
+        candidates.length;
+      const target = candidates[safeIdx];
+      if (target) root.focusTrigger(target.id);
+    };
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      moveTo(idx + 1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      moveTo(idx - 1);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      moveTo(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      moveTo(candidates.length - 1);
+    }
+
+    onKeyDown?.(e);
   };
 
   const tabIndex =
@@ -253,6 +287,7 @@ function AccordionTrigger(props: AccordionTriggerProps) {
       className={cls}
       style={style}
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
       {...rest}
     >
       <span className="acc-trigger-label">{children}</span>

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,0 +1,9 @@
+const Noop = () => null;
+
+export const Accordion = {
+  Root: Noop,
+  Item: Noop,
+  Header: Noop,
+  Trigger: Noop,
+  Content: Noop,
+};

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -5,9 +5,11 @@ import {
   useId,
   useMemo,
   useRef,
+  useState,
   type CSSProperties,
   type MouseEvent,
 } from "react";
+import { useContentHeight } from "./useContentHeight";
 import { useReducedMotion } from "../_shared/useReducedMotion";
 import { injectAccordionStyles } from "./Accordion.css";
 import {
@@ -262,23 +264,76 @@ AccordionTrigger.displayName = "Accordion.Trigger";
 
 function AccordionContent(props: AccordionContentProps) {
   const { children, className, style, forceMount, ...rest } = props;
+  const root = useAccordionRootContext();
   const item = useAccordionItemContext();
-  const cls = ["acc-content", className].filter(Boolean).join(" ");
+  const outerRef = useRef<HTMLDivElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
+  const contentHeight = useContentHeight(innerRef);
 
-  if (!item.isOpen && !forceMount) return null;
+  const isOpen = item.isOpen;
+  const [hiddenAttr, setHiddenAttr] = useState<boolean>(!isOpen);
+
+  useEffect(() => {
+    if (isOpen) {
+      setHiddenAttr(false);
+      return;
+    }
+    if (root.reducedMotion) {
+      setHiddenAttr(true);
+      return;
+    }
+    const el = outerRef.current;
+    if (!el) {
+      setHiddenAttr(true);
+      return;
+    }
+    const onEnd = (e: TransitionEvent) => {
+      if (e.propertyName !== "max-height") return;
+      if (el.getAttribute("data-state") !== "closed") return;
+      setHiddenAttr(true);
+    };
+    el.addEventListener("transitionend", onEnd);
+    return () => el.removeEventListener("transitionend", onEnd);
+  }, [isOpen, root.reducedMotion]);
+
+  if (!isOpen && !forceMount && hiddenAttr) return null;
+
+  const measuredMaxHeight =
+    contentHeight == null ? undefined : `${contentHeight}px`;
+
+  const baseStyle: CSSProperties = {
+    overflow: "hidden",
+    maxHeight: root.reducedMotion
+      ? isOpen
+        ? "none"
+        : 0
+      : isOpen
+        ? measuredMaxHeight ?? "none"
+        : 0,
+    transition: root.reducedMotion
+      ? "none"
+      : "max-height 200ms cubic-bezier(0.4, 0, 0.2, 1)",
+  };
+
+  const mergedStyle: CSSProperties = { ...baseStyle, ...style };
+
+  const cls = ["acc-content", className].filter(Boolean).join(" ");
 
   return (
     <div
+      ref={outerRef}
       role="region"
       id={item.contentId}
       aria-labelledby={item.triggerId}
-      data-state={item.isOpen ? "open" : "closed"}
+      data-state={isOpen ? "open" : "closed"}
       className={cls}
-      style={style}
-      {...(!item.isOpen ? { hidden: true } : {})}
+      style={mergedStyle}
+      {...(!isOpen && hiddenAttr ? { hidden: true } : {})}
       {...rest}
     >
-      <div className="acc-content-inner">{children}</div>
+      <div ref={innerRef} className="acc-content-inner">
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,7 +1,133 @@
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  type CSSProperties,
+} from "react";
+import { useReducedMotion } from "../_shared/useReducedMotion";
+import {
+  AccordionRootContext,
+  type AccordionRootContextValue,
+  type AccordionTriggerEntry,
+} from "./AccordionContext";
+import { paletteToCssVars } from "./theme";
+import type { AccordionRootProps } from "./Accordion.types";
+import { useAccordionState } from "./useAccordionState";
+
+function AccordionRoot(props: AccordionRootProps) {
+  const {
+    disabled = false,
+    disabledFocus = "skip",
+    theme = "light",
+    className,
+    style,
+    children,
+  } = props;
+
+  const state = useAccordionState(props);
+  const reducedMotion = useReducedMotion();
+
+  const triggersRef = useRef<
+    Map<string, { el: HTMLButtonElement | null; disabled: boolean }>
+  >(new Map());
+  const orderRef = useRef<string[]>([]);
+
+  const registerTrigger = useCallback(
+    (id: string, el: HTMLButtonElement | null, triggerDisabled: boolean) => {
+      const map = triggersRef.current;
+      if (el === null) {
+        map.delete(id);
+        orderRef.current = orderRef.current.filter((x) => x !== id);
+        return;
+      }
+      map.set(id, { el, disabled: triggerDisabled });
+      if (!orderRef.current.includes(id)) {
+        orderRef.current.push(id);
+      }
+    },
+    [],
+  );
+
+  const getTriggers = useCallback((): AccordionTriggerEntry[] => {
+    const map = triggersRef.current;
+    const entries: AccordionTriggerEntry[] = [];
+    for (const id of orderRef.current) {
+      const v = map.get(id);
+      if (!v) continue;
+      entries.push({ id, el: v.el, disabled: v.disabled });
+    }
+    if (entries.length < 2) return entries;
+    return [...entries].sort((a, b) => {
+      const ea = a.el;
+      const eb = b.el;
+      if (!ea || !eb || ea === eb) return 0;
+      const pos = ea.compareDocumentPosition(eb);
+      if (pos & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+      if (pos & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+      return 0;
+    });
+  }, []);
+
+  const focusTrigger = useCallback((id: string) => {
+    const v = triggersRef.current.get(id);
+    v?.el?.focus();
+  }, []);
+
+  const ctxValue = useMemo<AccordionRootContextValue>(
+    () => ({
+      type: state.type,
+      value: state.value,
+      toggle: state.toggle,
+      collapsible: state.collapsible,
+      disabled,
+      disabledFocus,
+      theme,
+      reducedMotion,
+      registerTrigger,
+      focusTrigger,
+      getTriggers,
+    }),
+    [
+      state.type,
+      state.value,
+      state.toggle,
+      state.collapsible,
+      disabled,
+      disabledFocus,
+      theme,
+      reducedMotion,
+      registerTrigger,
+      focusTrigger,
+      getTriggers,
+    ],
+  );
+
+  const mergedStyle: CSSProperties = {
+    ...(paletteToCssVars(theme) as CSSProperties),
+    ...style,
+  };
+
+  const rootClass = ["acc-root", className].filter(Boolean).join(" ");
+
+  return (
+    <AccordionRootContext.Provider value={ctxValue}>
+      <div
+        className={rootClass}
+        data-theme={theme}
+        {...(disabled ? { "data-disabled": "true" } : {})}
+        style={mergedStyle}
+      >
+        {children}
+      </div>
+    </AccordionRootContext.Provider>
+  );
+}
+AccordionRoot.displayName = "Accordion.Root";
+
 const Noop = () => null;
 
 export const Accordion = {
-  Root: Noop,
+  Root: AccordionRoot,
   Item: Noop,
   Header: Noop,
   Trigger: Noop,

--- a/src/components/Accordion/Accordion.types.ts
+++ b/src/components/Accordion/Accordion.types.ts
@@ -1,0 +1,72 @@
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+
+export type AccordionTheme = "light" | "dark";
+
+export type AccordionType = "single" | "multiple";
+
+export type AccordionDisabledFocus = "skip" | "stay";
+
+interface AccordionRootCommonProps {
+  disabled?: boolean;
+  disabledFocus?: AccordionDisabledFocus;
+  theme?: AccordionTheme;
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}
+
+export interface AccordionRootPropsSingle extends AccordionRootCommonProps {
+  type?: "single";
+  value?: string | null;
+  defaultValue?: string | null;
+  onValueChange?: (next: string | null) => void;
+  collapsible?: boolean;
+}
+
+export interface AccordionRootPropsMultiple extends AccordionRootCommonProps {
+  type: "multiple";
+  value?: string[];
+  defaultValue?: string[];
+  onValueChange?: (next: string[]) => void;
+  collapsible?: never;
+}
+
+export type AccordionRootProps =
+  | AccordionRootPropsSingle
+  | AccordionRootPropsMultiple;
+
+export interface AccordionItemProps {
+  value: string;
+  disabled?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}
+
+export type AccordionHeadingTag =
+  | "h1"
+  | "h2"
+  | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
+  | "div";
+
+export interface AccordionHeaderProps {
+  as?: AccordionHeadingTag;
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}
+
+export interface AccordionTriggerProps
+  extends Omit<HTMLAttributes<HTMLButtonElement>, "children"> {
+  children: ReactNode;
+  hideChevron?: boolean;
+}
+
+export interface AccordionContentProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  children: ReactNode;
+  forceMount?: boolean;
+}

--- a/src/components/Accordion/AccordionContext.ts
+++ b/src/components/Accordion/AccordionContext.ts
@@ -1,0 +1,65 @@
+import { createContext, useContext } from "react";
+import type {
+  AccordionDisabledFocus,
+  AccordionTheme,
+  AccordionType,
+} from "./Accordion.types";
+
+export interface AccordionTriggerEntry {
+  id: string;
+  el: HTMLButtonElement | null;
+  disabled: boolean;
+}
+
+export interface AccordionRootContextValue {
+  type: AccordionType;
+  value: string | string[] | null;
+  toggle: (v: string) => void;
+  collapsible: boolean;
+  disabled: boolean;
+  disabledFocus: AccordionDisabledFocus;
+  theme: AccordionTheme;
+  reducedMotion: boolean;
+  registerTrigger: (
+    id: string,
+    el: HTMLButtonElement | null,
+    disabled: boolean,
+  ) => void;
+  focusTrigger: (id: string) => void;
+  getTriggers: () => AccordionTriggerEntry[];
+}
+
+export const AccordionRootContext =
+  createContext<AccordionRootContextValue | null>(null);
+
+export function useAccordionRootContext(): AccordionRootContextValue {
+  const ctx = useContext(AccordionRootContext);
+  if (ctx === null) {
+    throw new Error(
+      "Accordion sub-components must be used within <Accordion.Root>",
+    );
+  }
+  return ctx;
+}
+
+export interface AccordionItemContextValue {
+  value: string;
+  itemId: string;
+  triggerId: string;
+  contentId: string;
+  isOpen: boolean;
+  isDisabled: boolean;
+}
+
+export const AccordionItemContext =
+  createContext<AccordionItemContextValue | null>(null);
+
+export function useAccordionItemContext(): AccordionItemContextValue {
+  const ctx = useContext(AccordionItemContext);
+  if (ctx === null) {
+    throw new Error(
+      "Accordion.Trigger/Content must be used within <Accordion.Item>",
+    );
+  }
+  return ctx;
+}

--- a/src/components/Accordion/index.ts
+++ b/src/components/Accordion/index.ts
@@ -1,0 +1,14 @@
+export { Accordion } from "./Accordion";
+export type {
+  AccordionTheme,
+  AccordionType,
+  AccordionDisabledFocus,
+  AccordionRootProps,
+  AccordionRootPropsSingle,
+  AccordionRootPropsMultiple,
+  AccordionItemProps,
+  AccordionHeaderProps,
+  AccordionHeadingTag,
+  AccordionTriggerProps,
+  AccordionContentProps,
+} from "./Accordion.types";

--- a/src/components/Accordion/theme.ts
+++ b/src/components/Accordion/theme.ts
@@ -1,0 +1,65 @@
+import type { AccordionTheme } from "./Accordion.types";
+
+export interface AccordionPaletteTokens {
+  rootBg: string;
+  itemBg: string;
+  itemBorder: string;
+  headerBg: string;
+  headerBgHover: string;
+  headerBgActive: string;
+  triggerFg: string;
+  triggerFgDisabled: string;
+  chevronFg: string;
+  contentBg: string;
+  contentFg: string;
+  focusRing: string;
+}
+
+export const accordionPalette: Record<AccordionTheme, AccordionPaletteTokens> = {
+  light: {
+    rootBg: "transparent",
+    itemBg: "#ffffff",
+    itemBorder: "rgba(0,0,0,0.08)",
+    headerBg: "#ffffff",
+    headerBgHover: "#f8fafc",
+    headerBgActive: "#eef2f7",
+    triggerFg: "#0f172a",
+    triggerFgDisabled: "rgba(15,23,42,0.35)",
+    chevronFg: "rgba(15,23,42,0.55)",
+    contentBg: "#ffffff",
+    contentFg: "#111827",
+    focusRing: "#2563eb",
+  },
+  dark: {
+    rootBg: "transparent",
+    itemBg: "#0f172a",
+    itemBorder: "rgba(255,255,255,0.08)",
+    headerBg: "#0f172a",
+    headerBgHover: "#121a2d",
+    headerBgActive: "#17213b",
+    triggerFg: "#e5e7eb",
+    triggerFgDisabled: "rgba(229,231,235,0.35)",
+    chevronFg: "rgba(229,231,235,0.7)",
+    contentBg: "#0f172a",
+    contentFg: "#cbd5e1",
+    focusRing: "#60a5fa",
+  },
+};
+
+export function paletteToCssVars(theme: AccordionTheme): Record<string, string> {
+  const p = accordionPalette[theme];
+  return {
+    "--acc-root-bg": p.rootBg,
+    "--acc-item-bg": p.itemBg,
+    "--acc-item-border": p.itemBorder,
+    "--acc-header-bg": p.headerBg,
+    "--acc-header-bg-hover": p.headerBgHover,
+    "--acc-header-bg-active": p.headerBgActive,
+    "--acc-trigger-fg": p.triggerFg,
+    "--acc-trigger-fg-disabled": p.triggerFgDisabled,
+    "--acc-chevron-fg": p.chevronFg,
+    "--acc-content-bg": p.contentBg,
+    "--acc-content-fg": p.contentFg,
+    "--acc-focus-ring": p.focusRing,
+  };
+}

--- a/src/components/Accordion/useAccordionState.ts
+++ b/src/components/Accordion/useAccordionState.ts
@@ -1,0 +1,104 @@
+import { useCallback } from "react";
+import { useControllable } from "../_shared/useControllable";
+import type {
+  AccordionRootProps,
+  AccordionRootPropsMultiple,
+  AccordionRootPropsSingle,
+} from "./Accordion.types";
+
+export interface AccordionState {
+  type: "single" | "multiple";
+  value: string | string[] | null;
+  toggle: (v: string) => void;
+  isOpen: (v: string) => boolean;
+  collapsible: boolean;
+}
+
+function isMultiple(
+  props: AccordionRootProps,
+): props is AccordionRootPropsMultiple {
+  return (props as AccordionRootPropsMultiple).type === "multiple";
+}
+
+export function useAccordionState(props: AccordionRootProps): AccordionState {
+  const multi = isMultiple(props);
+  const single = props as AccordionRootPropsSingle;
+  const multiple = props as AccordionRootPropsMultiple;
+
+  const collapsible = !multi ? single.collapsible ?? false : false;
+
+  const singleOnChange = !multi ? single.onValueChange : undefined;
+  const multipleOnChange = multi ? multiple.onValueChange : undefined;
+
+  const handleSingleChange = useCallback(
+    (next: string | null) => {
+      singleOnChange?.(next);
+    },
+    [singleOnChange],
+  );
+
+  const handleMultipleChange = useCallback(
+    (next: string[]) => {
+      multipleOnChange?.(next);
+    },
+    [multipleOnChange],
+  );
+
+  const [singleValue, setSingleValue] = useControllable<string | null>(
+    multi ? undefined : single.value === undefined ? undefined : single.value,
+    multi ? null : single.defaultValue ?? null,
+    handleSingleChange,
+  );
+
+  const [multipleValue, setMultipleValue] = useControllable<string[]>(
+    !multi
+      ? undefined
+      : multiple.value === undefined
+        ? undefined
+        : multiple.value,
+    !multi ? [] : multiple.defaultValue ?? [],
+    handleMultipleChange,
+  );
+
+  const toggle = useCallback(
+    (v: string) => {
+      if (multi) {
+        if (multipleValue.includes(v)) {
+          setMultipleValue(multipleValue.filter((x) => x !== v));
+        } else {
+          setMultipleValue([...multipleValue, v]);
+        }
+        return;
+      }
+      if (singleValue === v) {
+        if (collapsible) setSingleValue(null);
+        return;
+      }
+      setSingleValue(v);
+    },
+    [
+      multi,
+      multipleValue,
+      setMultipleValue,
+      singleValue,
+      setSingleValue,
+      collapsible,
+    ],
+  );
+
+  const isOpen = useCallback(
+    (v: string) => {
+      if (multi) return multipleValue.includes(v);
+      return singleValue === v;
+    },
+    [multi, multipleValue, singleValue],
+  );
+
+  return {
+    type: multi ? "multiple" : "single",
+    value: multi ? multipleValue : singleValue,
+    toggle,
+    isOpen,
+    collapsible,
+  };
+}

--- a/src/components/Accordion/useContentHeight.ts
+++ b/src/components/Accordion/useContentHeight.ts
@@ -1,0 +1,34 @@
+import { useEffect, useLayoutEffect, useState, type RefObject } from "react";
+
+const useIsoLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+export function useContentHeight(
+  ref: RefObject<HTMLDivElement | null>,
+): number | null {
+  const [height, setHeight] = useState<number | null>(null);
+
+  useIsoLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const measure = () => {
+      setHeight(el.scrollHeight);
+    };
+
+    measure();
+
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+
+    const mo = new MutationObserver(measure);
+    mo.observe(el, { childList: true, subtree: true, characterData: true });
+
+    return () => {
+      ro.disconnect();
+      mo.disconnect();
+    };
+  }, [ref]);
+
+  return height;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./Accordion";
 export * from "./Actionable";
 export * from "./Button";
 export * from "./Card";


### PR DESCRIPTION
## Summary
- Accordion 컴파운드 컴포넌트 구현 (Root/Item/Header/Trigger/Content)
- single/multiple, collapsible, controlled/uncontrolled, disabledFocus
- max-height 트랜지션 + reduced-motion 대응, ARIA region/aria-expanded/aria-controls
- 키보드 내비게이션 (ArrowUp/Down/Home/End) + disabled skip
- 데모 페이지 7섹션 (Basic/Multiple/Disabled/Controlled/Dark/Props/Usage) + NAV 라우팅

## Issues
#429-#441

## Test plan
- [ ] `npx tsc --noEmit` 통과 확인
- [ ] `npm run build` 통과 확인
- [ ] 데모 시각 확인 (single/multiple 토글, 키보드, dark theme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)