### PR TITLE
feat(Skeleton): 컴포넌트 + 데모 추가 (#419-#428)

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -13,8 +13,9 @@ import CommandPalettePage from "./pages/CommandPalettePage";
 import HexViewPage from "./pages/HexViewPage";
 import { PipelineGraphPage } from "./pages/PipelineGraphPage";
 import SelectPage from "./pages/SelectPage";
+import SkeletonPage from "./pages/SkeletonPage";
 
-type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select";
+type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select" | "skeleton";
 
 interface SubItem { label: string; id: string }
 
@@ -183,6 +184,20 @@ const NAV: { id: Page; label: string; description: string; sections: SubItem[] }
     { label: "Props", id: "props" },
     { label: "Usage", id: "usage" },
     { label: "Playground", id: "playground" },
+  ]},
+  { id: "skeleton", label: "Skeleton", description: "로딩 플레이스홀더", sections: [
+    { label: "Basic shapes", id: "basic" },
+    { label: "Text multi-line", id: "text" },
+    { label: "Avatar", id: "avatar" },
+    { label: "Card preset", id: "card" },
+    { label: "Table preset", id: "table" },
+    { label: "Pulse vs Shimmer", id: "animation" },
+    { label: "Reduced motion", id: "reduced" },
+    { label: "Dark", id: "dark" },
+    { label: "Swap to real content", id: "swap" },
+    { label: "Playground", id: "playground" },
+    { label: "Props", id: "props" },
+    { label: "Usage", id: "usage" },
   ]},
   { id: "dialog", label: "Dialog", description: "모달 다이얼로그", sections: [
     { label: "Basic", id: "basic" },
@@ -436,6 +451,7 @@ export function App() {
         {current === "hexview" && <HexViewPage />}
         {current === "pipelinegraph" && <PipelineGraphPage />}
         {current === "select" && <SelectPage />}
+        {current === "skeleton" && <SkeletonPage />}
       </main>
     </div>
   );

--- a/demo/src/pages/SkeletonPage.tsx
+++ b/demo/src/pages/SkeletonPage.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { CodeView, Skeleton } from "plastic";
+
+function Section({
+  id,
+  title,
+  desc,
+  children,
+}: {
+  id?: string;
+  title: string;
+  desc?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} className="mb-10">
+      <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-2">
+        {title}
+      </p>
+      {desc && <p className="text-sm text-gray-500 mb-3">{desc}</p>}
+      {children}
+    </section>
+  );
+}
+
+function Card({ children }: { children: ReactNode }) {
+  return (
+    <div className="p-6 bg-white rounded-lg border border-gray-200">
+      {children}
+    </div>
+  );
+}
+
+function DarkCard({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="p-6 rounded-lg border"
+      style={{ background: "#0b0c10", borderColor: "#23262d" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SwapDemo() {
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    const t = setTimeout(() => setLoading(false), 1500);
+    return () => clearTimeout(t);
+  }, [loading]);
+  return (
+    <Card>
+      <div className="flex items-center gap-3 mb-3">
+        <button
+          onClick={() => setLoading(true)}
+          className="px-3 py-1 text-xs rounded bg-gray-100 hover:bg-gray-200"
+        >
+          replay (1.5s)
+        </button>
+        <span className="text-xs text-gray-500">
+          visible={String(loading)}
+        </span>
+      </div>
+      <Skeleton.Card visible={loading} hasMedia hasAvatar lines={3}>
+        <div>
+          <img
+            src="https://placehold.co/400x160/3b82f6/ffffff?text=Loaded"
+            alt=""
+            className="w-full h-40 object-cover rounded"
+          />
+          <div className="flex items-center gap-3 mt-3">
+            <div className="w-10 h-10 rounded-full bg-blue-500" />
+            <div>
+              <p className="text-sm font-semibold">Real Title</p>
+              <p className="text-xs text-gray-500">Loaded content body…</p>
+            </div>
+          </div>
+        </div>
+      </Skeleton.Card>
+    </Card>
+  );
+}
+
+const USAGE_BASIC = `import { Skeleton } from "plastic";
+
+<Skeleton.Root shape="text" width={200} />
+<Skeleton.Root shape="rect" width={160} height={80} />
+<Skeleton.Root shape="circle" size={56} />`;
+
+const USAGE_PRESETS = `<Skeleton.Text lines={3} />
+<Skeleton.Avatar size={48} />
+<Skeleton.Card hasMedia hasAvatar lines={2} />
+<Skeleton.Table rows={5} cols={4} hasHeader />`;
+
+const USAGE_SWAP = `<Skeleton.Card visible={isLoading} hasMedia lines={2}>
+  <RealCard data={data} />
+</Skeleton.Card>`;
+
+export default function SkeletonPage() {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <header className="mb-10">
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">Skeleton</h1>
+        <p className="text-sm text-gray-500">
+          로딩 플레이스홀더. shape 3종 + 프리셋 4종 + shimmer/pulse 애니메이션
+          + prefers-reduced-motion 감지 + visible swap.
+        </p>
+      </header>
+
+      <Section
+        id="basic"
+        title="Basic shapes"
+        desc="Skeleton.Root 원자. shape=text / rect / circle."
+      >
+        <Card>
+          <div className="flex gap-6 items-center">
+            <Skeleton.Root shape="text" width={200} />
+            <Skeleton.Root shape="rect" width={160} height={80} />
+            <Skeleton.Root shape="circle" size={56} />
+          </div>
+        </Card>
+      </Section>
+
+      <Section
+        id="text"
+        title="Text multi-line"
+        desc="lines / lastLineWidth / randomize."
+      >
+        <Card>
+          <div className="space-y-6">
+            <Skeleton.Text lines={3} />
+            <Skeleton.Text lines={4} randomize seed={7} />
+          </div>
+        </Card>
+      </Section>
+
+      <Section id="avatar" title="Avatar" desc="circle / rounded / square 모양.">
+        <Card>
+          <div className="flex items-center gap-6">
+            <Skeleton.Avatar size={32} shape="circle" />
+            <Skeleton.Avatar size={48} shape="rounded" />
+            <Skeleton.Avatar size={64} shape="square" />
+          </div>
+        </Card>
+      </Section>
+
+      <Section id="card" title="Card preset">
+        <Card>
+          <div className="grid grid-cols-2 gap-4">
+            <Skeleton.Card hasMedia hasAvatar lines={3} />
+            <Skeleton.Card hasMedia hasFooter lines={2} />
+          </div>
+        </Card>
+      </Section>
+
+      <Section id="table" title="Table preset">
+        <Card>
+          <Skeleton.Table rows={5} cols={4} hasHeader />
+        </Card>
+      </Section>
+
+      <Section
+        id="animation"
+        title="Pulse vs Shimmer"
+        desc="animation prop으로 스타일 전환."
+      >
+        <Card>
+          <div className="grid grid-cols-3 gap-6">
+            <div>
+              <p className="text-xs text-gray-500 mb-2">shimmer (default)</p>
+              <Skeleton.Root shape="rect" width="100%" height={60} />
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 mb-2">pulse</p>
+              <Skeleton.Root
+                shape="rect"
+                width="100%"
+                height={60}
+                animation="pulse"
+              />
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 mb-2">none</p>
+              <Skeleton.Root
+                shape="rect"
+                width="100%"
+                height={60}
+                animation={false}
+              />
+            </div>
+          </div>
+        </Card>
+      </Section>
+
+      <Section
+        id="dark"
+        title="Dark"
+        desc="theme='dark' — palette는 CSS 변수로 주입."
+      >
+        <DarkCard>
+          <div className="space-y-4">
+            <Skeleton.Text lines={3} theme="dark" />
+            <Skeleton.Card hasMedia hasAvatar lines={2} theme="dark" />
+          </div>
+        </DarkCard>
+      </Section>
+
+      <Section
+        id="swap"
+        title="Swap to real content"
+        desc="visible prop으로 스켈레톤↔실콘텐츠 페이드 전환."
+      >
+        <SwapDemo />
+      </Section>
+
+      <Section id="props" title="Props">
+        <Card>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-gray-400 uppercase">
+                <th className="py-2 pr-4">Prop</th>
+                <th className="py-2 pr-4">Type</th>
+                <th className="py-2">Notes</th>
+              </tr>
+            </thead>
+            <tbody className="text-gray-700">
+              <tr className="border-t border-gray-100">
+                <td className="py-2 pr-4 font-mono">shape</td>
+                <td className="py-2 pr-4 font-mono">"text" | "rect" | "circle"</td>
+                <td className="py-2">Skeleton.Root 모양.</td>
+              </tr>
+              <tr className="border-t border-gray-100">
+                <td className="py-2 pr-4 font-mono">animation</td>
+                <td className="py-2 pr-4 font-mono">"shimmer" | "pulse" | false</td>
+                <td className="py-2">prefers-reduced-motion이 켜져 있으면 자동으로 정적.</td>
+              </tr>
+              <tr className="border-t border-gray-100">
+                <td className="py-2 pr-4 font-mono">visible</td>
+                <td className="py-2 pr-4 font-mono">boolean</td>
+                <td className="py-2">false 시 children으로 fade swap.</td>
+              </tr>
+              <tr className="border-t border-gray-100">
+                <td className="py-2 pr-4 font-mono">fadeMs</td>
+                <td className="py-2 pr-4 font-mono">number</td>
+                <td className="py-2">swap 페이드 지속시간 (default 200).</td>
+              </tr>
+              <tr className="border-t border-gray-100">
+                <td className="py-2 pr-4 font-mono">theme</td>
+                <td className="py-2 pr-4 font-mono">"light" | "dark"</td>
+                <td className="py-2">CSS 변수 팔레트.</td>
+              </tr>
+            </tbody>
+          </table>
+        </Card>
+      </Section>
+
+      <Section id="usage" title="Usage">
+        <div className="space-y-4">
+          <Card>
+            <p className="text-xs text-gray-500 mb-2">Basic shapes</p>
+            <CodeView
+              code={USAGE_BASIC}
+              language="tsx"
+              showLineNumbers={false}
+            />
+          </Card>
+          <Card>
+            <p className="text-xs text-gray-500 mb-2">Presets</p>
+            <CodeView
+              code={USAGE_PRESETS}
+              language="tsx"
+              showLineNumbers={false}
+            />
+          </Card>
+          <Card>
+            <p className="text-xs text-gray-500 mb-2">Swap to real content</p>
+            <CodeView
+              code={USAGE_SWAP}
+              language="tsx"
+              showLineNumbers={false}
+            />
+          </Card>
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -2,13 +2,12 @@ import { SkeletonRoot } from "./SkeletonRoot";
 import { SkeletonText } from "./SkeletonText";
 import { SkeletonAvatar } from "./SkeletonAvatar";
 import { SkeletonCard } from "./SkeletonCard";
-
-const Noop = () => null;
+import { SkeletonTable } from "./SkeletonTable";
 
 export const Skeleton = {
   Root: SkeletonRoot,
   Text: SkeletonText,
   Avatar: SkeletonAvatar,
   Card: SkeletonCard,
-  Table: Noop,
+  Table: SkeletonTable,
 };

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,9 @@
+const Noop = () => null;
+
+export const Skeleton = {
+  Root: Noop,
+  Text: Noop,
+  Avatar: Noop,
+  Card: Noop,
+  Table: Noop,
+};

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,6 +1,7 @@
 import { SkeletonRoot } from "./SkeletonRoot";
 import { SkeletonText } from "./SkeletonText";
 import { SkeletonAvatar } from "./SkeletonAvatar";
+import { SkeletonCard } from "./SkeletonCard";
 
 const Noop = () => null;
 
@@ -8,6 +9,6 @@ export const Skeleton = {
   Root: SkeletonRoot,
   Text: SkeletonText,
   Avatar: SkeletonAvatar,
-  Card: Noop,
+  Card: SkeletonCard,
   Table: Noop,
 };

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,7 +1,9 @@
+import { SkeletonRoot } from "./SkeletonRoot";
+
 const Noop = () => null;
 
 export const Skeleton = {
-  Root: Noop,
+  Root: SkeletonRoot,
   Text: Noop,
   Avatar: Noop,
   Card: Noop,

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,12 +1,13 @@
 import { SkeletonRoot } from "./SkeletonRoot";
 import { SkeletonText } from "./SkeletonText";
+import { SkeletonAvatar } from "./SkeletonAvatar";
 
 const Noop = () => null;
 
 export const Skeleton = {
   Root: SkeletonRoot,
   Text: SkeletonText,
-  Avatar: Noop,
+  Avatar: SkeletonAvatar,
   Card: Noop,
   Table: Noop,
 };

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,10 +1,11 @@
 import { SkeletonRoot } from "./SkeletonRoot";
+import { SkeletonText } from "./SkeletonText";
 
 const Noop = () => null;
 
 export const Skeleton = {
   Root: SkeletonRoot,
-  Text: Noop,
+  Text: SkeletonText,
   Avatar: Noop,
   Card: Noop,
   Table: Noop,

--- a/src/components/Skeleton/Skeleton.types.ts
+++ b/src/components/Skeleton/Skeleton.types.ts
@@ -1,0 +1,90 @@
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+
+export type SkeletonTheme = "light" | "dark";
+
+export type SkeletonShape = "text" | "rect" | "circle";
+
+export type SkeletonAnimation = "shimmer" | "pulse" | false;
+
+export type SkeletonSize = number | string;
+
+export interface SkeletonRootProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  shape?: SkeletonShape | undefined;
+  animation?: SkeletonAnimation | undefined;
+  width?: SkeletonSize | undefined;
+  height?: SkeletonSize | undefined;
+  size?: SkeletonSize | undefined;
+  borderRadius?: SkeletonSize | undefined;
+  theme?: SkeletonTheme | undefined;
+  visible?: boolean | undefined;
+  fadeMs?: number | undefined;
+  children?: ReactNode | undefined;
+  "aria-label"?: string | undefined;
+}
+
+export interface SkeletonTextProps {
+  lines?: number | undefined;
+  lastLineWidth?: SkeletonSize | null | undefined;
+  gap?: number | undefined;
+  randomize?: boolean | undefined;
+  lineHeight?: SkeletonSize | undefined;
+  widthRange?: [number, number] | undefined;
+  seed?: number | undefined;
+  animation?: SkeletonAnimation | undefined;
+  theme?: SkeletonTheme | undefined;
+  visible?: boolean | undefined;
+  fadeMs?: number | undefined;
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  "aria-label"?: string | undefined;
+}
+
+export interface SkeletonAvatarProps {
+  shape?: "circle" | "rounded" | "square" | undefined;
+  size?: SkeletonSize | undefined;
+  animation?: SkeletonAnimation | undefined;
+  theme?: SkeletonTheme | undefined;
+  visible?: boolean | undefined;
+  fadeMs?: number | undefined;
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  "aria-label"?: string | undefined;
+}
+
+export interface SkeletonCardProps {
+  hasMedia?: boolean | undefined;
+  mediaHeight?: SkeletonSize | undefined;
+  hasTitle?: boolean | undefined;
+  lines?: number | undefined;
+  hasFooter?: boolean | undefined;
+  hasAvatar?: boolean | undefined;
+  width?: SkeletonSize | undefined;
+  padding?: number | undefined;
+  animation?: SkeletonAnimation | undefined;
+  theme?: SkeletonTheme | undefined;
+  visible?: boolean | undefined;
+  fadeMs?: number | undefined;
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  "aria-label"?: string | undefined;
+}
+
+export interface SkeletonTableProps {
+  rows?: number | undefined;
+  cols?: number | undefined;
+  hasHeader?: boolean | undefined;
+  rowHeight?: SkeletonSize | undefined;
+  colWidths?: SkeletonSize[] | undefined;
+  animation?: SkeletonAnimation | undefined;
+  theme?: SkeletonTheme | undefined;
+  visible?: boolean | undefined;
+  fadeMs?: number | undefined;
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  "aria-label"?: string | undefined;
+}

--- a/src/components/Skeleton/Skeleton.utils.ts
+++ b/src/components/Skeleton/Skeleton.utils.ts
@@ -1,0 +1,100 @@
+import type {
+  SkeletonAnimation,
+  SkeletonRootProps,
+  SkeletonSize,
+  SkeletonTheme,
+} from "./Skeleton.types";
+
+export function toCssLength(v: SkeletonSize): string {
+  return typeof v === "number" ? `${v}px` : v;
+}
+
+export function resolveDimensions(props: SkeletonRootProps): {
+  width: string;
+  height: string;
+  borderRadius: string;
+} {
+  const shape = props.shape ?? "rect";
+  if (shape === "circle") {
+    const s = props.size ?? 40;
+    const px = toCssLength(s);
+    return {
+      width: px,
+      height: px,
+      borderRadius: toCssLength(props.borderRadius ?? "50%"),
+    };
+  }
+  if (shape === "text") {
+    return {
+      width: toCssLength(props.width ?? "100%"),
+      height: toCssLength(props.height ?? "1em"),
+      borderRadius: toCssLength(props.borderRadius ?? 4),
+    };
+  }
+  return {
+    width: toCssLength(props.width ?? "100%"),
+    height: toCssLength(props.height ?? 16),
+    borderRadius: toCssLength(props.borderRadius ?? 4),
+  };
+}
+
+export function seededRandom(seed: number, index: number): number {
+  let t = (seed + index * 0x6d2b79f5) >>> 0;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+
+export function computeTextLineWidths(
+  lines: number,
+  range: [number, number],
+  lastLineWidth: SkeletonSize | null | undefined,
+  randomize: boolean,
+  seed: number,
+): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < lines; i++) {
+    const isLast = i === lines - 1;
+    if (isLast && lastLineWidth !== null && lastLineWidth !== undefined) {
+      out.push(toCssLength(lastLineWidth));
+      continue;
+    }
+    if (!randomize) {
+      out.push("100%");
+      continue;
+    }
+    const [lo, hi] = range;
+    const pct = lo + (hi - lo) * seededRandom(seed, i);
+    out.push(`${(pct * 100).toFixed(1)}%`);
+  }
+  return out;
+}
+
+export function computeTableColWidths(
+  cols: number,
+  overrides: SkeletonSize[] | undefined,
+): string[] {
+  if (overrides && overrides.length === cols) return overrides.map(toCssLength);
+  const pct = 100 / cols;
+  return Array.from({ length: cols }, () => `${pct.toFixed(4)}%`);
+}
+
+export interface SkeletonCommonProps {
+  animation?: SkeletonAnimation | undefined;
+  theme?: SkeletonTheme | undefined;
+  visible?: boolean | undefined;
+  fadeMs?: number | undefined;
+  "aria-label"?: string | undefined;
+}
+
+export function extractCommonProps<T extends SkeletonCommonProps>(
+  p: T,
+): SkeletonCommonProps {
+  const out: SkeletonCommonProps = {};
+  if (p.animation !== undefined) out.animation = p.animation;
+  if (p.theme !== undefined) out.theme = p.theme;
+  if (p.visible !== undefined) out.visible = p.visible;
+  if (p.fadeMs !== undefined) out.fadeMs = p.fadeMs;
+  if (p["aria-label"] !== undefined) out["aria-label"] = p["aria-label"];
+  return out;
+}

--- a/src/components/Skeleton/SkeletonAvatar.tsx
+++ b/src/components/Skeleton/SkeletonAvatar.tsx
@@ -1,0 +1,54 @@
+import type { SkeletonAvatarProps } from "./Skeleton.types";
+import { SkeletonRoot } from "./SkeletonRoot";
+
+export function SkeletonAvatar(props: SkeletonAvatarProps) {
+  const {
+    shape = "circle",
+    size = 40,
+    animation,
+    theme,
+    visible,
+    fadeMs,
+    children,
+    className,
+    style,
+    "aria-label": ariaLabel,
+  } = props;
+
+  if (shape === "circle") {
+    return (
+      <SkeletonRoot
+        shape="circle"
+        size={size}
+        {...(animation !== undefined ? { animation } : {})}
+        {...(theme !== undefined ? { theme } : {})}
+        {...(visible !== undefined ? { visible } : {})}
+        {...(fadeMs !== undefined ? { fadeMs } : {})}
+        {...(className !== undefined ? { className } : {})}
+        {...(style !== undefined ? { style } : {})}
+        {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
+        {...(children !== undefined ? { children } : {})}
+      />
+    );
+  }
+
+  const borderRadius = shape === "rounded" ? 8 : 0;
+  return (
+    <SkeletonRoot
+      shape="rect"
+      width={size}
+      height={size}
+      borderRadius={borderRadius}
+      {...(animation !== undefined ? { animation } : {})}
+      {...(theme !== undefined ? { theme } : {})}
+      {...(visible !== undefined ? { visible } : {})}
+      {...(fadeMs !== undefined ? { fadeMs } : {})}
+      {...(className !== undefined ? { className } : {})}
+      {...(style !== undefined ? { style } : {})}
+      {...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {})}
+      {...(children !== undefined ? { children } : {})}
+    />
+  );
+}
+
+SkeletonAvatar.displayName = "Skeleton.Avatar";

--- a/src/components/Skeleton/SkeletonCard.tsx
+++ b/src/components/Skeleton/SkeletonCard.tsx
@@ -1,0 +1,142 @@
+import type { CSSProperties } from "react";
+import type { SkeletonCardProps } from "./Skeleton.types";
+import { toCssLength } from "./Skeleton.utils";
+import { SkeletonRoot } from "./SkeletonRoot";
+import { SkeletonText } from "./SkeletonText";
+import { skeletonPalette } from "./theme";
+
+export function SkeletonCard(props: SkeletonCardProps) {
+  const {
+    hasMedia = false,
+    mediaHeight = 160,
+    hasTitle = true,
+    lines = 2,
+    hasFooter = false,
+    hasAvatar = false,
+    width = "100%",
+    padding = 16,
+    animation,
+    theme = "light",
+    visible,
+    fadeMs,
+    children,
+    className,
+    style,
+    "aria-label": ariaLabel,
+  } = props;
+
+  const isVisible = visible ?? true;
+  const ms = fadeMs ?? 180;
+
+  if (!isVisible) {
+    if (children === undefined || children === null) return null;
+    if (ms === 0) return <>{children}</>;
+    return (
+      <div
+        className="sk-content-fadein"
+        style={{ animationDuration: `${ms}ms` }}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  const palette = skeletonPalette[theme];
+  const containerStyle: CSSProperties = {
+    boxSizing: "border-box",
+    background: palette.cardBg,
+    border: `1px solid ${palette.cardBorder}`,
+    borderRadius: 8,
+    overflow: "hidden",
+    width: toCssLength(width),
+    display: "flex",
+    flexDirection: "column",
+    ...style,
+  };
+
+  const innerPadding: CSSProperties = {
+    padding: `${padding}px`,
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
+  };
+
+  const forwardCommon = {
+    ...(animation !== undefined ? { animation } : {}),
+    theme,
+  };
+
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label={ariaLabel ?? "Loading"}
+      className={className}
+      style={containerStyle}
+    >
+      {hasMedia && (
+        <SkeletonRoot
+          shape="rect"
+          width="100%"
+          height={mediaHeight}
+          borderRadius={0}
+          {...forwardCommon}
+          _suppressAria
+        />
+      )}
+      <div style={innerPadding}>
+        {hasAvatar && (
+          <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
+            <SkeletonRoot
+              shape="circle"
+              size={40}
+              {...forwardCommon}
+              _suppressAria
+            />
+            <SkeletonRoot
+              shape="rect"
+              width="40%"
+              height={14}
+              {...forwardCommon}
+              _suppressAria
+            />
+          </div>
+        )}
+        {hasTitle && (
+          <SkeletonRoot
+            shape="rect"
+            width="70%"
+            height={20}
+            {...forwardCommon}
+            _suppressAria
+          />
+        )}
+        {lines > 0 && (
+          <SkeletonText lines={lines} {...forwardCommon} _suppressAria />
+        )}
+        {hasFooter && (
+          <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
+            <SkeletonRoot
+              shape="rect"
+              width={72}
+              height={28}
+              borderRadius={6}
+              {...forwardCommon}
+              _suppressAria
+            />
+            <SkeletonRoot
+              shape="rect"
+              width={72}
+              height={28}
+              borderRadius={6}
+              {...forwardCommon}
+              _suppressAria
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+SkeletonCard.displayName = "Skeleton.Card";

--- a/src/components/Skeleton/SkeletonRoot.tsx
+++ b/src/components/Skeleton/SkeletonRoot.tsx
@@ -1,0 +1,92 @@
+import type { CSSProperties } from "react";
+import type { SkeletonAnimation, SkeletonRootProps } from "./Skeleton.types";
+import { resolveDimensions } from "./Skeleton.utils";
+import { applyPaletteVars } from "./theme";
+import { ensureSkeletonStyles } from "./styles";
+import { useReducedMotion } from "./useReducedMotion";
+
+interface InternalRootProps extends SkeletonRootProps {
+  _suppressAria?: boolean | undefined;
+}
+
+function animationClass(a: SkeletonAnimation): string {
+  if (a === "shimmer") return "sk-root--shimmer";
+  if (a === "pulse") return "sk-root--pulse";
+  return "sk-root--none";
+}
+
+export function SkeletonRoot(props: InternalRootProps) {
+  ensureSkeletonStyles();
+  const reduced = useReducedMotion();
+
+  const {
+    shape = "rect",
+    animation: animationProp,
+    theme = "light",
+    className,
+    style,
+    _suppressAria,
+    "aria-label": ariaLabel,
+    children,
+    visible,
+    fadeMs,
+    width: _w,
+    height: _h,
+    size: _s,
+    borderRadius: _br,
+    ...rest
+  } = props;
+  void _w;
+  void _h;
+  void _s;
+  void _br;
+
+  const dims = resolveDimensions(props);
+  const effectiveAnimation: SkeletonAnimation = reduced
+    ? false
+    : animationProp ?? "shimmer";
+
+  const classes = [
+    "sk-root",
+    `sk-root--${theme}`,
+    animationClass(effectiveAnimation),
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const paletteVars = applyPaletteVars(theme);
+  const mergedStyle: CSSProperties = {
+    ...paletteVars,
+    width: dims.width,
+    height: dims.height,
+    borderRadius: dims.borderRadius,
+    ...style,
+  };
+
+  const ariaProps: Record<string, string | undefined> = _suppressAria
+    ? {}
+    : {
+        role: "status",
+        "aria-busy": "true",
+        "aria-label": ariaLabel ?? "Loading",
+      };
+
+  void visible;
+  void fadeMs;
+  void children;
+
+  return (
+    <div
+      {...rest}
+      {...ariaProps}
+      data-shape={shape}
+      className={classes}
+      style={mergedStyle}
+    >
+      <span className="sk-shimmer" aria-hidden="true" />
+    </div>
+  );
+}
+
+SkeletonRoot.displayName = "Skeleton.Root";

--- a/src/components/Skeleton/SkeletonRoot.tsx
+++ b/src/components/Skeleton/SkeletonRoot.tsx
@@ -64,6 +64,22 @@ export function SkeletonRoot(props: InternalRootProps) {
     ...style,
   };
 
+  const isVisible = visible ?? true;
+  const ms = fadeMs ?? 180;
+
+  if (!isVisible) {
+    if (children === undefined || children === null) return null;
+    if (ms === 0) return <>{children}</>;
+    return (
+      <div
+        className="sk-content-fadein"
+        style={{ animationDuration: `${ms}ms` }}
+      >
+        {children}
+      </div>
+    );
+  }
+
   const ariaProps: Record<string, string | undefined> = _suppressAria
     ? {}
     : {
@@ -71,10 +87,6 @@ export function SkeletonRoot(props: InternalRootProps) {
         "aria-busy": "true",
         "aria-label": ariaLabel ?? "Loading",
       };
-
-  void visible;
-  void fadeMs;
-  void children;
 
   return (
     <div

--- a/src/components/Skeleton/SkeletonTable.tsx
+++ b/src/components/Skeleton/SkeletonTable.tsx
@@ -1,0 +1,120 @@
+import { useEffect, type CSSProperties } from "react";
+import type { SkeletonTableProps } from "./Skeleton.types";
+import { computeTableColWidths, toCssLength } from "./Skeleton.utils";
+import { SkeletonRoot } from "./SkeletonRoot";
+import { skeletonPalette } from "./theme";
+
+export function SkeletonTable(props: SkeletonTableProps) {
+  const {
+    rows = 5,
+    cols = 4,
+    hasHeader = true,
+    rowHeight = 44,
+    colWidths,
+    animation,
+    theme = "light",
+    visible,
+    fadeMs,
+    children,
+    className,
+    style,
+    "aria-label": ariaLabel,
+  } = props;
+
+  useEffect(() => {
+    if (rows > 200 && typeof console !== "undefined") {
+      console.warn(
+        "[Skeleton.Table] rows > 200 may cause perf issues; consider virtualization",
+      );
+    }
+  }, [rows]);
+
+  const isVisible = visible ?? true;
+  const ms = fadeMs ?? 180;
+
+  if (!isVisible) {
+    if (children === undefined || children === null) return null;
+    if (ms === 0) return <>{children}</>;
+    return (
+      <div
+        className="sk-content-fadein"
+        style={{ animationDuration: `${ms}ms` }}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  const widths = computeTableColWidths(cols, colWidths);
+  const palette = skeletonPalette[theme];
+
+  const containerStyle: CSSProperties = {
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    ...style,
+  };
+
+  const rowStyle: CSSProperties = {
+    display: "flex",
+    gap: 12,
+    height: toCssLength(rowHeight),
+    alignItems: "center",
+    padding: "0 12px",
+    borderTop: `1px solid ${palette.rowSep}`,
+  };
+
+  const headerStyle: CSSProperties = {
+    ...rowStyle,
+    borderTop: "none",
+    borderBottom: `1px solid ${palette.rowSep}`,
+  };
+
+  const forwardCommon = {
+    ...(animation !== undefined ? { animation } : {}),
+    theme,
+  };
+
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label={ariaLabel ?? "Loading"}
+      className={className}
+      style={containerStyle}
+    >
+      {hasHeader && (
+        <div style={headerStyle}>
+          {widths.map((w, c) => (
+            <div key={`h-${c}`} style={{ width: w }}>
+              <SkeletonRoot
+                shape="rect"
+                width="70%"
+                height={12}
+                {...forwardCommon}
+                _suppressAria
+              />
+            </div>
+          ))}
+        </div>
+      )}
+      {Array.from({ length: rows }).map((_, r) => (
+        <div key={`r-${r}`} style={rowStyle}>
+          {widths.map((w, c) => (
+            <div key={`c-${r}-${c}`} style={{ width: w }}>
+              <SkeletonRoot
+                shape="rect"
+                width="85%"
+                height={14}
+                {...forwardCommon}
+                _suppressAria
+              />
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+SkeletonTable.displayName = "Skeleton.Table";

--- a/src/components/Skeleton/SkeletonText.tsx
+++ b/src/components/Skeleton/SkeletonText.tsx
@@ -1,0 +1,84 @@
+import { useMemo, type CSSProperties } from "react";
+import type { SkeletonTextProps } from "./Skeleton.types";
+import { computeTextLineWidths } from "./Skeleton.utils";
+import { SkeletonRoot } from "./SkeletonRoot";
+
+interface InternalTextProps extends SkeletonTextProps {
+  _suppressAria?: boolean | undefined;
+}
+
+export function SkeletonText(props: InternalTextProps) {
+  const {
+    lines = 3,
+    lastLineWidth = "60%",
+    gap = 8,
+    randomize = true,
+    lineHeight = "1em",
+    widthRange = [0.75, 0.95],
+    seed = 1,
+    animation,
+    theme,
+    visible,
+    fadeMs,
+    children,
+    className,
+    style,
+    _suppressAria,
+    "aria-label": ariaLabel,
+  } = props;
+
+  const widths = useMemo(
+    () =>
+      computeTextLineWidths(lines, widthRange, lastLineWidth, randomize, seed),
+    [lines, widthRange, lastLineWidth, randomize, seed],
+  );
+
+  const isVisible = visible ?? true;
+  const ms = fadeMs ?? 180;
+
+  if (!isVisible) {
+    if (children === undefined || children === null) return null;
+    if (ms === 0) return <>{children}</>;
+    return (
+      <div
+        className="sk-content-fadein"
+        style={{ animationDuration: `${ms}ms` }}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  const containerStyle: CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    gap: `${gap}px`,
+    ...style,
+  };
+
+  const ariaProps: Record<string, string | undefined> = _suppressAria
+    ? {}
+    : {
+        role: "status",
+        "aria-busy": "true",
+        "aria-label": ariaLabel ?? "Loading",
+      };
+
+  return (
+    <div {...ariaProps} className={className} style={containerStyle}>
+      {widths.map((w, i) => (
+        <SkeletonRoot
+          key={i}
+          shape="text"
+          width={w}
+          height={lineHeight}
+          {...(animation !== undefined ? { animation } : {})}
+          {...(theme !== undefined ? { theme } : {})}
+          _suppressAria
+        />
+      ))}
+    </div>
+  );
+}
+
+SkeletonText.displayName = "Skeleton.Text";

--- a/src/components/Skeleton/index.ts
+++ b/src/components/Skeleton/index.ts
@@ -1,0 +1,12 @@
+export { Skeleton } from "./Skeleton";
+export type {
+  SkeletonRootProps,
+  SkeletonTextProps,
+  SkeletonAvatarProps,
+  SkeletonCardProps,
+  SkeletonTableProps,
+  SkeletonShape,
+  SkeletonAnimation,
+  SkeletonSize,
+  SkeletonTheme,
+} from "./Skeleton.types";

--- a/src/components/Skeleton/styles.ts
+++ b/src/components/Skeleton/styles.ts
@@ -1,0 +1,51 @@
+const STYLE_ID = "plastic-skeleton-styles";
+
+const CSS_TEXT = `
+.sk-root {
+  position: relative;
+  display: inline-block;
+  background-color: var(--sk-bg);
+  overflow: hidden;
+  isolation: isolate;
+  line-height: 1;
+  vertical-align: middle;
+}
+.sk-root[data-shape="text"] { display: block; }
+.sk-shimmer {
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent 0%, var(--sk-shine) 50%, transparent 100%);
+  animation: sk-shimmer 1500ms linear infinite;
+  will-change: transform;
+  pointer-events: none;
+}
+@keyframes sk-shimmer {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+.sk-root--pulse { animation: sk-pulse 1500ms ease-in-out infinite; }
+.sk-root--pulse > .sk-shimmer { display: none; }
+@keyframes sk-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.55; }
+}
+.sk-root--none > .sk-shimmer { display: none; }
+.sk-root--none { animation: none; }
+.sk-content-fadein { animation: sk-fadein 180ms ease-out both; }
+@keyframes sk-fadein { from { opacity: 0 } to { opacity: 1 } }
+@media (prefers-reduced-motion: reduce) {
+  .sk-root, .sk-root--pulse { animation: none !important; }
+  .sk-shimmer { display: none !important; animation: none !important; }
+  .sk-content-fadein { animation: none !important; }
+}
+`;
+
+export function ensureSkeletonStyles(): void {
+  if (typeof document === "undefined") return;
+  if (document.getElementById(STYLE_ID)) return;
+  const el = document.createElement("style");
+  el.id = STYLE_ID;
+  el.textContent = CSS_TEXT;
+  document.head.appendChild(el);
+}

--- a/src/components/Skeleton/theme.ts
+++ b/src/components/Skeleton/theme.ts
@@ -1,0 +1,38 @@
+import type { CSSProperties } from "react";
+import type { SkeletonTheme } from "./Skeleton.types";
+
+export interface SkeletonPalette {
+  bg: string;
+  shine: string;
+  border: string;
+  cardBg: string;
+  cardBorder: string;
+  rowSep: string;
+}
+
+export const skeletonPalette: Record<SkeletonTheme, SkeletonPalette> = {
+  light: {
+    bg: "#e5e7eb",
+    shine: "rgba(255,255,255,0.7)",
+    border: "rgba(0,0,0,0.06)",
+    cardBg: "#ffffff",
+    cardBorder: "rgba(0,0,0,0.08)",
+    rowSep: "rgba(0,0,0,0.06)",
+  },
+  dark: {
+    bg: "#334155",
+    shine: "rgba(255,255,255,0.08)",
+    border: "rgba(255,255,255,0.06)",
+    cardBg: "#0f172a",
+    cardBorder: "rgba(255,255,255,0.08)",
+    rowSep: "rgba(255,255,255,0.06)",
+  },
+};
+
+export function applyPaletteVars(theme: SkeletonTheme): CSSProperties {
+  const p = skeletonPalette[theme];
+  return {
+    ["--sk-bg" as string]: p.bg,
+    ["--sk-shine" as string]: p.shine,
+  } as CSSProperties;
+}

--- a/src/components/Skeleton/useReducedMotion.ts
+++ b/src/components/Skeleton/useReducedMotion.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(mql.matches);
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    }
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
+  }, []);
+
+  return reduced;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,6 +10,7 @@ export * from "./PathInput";
 export * from "./PipelineGraph";
 export * from "./Popover";
 export * from "./Select";
+export * from "./Skeleton";
 export * from "./Stepper";
 export * from "./Toast";
 export * from "./Tooltip";


### PR DESCRIPTION
## Summary
- Skeleton 컴포넌트 (Root + Text/Avatar/Card/Table 4종 프리셋)
- shape 3종 (text/rect/circle), animation 3종 (shimmer/pulse/false)
- prefers-reduced-motion 자동 감지, visible swap + fade
- light/dark theme palette (CSS 변수)
- Table preset에 rows>200 perf warn
- 데모 페이지 10섹션 + NAV 라우팅

## Issues
#419-#428

## Test plan
- [ ] `npx tsc --noEmit` 통과 확인
- [ ] `npm run build` 통과 확인
- [ ] 데모 시각 확인 (shimmer/pulse 토글, swap fade, dark theme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)