### PR TITLE
feat(Progress): 컴포넌트 + 데모 추가 (#402-#418)

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -13,8 +13,9 @@ import CommandPalettePage from "./pages/CommandPalettePage";
 import HexViewPage from "./pages/HexViewPage";
 import { PipelineGraphPage } from "./pages/PipelineGraphPage";
 import SelectPage from "./pages/SelectPage";
+import ProgressPage from "./pages/ProgressPage";
 
-type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select";
+type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select" | "progress";
 
 interface SubItem { label: string; id: string }
 
@@ -183,6 +184,21 @@ const NAV: { id: Page; label: string; description: string; sections: SubItem[] }
     { label: "Props", id: "props" },
     { label: "Usage", id: "usage" },
     { label: "Playground", id: "playground" },
+  ]},
+  { id: "progress", label: "Progress", description: "진행 상태 인디케이터", sections: [
+    { label: "Linear Basic", id: "linear" },
+    { label: "Indeterminate", id: "indeterminate" },
+    { label: "Buffer", id: "buffer" },
+    { label: "Segmented", id: "segmented" },
+    { label: "Circular", id: "circular" },
+    { label: "States (variant)", id: "states" },
+    { label: "Striped + Animated", id: "striped" },
+    { label: "Sizes", id: "sizes" },
+    { label: "Dark Theme", id: "dark" },
+    { label: "Controlled Counter", id: "controlled" },
+    { label: "Playground", id: "playground" },
+    { label: "Props", id: "props" },
+    { label: "Usage", id: "usage" },
   ]},
   { id: "dialog", label: "Dialog", description: "모달 다이얼로그", sections: [
     { label: "Basic", id: "basic" },
@@ -436,6 +452,7 @@ export function App() {
         {current === "hexview" && <HexViewPage />}
         {current === "pipelinegraph" && <PipelineGraphPage />}
         {current === "select" && <SelectPage />}
+        {current === "progress" && <ProgressPage />}
       </main>
     </div>
   );

--- a/demo/src/pages/ProgressPage.tsx
+++ b/demo/src/pages/ProgressPage.tsx
@@ -1,0 +1,723 @@
+import { useEffect, useState } from "react";
+import { CodeView, Progress } from "plastic";
+import type {
+  ProgressLabelPlacement,
+  ProgressShape,
+  ProgressSize,
+  ProgressStrokeLinecap,
+  ProgressTheme,
+  ProgressVariant,
+} from "plastic";
+
+function Section({
+  id,
+  title,
+  desc,
+  children,
+}: {
+  id?: string;
+  title: string;
+  desc?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="mb-10">
+      <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-2">
+        {title}
+      </p>
+      {desc && <p className="text-sm text-gray-500 mb-3">{desc}</p>}
+      {children}
+    </section>
+  );
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="p-6 bg-white rounded-lg border border-gray-200">
+      {children}
+    </div>
+  );
+}
+
+function PropsTable({
+  rows,
+}: {
+  rows: Array<[string, string, string, string]>;
+}) {
+  return (
+    <table className="w-full text-left text-sm border border-gray-200 rounded-lg overflow-hidden">
+      <thead className="bg-gray-50">
+        <tr>
+          <th className="px-4 py-2 border-b border-gray-200 font-semibold">Prop</th>
+          <th className="px-4 py-2 border-b border-gray-200 font-semibold">Type</th>
+          <th className="px-4 py-2 border-b border-gray-200 font-semibold">Default</th>
+          <th className="px-4 py-2 border-b border-gray-200 font-semibold">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(([prop, type, def, desc]) => (
+          <tr key={prop} className="border-t border-gray-100">
+            <td className="px-4 py-2 font-mono text-xs">{prop}</td>
+            <td className="px-4 py-2 font-mono text-xs text-gray-600">{type}</td>
+            <td className="px-4 py-2 font-mono text-xs text-gray-600">{def}</td>
+            <td className="px-4 py-2 text-gray-700">{desc}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function LinearBasicDemo() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Progress value={0} aria-label="0%" />
+      <Progress value={25} aria-label="25%" />
+      <Progress value={60} aria-label="60%" />
+      <Progress value={100} aria-label="완료" />
+    </div>
+  );
+}
+
+function IndeterminateDemo() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Progress indeterminate aria-label="로딩 중" />
+      <div className="flex items-center gap-6">
+        <Progress shape="circular" indeterminate aria-label="처리 중" />
+        <span className="text-sm text-gray-500">Circular indeterminate</span>
+      </div>
+      <Progress indeterminate striped aria-label="업로드 중" />
+    </div>
+  );
+}
+
+function BufferDemo() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Progress value={42} buffer={68} aria-label="다운로드 vs 재생" />
+      <Progress.Root value={30} buffer={80} variant="success" aria-label="compound 버퍼">
+        <Progress.Track>
+          <Progress.Indicator kind="buffer" value={80} />
+          <Progress.Indicator />
+        </Progress.Track>
+      </Progress.Root>
+    </div>
+  );
+}
+
+function SegmentedDemo() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Progress segments={5} value={3} aria-label="단계 3/5" />
+      <Progress segments={10} value={7} variant="success" aria-label="Quiz 7/10" />
+      <Progress segments={4} value={0} aria-label="시작 전" />
+      <Progress segments={6} value={6} variant="success" aria-label="완료" />
+    </div>
+  );
+}
+
+function CircularDemo() {
+  return (
+    <div className="flex items-center gap-8 flex-wrap">
+      <Progress shape="circular" value={25} size="sm" aria-label="25%" />
+      <Progress shape="circular" value={50} size="md" labelPlacement="outside" aria-label="50%">
+        50%
+      </Progress>
+      <Progress shape="circular" value={75} size="lg" strokeWidth={8} aria-label="75%">
+        75%
+      </Progress>
+      <Progress shape="circular" indeterminate size="md" aria-label="처리 중" />
+      <Progress shape="circular" value={90} variant="success" size="md" aria-label="90%">
+        <span style={{ fontWeight: 600 }}>OK</span>
+      </Progress>
+    </div>
+  );
+}
+
+function StatesDemo() {
+  return (
+    <div className="flex flex-col gap-3">
+      <Progress value={30} variant="default" aria-label="default" />
+      <Progress value={80} variant="success" aria-label="success" />
+      <Progress value={90} variant="warning" aria-label="warning" />
+      <Progress value={45} variant="error" aria-label="error" />
+    </div>
+  );
+}
+
+function StripedDemo() {
+  return (
+    <div className="flex flex-col gap-3">
+      <Progress value={60} striped aria-label="striped" />
+      <Progress value={60} striped animated aria-label="striped animated" />
+      <Progress
+        value={60}
+        striped
+        animated
+        variant="success"
+        size="lg"
+        aria-label="striped animated large"
+      />
+    </div>
+  );
+}
+
+function SizesDemo() {
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-4">
+        <Progress value={40} size="sm" aria-label="sm" />
+        <Progress value={40} size="md" aria-label="md" />
+        <Progress value={40} size="lg" aria-label="lg" />
+      </div>
+      <div className="flex items-center gap-6">
+        <Progress shape="circular" value={40} size="sm" aria-label="circular sm" />
+        <Progress shape="circular" value={40} size="md" aria-label="circular md" />
+        <Progress shape="circular" value={40} size="lg" aria-label="circular lg" />
+      </div>
+    </div>
+  );
+}
+
+function DarkDemo() {
+  return (
+    <div
+      style={{ background: "#0b1220", padding: 24, borderRadius: 8 }}
+    >
+      <div className="flex flex-col gap-4">
+        <Progress value={50} theme="dark" aria-label="dark default" />
+        <Progress
+          value={80}
+          theme="dark"
+          variant="success"
+          aria-label="dark success"
+        />
+        <Progress
+          value={45}
+          theme="dark"
+          variant="error"
+          striped
+          animated
+          aria-label="dark error animated"
+        />
+        <div className="flex items-center gap-6">
+          <Progress
+            shape="circular"
+            value={65}
+            theme="dark"
+            aria-label="dark circular"
+          />
+          <Progress
+            shape="circular"
+            indeterminate
+            theme="dark"
+            aria-label="dark circular indeterminate"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ControlledDemo() {
+  const [v, setV] = useState(0);
+  useEffect(() => {
+    if (v >= 100) return;
+    const t = setTimeout(() => setV((x) => Math.min(100, x + 5)), 300);
+    return () => clearTimeout(t);
+  }, [v]);
+  return (
+    <div className="flex flex-col gap-3">
+      <Progress value={v} aria-label="자동 증가" announce />
+      <div className="flex gap-2">
+        <button
+          onClick={() => setV(0)}
+          className="px-3 py-1 text-sm bg-gray-100 rounded hover:bg-gray-200"
+        >
+          Reset
+        </button>
+        <button
+          onClick={() => setV(100)}
+          className="px-3 py-1 text-sm bg-gray-100 rounded hover:bg-gray-200"
+        >
+          Jump to 100
+        </button>
+        <button
+          onClick={() => setV((x) => Math.min(100, x + 10))}
+          className="px-3 py-1 text-sm bg-gray-100 rounded hover:bg-gray-200"
+        >
+          +10
+        </button>
+      </div>
+      <div className="text-sm text-slate-600">current: {v}</div>
+    </div>
+  );
+}
+
+function Playground() {
+  const [shape, setShape] = useState<ProgressShape>("linear");
+  const [variant, setVariant] = useState<ProgressVariant>("default");
+  const [size, setSize] = useState<ProgressSize>("md");
+  const [theme, setTheme] = useState<ProgressTheme>("light");
+  const [value, setValue] = useState(40);
+  const [indeterminate, setIndeterminate] = useState(false);
+  const [buffer, setBuffer] = useState(70);
+  const [useBuffer, setUseBuffer] = useState(false);
+  const [segments, setSegments] = useState(0);
+  const [striped, setStriped] = useState(false);
+  const [animated, setAnimated] = useState(false);
+  const [labelPlacement, setLabelPlacement] =
+    useState<ProgressLabelPlacement>("none");
+  const [announce, setAnnounce] = useState(false);
+  const [strokeWidth, setStrokeWidth] = useState(4);
+  const [strokeLinecap, setStrokeLinecap] =
+    useState<ProgressStrokeLinecap>("round");
+
+  const isLinear = shape === "linear";
+  const effectiveSegments = isLinear && segments >= 2 ? segments : undefined;
+  const effectiveBuffer =
+    isLinear && useBuffer && !indeterminate && effectiveSegments === undefined
+      ? buffer
+      : undefined;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 lg:grid-cols-3 gap-4 text-sm">
+        <label className="flex flex-col gap-1">
+          <span>shape</span>
+          <select
+            value={shape}
+            onChange={(e) => setShape(e.target.value as ProgressShape)}
+            className="px-2 py-1 rounded border border-gray-300"
+          >
+            <option value="linear">linear</option>
+            <option value="circular">circular</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>variant</span>
+          <select
+            value={variant}
+            onChange={(e) => setVariant(e.target.value as ProgressVariant)}
+            className="px-2 py-1 rounded border border-gray-300"
+          >
+            <option value="default">default</option>
+            <option value="success">success</option>
+            <option value="warning">warning</option>
+            <option value="error">error</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>size</span>
+          <select
+            value={size}
+            onChange={(e) => setSize(e.target.value as ProgressSize)}
+            className="px-2 py-1 rounded border border-gray-300"
+          >
+            <option value="sm">sm</option>
+            <option value="md">md</option>
+            <option value="lg">lg</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>theme</span>
+          <select
+            value={theme}
+            onChange={(e) => setTheme(e.target.value as ProgressTheme)}
+            className="px-2 py-1 rounded border border-gray-300"
+          >
+            <option value="light">light</option>
+            <option value="dark">dark</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>labelPlacement</span>
+          <select
+            value={labelPlacement}
+            onChange={(e) =>
+              setLabelPlacement(e.target.value as ProgressLabelPlacement)
+            }
+            className="px-2 py-1 rounded border border-gray-300"
+          >
+            <option value="none">none</option>
+            <option value="outside">outside</option>
+            <option value="inside">inside</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>strokeLinecap (circular)</span>
+          <select
+            value={strokeLinecap}
+            onChange={(e) =>
+              setStrokeLinecap(e.target.value as ProgressStrokeLinecap)
+            }
+            className="px-2 py-1 rounded border border-gray-300"
+          >
+            <option value="round">round</option>
+            <option value="butt">butt</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>value ({value})</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={value}
+            onChange={(e) => setValue(Number(e.target.value))}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>buffer ({buffer})</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={buffer}
+            onChange={(e) => setBuffer(Number(e.target.value))}
+            disabled={!isLinear}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>segments ({segments === 0 ? "none" : segments})</span>
+          <input
+            type="range"
+            min={0}
+            max={10}
+            value={segments}
+            onChange={(e) => setSegments(Number(e.target.value))}
+            disabled={!isLinear}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>strokeWidth ({strokeWidth})</span>
+          <input
+            type="range"
+            min={2}
+            max={12}
+            value={strokeWidth}
+            onChange={(e) => setStrokeWidth(Number(e.target.value))}
+            disabled={isLinear}
+          />
+        </label>
+      </div>
+      <div className="flex gap-4 flex-wrap text-sm">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={indeterminate}
+            onChange={(e) => setIndeterminate(e.target.checked)}
+          />
+          indeterminate
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={useBuffer}
+            onChange={(e) => setUseBuffer(e.target.checked)}
+            disabled={!isLinear}
+          />
+          use buffer
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={striped}
+            onChange={(e) => setStriped(e.target.checked)}
+          />
+          striped
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={animated}
+            onChange={(e) => setAnimated(e.target.checked)}
+          />
+          animated
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={announce}
+            onChange={(e) => setAnnounce(e.target.checked)}
+          />
+          announce
+        </label>
+      </div>
+      <div
+        style={{
+          background: theme === "dark" ? "#0b1220" : "#f9fafb",
+          padding: 24,
+          borderRadius: 8,
+          minHeight: 120,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: shape === "circular" ? "center" : "stretch",
+        }}
+      >
+        <div style={{ width: shape === "circular" ? "auto" : "100%" }}>
+          <Progress
+            shape={shape}
+            variant={variant}
+            size={size}
+            theme={theme}
+            value={indeterminate ? undefined : value}
+            indeterminate={indeterminate}
+            {...(effectiveBuffer !== undefined ? { buffer: effectiveBuffer } : {})}
+            {...(effectiveSegments !== undefined ? { segments: effectiveSegments } : {})}
+            striped={striped}
+            animated={animated}
+            labelPlacement={labelPlacement}
+            announce={announce}
+            strokeWidth={strokeWidth}
+            strokeLinecap={strokeLinecap}
+            aria-label="Playground"
+          >
+            {shape === "circular" && !indeterminate ? `${value}%` : null}
+          </Progress>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const COMMON_PROPS: Array<[string, string, string, string]> = [
+  ["value", "number", "—", "현재 값 (0 ~ max). 미지정 시 indeterminate 자동"],
+  ["defaultValue", "number", "—", "uncontrolled 초기값"],
+  ["max", "number", "100", "value 상한"],
+  ["indeterminate", "boolean", "auto", "true 면 강제 indeterminate 애니메이션"],
+  ["shape", "'linear' | 'circular'", "'linear'", "선형/원형"],
+  ["size", "'sm' | 'md' | 'lg'", "'md'", "크기 (linear 높이 또는 circular 직경)"],
+  ["variant", "'default' | 'success' | 'warning' | 'error'", "'default'", "상태별 팔레트"],
+  ["theme", "'light' | 'dark'", "'light'", "Light/Dark 테마"],
+  ["segments", "number", "—", "단계형 막대. 2 이상 (Linear 전용)"],
+  ["buffer", "number", "—", "보조 게이지 (Linear determinate 전용)"],
+  ["striped", "boolean", "false", "대각선 줄무늬 (Linear)"],
+  ["animated", "boolean", "false", "줄무늬 애니메이션 (striped 조합)"],
+  ["labelPlacement", "'inside' | 'outside' | 'none'", "'none'", "라벨/값 텍스트 배치"],
+  ["formatLabel", "(value, max) => ReactNode", "'% 반올림'", "ValueText 포매터"],
+  ["strokeWidth", "number", "size 별", "Circular stroke 두께"],
+  ["strokeLinecap", "'butt' | 'round'", "'round'", "Circular stroke 끝 모양"],
+  ["trackOpacity", "number", "1", "Circular 트랙 투명도"],
+  ["aria-label", "string", "—", "접근성 라벨 (또는 aria-labelledby)"],
+  ["announce", "boolean", "false", "aria-live='polite' 활성"],
+  ["className", "string", "—", "루트 className"],
+  ["style", "CSSProperties", "—", "루트 style"],
+];
+
+const SHORTCUT_PROPS: Array<[string, string, string, string]> = [
+  ...COMMON_PROPS,
+  ["children", "ReactNode", "—", "Circular 중앙 텍스트 또는 Linear outside 라벨"],
+];
+
+const ROOT_PROPS: Array<[string, string, string, string]> = [
+  ...COMMON_PROPS,
+  ["children", "ReactNode", "—", "Track / Indicator / Label / ValueText 조합"],
+];
+
+const TRACK_PROPS: Array<[string, string, string, string]> = [
+  ["children", "ReactNode", "—", "Indicator (Linear 1~2 개, Circular 1 개)"],
+  ["className", "string", "—", "트랙 className"],
+  ["style", "CSSProperties", "—", "트랙 style"],
+];
+
+const INDICATOR_PROPS: Array<[string, string, string, string]> = [
+  ["kind", "'primary' | 'buffer'", "'primary'", "primary 또는 buffer. buffer 는 Linear 전용"],
+  ["value", "number", "—", "kind='buffer' 일 때 별도 값"],
+  ["className", "string", "—", "인디케이터 className"],
+  ["style", "CSSProperties", "—", "인디케이터 style"],
+];
+
+const LABEL_PROPS: Array<[string, string, string, string]> = [
+  ["placement", "'inside' | 'outside'", "'outside'", "라벨 위치 (Linear)"],
+  ["children", "ReactNode", "—", "라벨 콘텐츠"],
+  ["className", "string", "—", "라벨 className"],
+  ["style", "CSSProperties", "—", "라벨 style"],
+];
+
+const VALUE_TEXT_PROPS: Array<[string, string, string, string]> = [
+  ["format", "(value, max) => ReactNode", "formatLabel", "포매터 override"],
+  ["className", "string", "—", "value text className"],
+  ["style", "CSSProperties", "—", "value text style"],
+];
+
+const USAGE_CODE = `import { Progress } from "plastic";
+
+// 1) 기본 Linear determinate
+<Progress value={42} aria-label="업로드" />
+
+// 2) Indeterminate (값 미정)
+<Progress indeterminate aria-label="로딩" />
+
+// 3) Circular
+<Progress shape="circular" value={72} aria-label="72%">72%</Progress>
+
+// 4) Segmented (Quiz)
+<Progress segments={10} value={q} variant="success" aria-label={\`문제 \${q}/10\`} />
+
+// 5) Buffer (비디오 재생 위치)
+<Progress.Root value={played} buffer={loaded} max={duration} aria-label="재생">
+  <Progress.Track>
+    <Progress.Indicator kind="buffer" value={loaded} />
+    <Progress.Indicator />
+  </Progress.Track>
+</Progress.Root>
+
+// 6) 파일 업로드 인라인
+function UploadRow({ filename, percent }: { filename: string; percent: number }) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="w-40 truncate text-sm">{filename}</span>
+      <Progress value={percent} size="sm" className="flex-1" aria-label={\`\${filename} 업로드\`} />
+      <span className="w-10 text-xs text-slate-500">{percent}%</span>
+    </div>
+  );
+}
+
+// 7) 모달 로딩 스피너
+<Progress shape="circular" indeterminate size="lg" aria-label="처리 중" />
+`;
+
+export default function ProgressPage() {
+  return (
+    <div className="max-w-5xl">
+      <header className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">Progress</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Linear / Circular 진행 상태 인디케이터. determinate · indeterminate ·
+          buffer · segmented · striped 조합 지원. runtime-zero.
+        </p>
+      </header>
+
+      <Section id="linear" title="Linear Basic" desc="value 0 ~ 100">
+        <Card>
+          <LinearBasicDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="indeterminate"
+        title="Indeterminate"
+        desc="value 미지정 또는 indeterminate 로 무한 애니메이션"
+      >
+        <Card>
+          <IndeterminateDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="buffer"
+        title="Buffer"
+        desc="Linear 전용 보조 게이지 (다운로드 vs 재생)"
+      >
+        <Card>
+          <BufferDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="segmented"
+        title="Segmented"
+        desc="단계형 막대 (Linear 전용). segments={n}, value 0..n"
+      >
+        <Card>
+          <SegmentedDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="circular"
+        title="Circular"
+        desc="SVG 기반 원형. children 은 중앙에 배치"
+      >
+        <Card>
+          <CircularDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="states"
+        title="States (variant)"
+        desc="default / success / warning / error"
+      >
+        <Card>
+          <StatesDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="striped"
+        title="Striped + Animated"
+        desc="Linear 전용 대각선 줄무늬. animated 는 흐르는 애니메이션"
+      >
+        <Card>
+          <StripedDemo />
+        </Card>
+      </Section>
+
+      <Section id="sizes" title="Sizes" desc="sm / md / lg">
+        <Card>
+          <SizesDemo />
+        </Card>
+      </Section>
+
+      <Section id="dark" title="Dark Theme" desc="theme='dark'">
+        <DarkDemo />
+      </Section>
+
+      <Section
+        id="controlled"
+        title="Controlled Counter"
+        desc="외부 state 로 value 주입. announce 로 보조공학 읽기"
+      >
+        <Card>
+          <ControlledDemo />
+        </Card>
+      </Section>
+
+      <Section
+        id="playground"
+        title="Playground"
+        desc="모든 prop 을 토글해 실시간 미리보기"
+      >
+        <Card>
+          <Playground />
+        </Card>
+      </Section>
+
+      <Section id="props" title="Props">
+        <div className="flex flex-col gap-6">
+          <div>
+            <p className="text-sm font-semibold mb-2">Progress (단축)</p>
+            <PropsTable rows={SHORTCUT_PROPS} />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">Progress.Root</p>
+            <PropsTable rows={ROOT_PROPS} />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">Progress.Track</p>
+            <PropsTable rows={TRACK_PROPS} />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">Progress.Indicator</p>
+            <PropsTable rows={INDICATOR_PROPS} />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">Progress.Label</p>
+            <PropsTable rows={LABEL_PROPS} />
+          </div>
+          <div>
+            <p className="text-sm font-semibold mb-2">Progress.ValueText</p>
+            <PropsTable rows={VALUE_TEXT_PROPS} />
+          </div>
+        </div>
+      </Section>
+
+      <Section id="usage" title="Usage">
+        <CodeView code={USAGE_CODE} language="tsx" />
+      </Section>
+    </div>
+  );
+}

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -1,0 +1,10 @@
+import type { ProgressProps } from "./Progress.types";
+
+const Placeholder = (_props: ProgressProps) => null;
+Placeholder.Root = (_props: unknown) => null;
+Placeholder.Track = (_props: unknown) => null;
+Placeholder.Indicator = (_props: unknown) => null;
+Placeholder.Label = (_props: unknown) => null;
+Placeholder.ValueText = (_props: unknown) => null;
+
+export const Progress = Placeholder;

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -1,10 +1,75 @@
+import type { ReactNode } from "react";
 import type { ProgressProps } from "./Progress.types";
+import { ProgressRoot } from "./ProgressRoot";
+import { ProgressTrack } from "./ProgressTrack";
+import { ProgressIndicator } from "./ProgressIndicator";
+import { ProgressLabel } from "./ProgressLabel";
+import { ProgressValueText } from "./ProgressValueText";
 
-const Placeholder = (_props: ProgressProps) => null;
-Placeholder.Root = (_props: unknown) => null;
-Placeholder.Track = (_props: unknown) => null;
-Placeholder.Indicator = (_props: unknown) => null;
-Placeholder.Label = (_props: unknown) => null;
-Placeholder.ValueText = (_props: unknown) => null;
+function ProgressShortcut(props: ProgressProps) {
+  const {
+    children,
+    buffer,
+    segments,
+    labelPlacement = "none",
+    shape = "linear",
+    ...rest
+  } = props;
 
-export const Progress = Placeholder;
+  const showValueText =
+    labelPlacement !== "none" && segments == null;
+
+  let trackChildren: ReactNode;
+  if (segments != null && shape !== "circular") {
+    trackChildren = null;
+  } else if (shape === "circular") {
+    trackChildren = <ProgressIndicator />;
+  } else {
+    if (buffer != null) {
+      trackChildren = (
+        <>
+          <ProgressIndicator kind="buffer" value={buffer} />
+          <ProgressIndicator />
+        </>
+      );
+    } else {
+      trackChildren = <ProgressIndicator />;
+    }
+  }
+
+  const centerChildren = shape === "circular" ? children : null;
+  const outsideChildren = shape !== "circular" ? children : null;
+
+  return (
+    <ProgressRoot
+      shape={shape}
+      labelPlacement={labelPlacement}
+      {...(buffer !== undefined ? { buffer } : {})}
+      {...(segments !== undefined ? { segments } : {})}
+      {...rest}
+    >
+      {outsideChildren != null && labelPlacement === "outside" ? (
+        <ProgressLabel placement="outside">{outsideChildren}</ProgressLabel>
+      ) : null}
+      <ProgressTrack>{trackChildren}</ProgressTrack>
+      {showValueText && shape !== "circular" ? <ProgressValueText /> : null}
+      {shape === "circular" && centerChildren != null ? (
+        <div className="plastic-progress__center">{centerChildren}</div>
+      ) : shape === "circular" && labelPlacement !== "none" ? (
+        <ProgressValueText />
+      ) : null}
+    </ProgressRoot>
+  );
+}
+
+ProgressShortcut.displayName = "Progress";
+
+const Progress = Object.assign(ProgressShortcut, {
+  Root: ProgressRoot,
+  Track: ProgressTrack,
+  Indicator: ProgressIndicator,
+  Label: ProgressLabel,
+  ValueText: ProgressValueText,
+});
+
+export { Progress };

--- a/src/components/Progress/Progress.types.ts
+++ b/src/components/Progress/Progress.types.ts
@@ -1,0 +1,73 @@
+import type { ReactNode, CSSProperties } from "react";
+
+export type ProgressTheme = "light" | "dark";
+export type ProgressShape = "linear" | "circular";
+export type ProgressSize = "sm" | "md" | "lg";
+export type ProgressVariant = "default" | "success" | "warning" | "error";
+export type ProgressLabelPlacement = "inside" | "outside" | "none";
+export type ProgressStrokeLinecap = "butt" | "round";
+
+export interface ProgressCommonProps {
+  value?: number | undefined;
+  defaultValue?: number | undefined;
+  max?: number | undefined;
+  indeterminate?: boolean | undefined;
+  shape?: ProgressShape | undefined;
+  size?: ProgressSize | undefined;
+  variant?: ProgressVariant | undefined;
+  theme?: ProgressTheme | undefined;
+
+  segments?: number | undefined;
+  buffer?: number | undefined;
+
+  striped?: boolean | undefined;
+  animated?: boolean | undefined;
+
+  labelPlacement?: ProgressLabelPlacement | undefined;
+  formatLabel?: ((value: number, max: number) => ReactNode) | undefined;
+
+  strokeWidth?: number | undefined;
+  strokeLinecap?: ProgressStrokeLinecap | undefined;
+  trackOpacity?: number | undefined;
+
+  "aria-label"?: string | undefined;
+  "aria-labelledby"?: string | undefined;
+  announce?: boolean | undefined;
+
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface ProgressProps extends ProgressCommonProps {
+  children?: ReactNode | undefined;
+}
+
+export interface ProgressRootProps extends ProgressCommonProps {
+  children: ReactNode;
+}
+
+export interface ProgressTrackProps {
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  children: ReactNode;
+}
+
+export interface ProgressIndicatorProps {
+  kind?: "primary" | "buffer" | undefined;
+  value?: number | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface ProgressLabelProps {
+  placement?: "inside" | "outside" | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  children: ReactNode;
+}
+
+export interface ProgressValueTextProps {
+  format?: ((value: number, max: number) => ReactNode) | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}

--- a/src/components/Progress/Progress.utils.ts
+++ b/src/components/Progress/Progress.utils.ts
@@ -1,0 +1,91 @@
+import type { ProgressSize } from "./Progress.types";
+
+export function sanitizeMax(max: number | undefined): number {
+  if (max == null) return 100;
+  if (!Number.isFinite(max) || max <= 0) {
+    console.warn("[Progress] max must be a positive finite number. Fallback to 100.");
+    return 100;
+  }
+  return max;
+}
+
+export function clampValue(value: number | undefined, max: number): number | null {
+  if (value == null) return null;
+  if (!Number.isFinite(value)) {
+    console.warn("[Progress] value must be a finite number.");
+    return 0;
+  }
+  if (value < 0) {
+    console.warn(`[Progress] value ${value} < 0. Clamped to 0.`);
+    return 0;
+  }
+  if (value > max) {
+    console.warn(`[Progress] value ${value} > max ${max}. Clamped to max.`);
+    return max;
+  }
+  return value;
+}
+
+export function clampBuffer(buffer: number | undefined, max: number): number | null {
+  if (buffer == null) return null;
+  if (!Number.isFinite(buffer)) return 0;
+  if (buffer < 0) return 0;
+  if (buffer > max) return max;
+  return buffer;
+}
+
+export function toPercent(value: number | null, max: number): number | null {
+  return value == null ? null : (value / max) * 100;
+}
+
+export function resolveMode(
+  value: number | undefined,
+  indeterminate: boolean | undefined,
+): "determinate" | "indeterminate" {
+  if (indeterminate === true) return "indeterminate";
+  if (indeterminate === false) return "determinate";
+  return value == null ? "indeterminate" : "determinate";
+}
+
+export function resolveSegments(
+  segments: number | undefined,
+  value: number | null,
+): { count: number; filled: number } | null {
+  if (segments == null) return null;
+  if (!Number.isFinite(segments)) return null;
+  let n = Math.floor(segments);
+  if (n < 2) {
+    console.warn(`[Progress] segments ${segments} < 2. Clamped to 2.`);
+    n = 2;
+  }
+  const v = value == null ? 0 : Math.max(0, Math.min(n, Math.floor(value)));
+  return { count: n, filled: v };
+}
+
+export function circularGeometry(
+  diameter: number,
+  strokeWidth: number,
+  percent: number,
+): { r: number; c: number; offset: number } {
+  const r = (diameter - strokeWidth) / 2;
+  const c = 2 * Math.PI * r;
+  const clampedPct = Math.max(0, Math.min(100, percent));
+  const offset = c * (1 - clampedPct / 100);
+  return { r, c, offset };
+}
+
+export function sizeToLinearHeight(size: ProgressSize): number {
+  return size === "sm" ? 4 : size === "lg" ? 12 : 8;
+}
+
+export function sizeToCircularDiameter(size: ProgressSize): number {
+  return size === "sm" ? 24 : size === "lg" ? 64 : 40;
+}
+
+export function sizeToStrokeWidth(size: ProgressSize): number {
+  return size === "sm" ? 3 : size === "lg" ? 6 : 4;
+}
+
+export function sizeToLabelFont(size: ProgressSize): number {
+  return size === "sm" ? 11 : size === "lg" ? 14 : 12;
+}

--- a/src/components/Progress/ProgressContext.ts
+++ b/src/components/Progress/ProgressContext.ts
@@ -1,0 +1,42 @@
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+import type {
+  ProgressShape,
+  ProgressSize,
+  ProgressVariant,
+  ProgressTheme,
+  ProgressLabelPlacement,
+  ProgressStrokeLinecap,
+} from "./Progress.types";
+
+export interface ProgressContextValue {
+  mode: "determinate" | "indeterminate";
+  shape: ProgressShape;
+  size: ProgressSize;
+  variant: ProgressVariant;
+  theme: ProgressTheme;
+  value: number | null;
+  max: number;
+  percent: number | null;
+  buffer: number | null;
+  bufferPercent: number | null;
+  segments: { count: number; filled: number } | null;
+  striped: boolean;
+  animated: boolean;
+  labelPlacement: ProgressLabelPlacement;
+  formatLabel: (value: number, max: number) => ReactNode;
+  strokeWidth: number;
+  strokeLinecap: ProgressStrokeLinecap;
+  trackOpacity: number;
+  announce: boolean;
+}
+
+export const ProgressContext = createContext<ProgressContextValue | null>(null);
+
+export function useProgressContext(): ProgressContextValue {
+  const ctx = useContext(ProgressContext);
+  if (ctx === null) {
+    throw new Error("Progress.* must be used within <Progress.Root>");
+  }
+  return ctx;
+}

--- a/src/components/Progress/ProgressIndicator.tsx
+++ b/src/components/Progress/ProgressIndicator.tsx
@@ -1,0 +1,88 @@
+import type { CSSProperties } from "react";
+import { useProgressContext } from "./ProgressContext";
+import { circularGeometry, sizeToCircularDiameter, toPercent } from "./Progress.utils";
+import type { ProgressIndicatorProps } from "./Progress.types";
+
+export function ProgressIndicator(props: ProgressIndicatorProps) {
+  const { kind = "primary", value: bufferValue, className, style } = props;
+  const ctx = useProgressContext();
+  const {
+    shape,
+    mode,
+    percent,
+    bufferPercent,
+    max,
+    segments,
+    size,
+    strokeWidth,
+    strokeLinecap,
+  } = ctx;
+
+  if (segments !== null) {
+    return null;
+  }
+
+  if (shape === "circular") {
+    if (kind === "buffer") {
+      console.warn("[Progress] kind=\"buffer\" is not supported in circular shape (v1). Ignored.");
+      return null;
+    }
+    const d = sizeToCircularDiameter(size);
+    const cx = d / 2;
+    const cy = d / 2;
+    const { r, c, offset } = circularGeometry(d, strokeWidth, percent ?? 0);
+    const baseStyle: CSSProperties =
+      mode === "determinate"
+        ? { strokeDasharray: c, strokeDashoffset: offset }
+        : {};
+    const cls = [
+      "plastic-progress__circle",
+      "plastic-progress__circle--indicator",
+      className ?? "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    return (
+      <circle
+        className={cls}
+        cx={cx}
+        cy={cy}
+        r={r}
+        fill="none"
+        strokeWidth={strokeWidth}
+        strokeLinecap={strokeLinecap}
+        transform={`rotate(-90 ${cx} ${cy})`}
+        style={{ ...baseStyle, ...(style ?? {}) }}
+      />
+    );
+  }
+
+  if (kind === "buffer") {
+    const bv = bufferValue == null ? bufferPercent : toPercent(bufferValue, max);
+    if (bv == null) return null;
+    const ratio = Math.max(0, Math.min(1, bv / 100));
+    const baseStyle: CSSProperties = { transform: `scaleX(${ratio})` };
+    const cls = [
+      "plastic-progress__fill",
+      "plastic-progress__fill--buffer",
+      className ?? "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    return <div className={cls} style={{ ...baseStyle, ...(style ?? {}) }} />;
+  }
+
+  const ratio = mode === "determinate" ? Math.max(0, Math.min(1, (percent ?? 0) / 100)) : 0;
+  const baseStyle: CSSProperties =
+    mode === "determinate" ? { transform: `scaleX(${ratio})` } : {};
+  const cls = [
+    "plastic-progress__fill",
+    "plastic-progress__fill--primary",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return <div className={cls} style={{ ...baseStyle, ...(style ?? {}) }} />;
+}
+
+ProgressIndicator.displayName = "Progress.Indicator";

--- a/src/components/Progress/ProgressLabel.tsx
+++ b/src/components/Progress/ProgressLabel.tsx
@@ -1,0 +1,38 @@
+import type { ProgressLabelProps } from "./Progress.types";
+import { useProgressContext } from "./ProgressContext";
+
+export function ProgressLabel(props: ProgressLabelProps) {
+  const { placement, className, style, children } = props;
+  const { shape, labelPlacement, size } = useProgressContext();
+
+  const effective = placement ?? (labelPlacement === "none" ? "outside" : labelPlacement);
+
+  if (shape === "circular") {
+    const cls = ["plastic-progress__center", className ?? ""].filter(Boolean).join(" ");
+    return (
+      <div className={cls} {...(style ? { style } : {})}>
+        {children}
+      </div>
+    );
+  }
+
+  if (effective === "inside" && size === "sm") {
+    console.warn("[Progress] labelPlacement=\"inside\" is not supported for size=sm. Fallback to outside.");
+  }
+  const resolved = effective === "inside" && size === "sm" ? "outside" : effective;
+
+  const cls = [
+    "plastic-progress__label",
+    resolved === "inside" ? "plastic-progress__label--inside" : "plastic-progress__label--outside",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <div className={cls} {...(style ? { style } : {})}>
+      {children}
+    </div>
+  );
+}
+
+ProgressLabel.displayName = "Progress.Label";

--- a/src/components/Progress/ProgressRoot.tsx
+++ b/src/components/Progress/ProgressRoot.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useMemo, useRef } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { useControllable } from "../_shared/useControllable";
+import { ProgressContext, type ProgressContextValue } from "./ProgressContext";
+import { progressPalette } from "./theme";
+import { ensureProgressStyles } from "./ProgressStyles";
+import {
+  clampBuffer,
+  clampValue,
+  resolveMode,
+  resolveSegments,
+  sanitizeMax,
+  sizeToCircularDiameter,
+  sizeToLabelFont,
+  sizeToLinearHeight,
+  sizeToStrokeWidth,
+  toPercent,
+} from "./Progress.utils";
+import type {
+  ProgressLabelPlacement,
+  ProgressRootProps,
+  ProgressShape,
+  ProgressSize,
+  ProgressStrokeLinecap,
+  ProgressTheme,
+  ProgressVariant,
+} from "./Progress.types";
+
+function defaultFormatLabel(value: number, max: number): ReactNode {
+  return `${Math.round((value / max) * 100)}%`;
+}
+
+export function ProgressRoot(props: ProgressRootProps) {
+  const {
+    children,
+    value: controlledValue,
+    defaultValue,
+    max: rawMax,
+    indeterminate,
+    shape = "linear" as ProgressShape,
+    size = "md" as ProgressSize,
+    variant = "default" as ProgressVariant,
+    theme = "light" as ProgressTheme,
+    segments: rawSegments,
+    buffer: rawBuffer,
+    striped = false,
+    animated = false,
+    labelPlacement = "none" as ProgressLabelPlacement,
+    formatLabel,
+    strokeWidth: rawStrokeWidth,
+    strokeLinecap = "round" as ProgressStrokeLinecap,
+    trackOpacity = 1,
+    announce = false,
+    className,
+    style,
+  } = props;
+
+  const ariaLabel = props["aria-label"];
+  const ariaLabelledBy = props["aria-labelledby"];
+
+  const [rawValue] = useControllable<number | undefined>(
+    controlledValue,
+    defaultValue,
+    undefined,
+  );
+
+  const max = sanitizeMax(rawMax);
+  const clamped = clampValue(rawValue, max);
+  const mode = resolveMode(rawValue, indeterminate);
+
+  let bufferClamped = clampBuffer(rawBuffer, max);
+  let segments = resolveSegments(rawSegments, clamped);
+
+  const warnedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    ensureProgressStyles();
+  }, []);
+
+  const warnOnce = (key: string, msg: string) => {
+    if (warnedRef.current.has(key)) return;
+    warnedRef.current.add(key);
+    console.warn(msg);
+  };
+
+  if (shape === "circular") {
+    if (bufferClamped !== null) {
+      warnOnce("circ-buffer", "[Progress] buffer is not supported in circular shape (v1). Ignored.");
+      bufferClamped = null;
+    }
+    if (segments !== null) {
+      warnOnce("circ-segments", "[Progress] segments is not supported in circular shape. Ignored.");
+      segments = null;
+    }
+  } else {
+    if (segments !== null && bufferClamped !== null) {
+      warnOnce("seg-buffer", "[Progress] segments + buffer is invalid. buffer ignored.");
+      bufferClamped = null;
+    }
+    if (segments !== null && indeterminate === true) {
+      warnOnce("seg-indet", "[Progress] segments + indeterminate is invalid. indeterminate ignored.");
+    }
+    if (bufferClamped !== null && mode === "indeterminate") {
+      warnOnce("indet-buffer", "[Progress] buffer + indeterminate is invalid. buffer ignored.");
+      bufferClamped = null;
+    }
+  }
+
+  const effectiveMode: "determinate" | "indeterminate" =
+    segments !== null ? "determinate" : mode;
+
+  if (!ariaLabel && !ariaLabelledBy) {
+    warnOnce(
+      "aria-label",
+      "[Progress] aria-label or aria-labelledby is recommended for screen readers.",
+    );
+  }
+
+  const percent = toPercent(clamped, max);
+  const bufferPercent = toPercent(bufferClamped, max);
+
+  const strokeWidth = rawStrokeWidth ?? sizeToStrokeWidth(size);
+
+  const paletteTheme = progressPalette[theme];
+  const variantPal = paletteTheme.variants[variant];
+
+  const rootStyle: CSSProperties = {
+    "--plastic-progress-track": paletteTheme.track,
+    "--plastic-progress-track-segmented": paletteTheme.trackSegmented,
+    "--plastic-progress-fill": variantPal.fill,
+    "--plastic-progress-buffer": variantPal.buffer,
+    "--plastic-progress-label-fg": paletteTheme.labelFg,
+    "--plastic-progress-value-fg-inside": paletteTheme.valueTextFg,
+    "--plastic-progress-value-fg-outside": paletteTheme.valueTextFgOut,
+    "--plastic-progress-size-linear": `${sizeToLinearHeight(size)}px`,
+    "--plastic-progress-size-circular": `${sizeToCircularDiameter(size)}px`,
+    "--plastic-progress-stroke-width": String(strokeWidth),
+    "--plastic-progress-label-font": `${sizeToLabelFont(size)}px`,
+    "--plastic-progress-track-opacity": String(trackOpacity),
+    ...(style ?? {}),
+  } as CSSProperties;
+
+  const ctx = useMemo<ProgressContextValue>(
+    () => ({
+      mode: effectiveMode,
+      shape,
+      size,
+      variant,
+      theme,
+      value: clamped,
+      max,
+      percent,
+      buffer: bufferClamped,
+      bufferPercent,
+      segments,
+      striped,
+      animated,
+      labelPlacement,
+      formatLabel: formatLabel ?? defaultFormatLabel,
+      strokeWidth,
+      strokeLinecap,
+      trackOpacity,
+      announce,
+    }),
+    [
+      effectiveMode,
+      shape,
+      size,
+      variant,
+      theme,
+      clamped,
+      max,
+      percent,
+      bufferClamped,
+      bufferPercent,
+      segments,
+      striped,
+      animated,
+      labelPlacement,
+      formatLabel,
+      strokeWidth,
+      strokeLinecap,
+      trackOpacity,
+      announce,
+    ],
+  );
+
+  const ariaValueMax =
+    segments !== null ? segments.count : effectiveMode === "determinate" ? 100 : undefined;
+  const ariaValueNow =
+    segments !== null
+      ? segments.filled
+      : effectiveMode === "determinate"
+        ? Math.round(percent ?? 0)
+        : undefined;
+
+  const dataAttrs: Record<string, string> = {
+    "data-variant": variant,
+    "data-size": size,
+    "data-theme": theme,
+    "data-mode": effectiveMode,
+    "data-striped": striped ? "true" : "false",
+    "data-animated": animated ? "true" : "false",
+  };
+  if (segments !== null) dataAttrs["data-segmented"] = "true";
+
+  const ariaProps: Record<string, string | number> = {
+    "aria-valuemin": 0,
+  };
+  if (ariaValueMax !== undefined) ariaProps["aria-valuemax"] = ariaValueMax;
+  if (ariaValueNow !== undefined) ariaProps["aria-valuenow"] = ariaValueNow;
+  if (ariaLabel) ariaProps["aria-label"] = ariaLabel;
+  if (ariaLabelledBy) ariaProps["aria-labelledby"] = ariaLabelledBy;
+  if (announce) {
+    ariaProps["aria-live"] = "polite";
+    ariaProps["aria-atomic"] = "true";
+  }
+
+  const cls = [
+    "plastic-progress",
+    shape === "linear" ? "plastic-progress--linear" : "plastic-progress--circular",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <ProgressContext.Provider value={ctx}>
+      <div
+        className={cls}
+        style={rootStyle}
+        role="progressbar"
+        {...dataAttrs}
+        {...ariaProps}
+      >
+        {children}
+      </div>
+    </ProgressContext.Provider>
+  );
+}
+
+ProgressRoot.displayName = "Progress.Root";

--- a/src/components/Progress/ProgressStyles.ts
+++ b/src/components/Progress/ProgressStyles.ts
@@ -1,0 +1,238 @@
+const STYLE_ID = "plastic-progress-styles";
+
+const CSS = `
+.plastic-progress {
+  position: relative;
+  width: 100%;
+  color: var(--plastic-progress-label-fg);
+  font-family: inherit;
+}
+.plastic-progress--linear {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.plastic-progress__track {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: var(--plastic-progress-size-linear, 8px);
+  background: var(--plastic-progress-track);
+  border-radius: 9999px;
+}
+.plastic-progress__fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  transform-origin: left center;
+  transform: scaleX(0);
+  transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  border-radius: inherit;
+}
+.plastic-progress__fill--primary {
+  background: var(--plastic-progress-fill);
+  z-index: 2;
+}
+.plastic-progress__fill--buffer {
+  background: var(--plastic-progress-buffer);
+  z-index: 1;
+}
+.plastic-progress[data-mode="indeterminate"] .plastic-progress__fill--primary {
+  transform: none;
+  transition: none;
+  width: 40%;
+  animation: plastic-progress-linear-indeterminate 1.6s ease-in-out infinite;
+}
+.plastic-progress[data-mode="indeterminate"] .plastic-progress__fill--buffer {
+  display: none;
+}
+.plastic-progress__track--segmented {
+  display: flex;
+  gap: 4px;
+  background: transparent;
+  overflow: visible;
+  border-radius: 0;
+}
+.plastic-progress__seg {
+  flex: 1 1 0;
+  height: 100%;
+  background: var(--plastic-progress-track-segmented);
+  border-radius: 2px;
+  transition: background 160ms ease;
+}
+.plastic-progress__seg[data-filled="true"] {
+  background: var(--plastic-progress-fill);
+}
+.plastic-progress__label {
+  font-size: var(--plastic-progress-label-font, 12px);
+  color: var(--plastic-progress-label-fg);
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.plastic-progress__label--outside {
+  display: block;
+}
+.plastic-progress__label--inside {
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--plastic-progress-value-fg-inside);
+  font-weight: 600;
+  z-index: 3;
+  pointer-events: none;
+}
+.plastic-progress__value-text {
+  font-size: var(--plastic-progress-label-font, 12px);
+  color: var(--plastic-progress-value-fg-outside);
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+}
+.plastic-progress__value-text--outside {
+  align-self: flex-end;
+}
+.plastic-progress__value-text--inside {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--plastic-progress-value-fg-inside);
+  font-weight: 600;
+  z-index: 3;
+  pointer-events: none;
+}
+.plastic-progress[data-striped="true"] .plastic-progress__fill--primary {
+  background-image: linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.2) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.2) 75%,
+    transparent 75%
+  );
+  background-size: 16px 16px;
+}
+.plastic-progress[data-striped="true"][data-animated="true"] .plastic-progress__fill--primary {
+  animation: plastic-progress-stripes 1s linear infinite;
+}
+.plastic-progress[data-mode="indeterminate"][data-striped="true"] .plastic-progress__fill--primary {
+  animation:
+    plastic-progress-linear-indeterminate 1.6s ease-in-out infinite,
+    plastic-progress-stripes 1s linear infinite;
+}
+.plastic-progress--circular {
+  display: inline-flex;
+  position: relative;
+  width: var(--plastic-progress-size-circular, 40px);
+  height: var(--plastic-progress-size-circular, 40px);
+  vertical-align: middle;
+}
+.plastic-progress__svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.plastic-progress__circle--track {
+  stroke: var(--plastic-progress-track);
+  opacity: var(--plastic-progress-track-opacity, 1);
+}
+.plastic-progress__circle--indicator {
+  stroke: var(--plastic-progress-fill);
+  transition: stroke-dashoffset 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.plastic-progress--circular[data-mode="indeterminate"] .plastic-progress__svg {
+  animation: plastic-progress-circular-rotate 1.4s linear infinite;
+}
+.plastic-progress--circular[data-mode="indeterminate"] .plastic-progress__circle--indicator {
+  stroke-dasharray: 80, 200;
+  stroke-dashoffset: 0;
+  transition: none;
+  animation: plastic-progress-circular-dash 1.4s ease-in-out infinite;
+}
+.plastic-progress__center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--plastic-progress-label-font, 12px);
+  color: var(--plastic-progress-value-fg-outside);
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+}
+@keyframes plastic-progress-linear-indeterminate {
+  0% {
+    left: -40%;
+    right: 100%;
+  }
+  60% {
+    left: 100%;
+    right: -40%;
+  }
+  100% {
+    left: 100%;
+    right: -40%;
+  }
+}
+@keyframes plastic-progress-circular-rotate {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+@keyframes plastic-progress-circular-dash {
+  0% {
+    stroke-dasharray: 1, 200;
+    stroke-dashoffset: 0;
+  }
+  50% {
+    stroke-dasharray: 100, 200;
+    stroke-dashoffset: -15;
+  }
+  100% {
+    stroke-dasharray: 100, 200;
+    stroke-dashoffset: -125;
+  }
+}
+@keyframes plastic-progress-stripes {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 16px 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .plastic-progress__fill--primary,
+  .plastic-progress__circle--indicator {
+    transition: none;
+  }
+  .plastic-progress[data-mode="indeterminate"] .plastic-progress__fill--primary,
+  .plastic-progress--circular[data-mode="indeterminate"] .plastic-progress__svg,
+  .plastic-progress--circular[data-mode="indeterminate"] .plastic-progress__circle--indicator,
+  .plastic-progress[data-striped="true"][data-animated="true"] .plastic-progress__fill--primary {
+    animation: none !important;
+  }
+}
+`;
+
+let injected = false;
+
+export function ensureProgressStyles(): void {
+  if (injected) return;
+  if (typeof document === "undefined") return;
+  if (document.getElementById(STYLE_ID)) {
+    injected = true;
+    return;
+  }
+  const el = document.createElement("style");
+  el.id = STYLE_ID;
+  el.setAttribute("data-plastic-progress", "injected");
+  el.textContent = CSS;
+  document.head.appendChild(el);
+  injected = true;
+}

--- a/src/components/Progress/ProgressTrack.tsx
+++ b/src/components/Progress/ProgressTrack.tsx
@@ -1,0 +1,28 @@
+import type { ProgressTrackProps } from "./Progress.types";
+import { useProgressContext } from "./ProgressContext";
+import { ProgressTrackLinear } from "./ProgressTrackLinear";
+import { ProgressTrackCircular } from "./ProgressTrackCircular";
+
+export function ProgressTrack(props: ProgressTrackProps) {
+  const { shape } = useProgressContext();
+  if (shape === "circular") {
+    return (
+      <ProgressTrackCircular
+        {...(props.className !== undefined ? { className: props.className } : {})}
+        {...(props.style !== undefined ? { style: props.style } : {})}
+      >
+        {props.children}
+      </ProgressTrackCircular>
+    );
+  }
+  return (
+    <ProgressTrackLinear
+      {...(props.className !== undefined ? { className: props.className } : {})}
+      {...(props.style !== undefined ? { style: props.style } : {})}
+    >
+      {props.children}
+    </ProgressTrackLinear>
+  );
+}
+
+ProgressTrack.displayName = "Progress.Track";

--- a/src/components/Progress/ProgressTrackCircular.tsx
+++ b/src/components/Progress/ProgressTrackCircular.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode, CSSProperties } from "react";
+import { useProgressContext } from "./ProgressContext";
+import { sizeToCircularDiameter } from "./Progress.utils";
+
+export interface ProgressTrackCircularProps {
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  children: ReactNode;
+}
+
+export function ProgressTrackCircular({
+  className,
+  style,
+  children,
+}: ProgressTrackCircularProps) {
+  const { size, strokeWidth, trackOpacity } = useProgressContext();
+  const d = sizeToCircularDiameter(size);
+  const cx = d / 2;
+  const cy = d / 2;
+  const r = (d - strokeWidth) / 2;
+
+  const cls = ["plastic-progress__svg", className ?? ""].filter(Boolean).join(" ");
+
+  return (
+    <svg
+      className={cls}
+      width={d}
+      height={d}
+      viewBox={`0 0 ${d} ${d}`}
+      {...(style ? { style } : {})}
+      aria-hidden="true"
+    >
+      <circle
+        className="plastic-progress__circle plastic-progress__circle--track"
+        cx={cx}
+        cy={cy}
+        r={r}
+        fill="none"
+        strokeWidth={strokeWidth}
+        opacity={trackOpacity}
+      />
+      {children}
+    </svg>
+  );
+}

--- a/src/components/Progress/ProgressTrackLinear.tsx
+++ b/src/components/Progress/ProgressTrackLinear.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode, CSSProperties } from "react";
+import { useProgressContext } from "./ProgressContext";
+
+export interface ProgressTrackLinearProps {
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  children: ReactNode;
+}
+
+export function ProgressTrackLinear({
+  className,
+  style,
+  children,
+}: ProgressTrackLinearProps) {
+  const { segments, variant } = useProgressContext();
+
+  if (segments !== null) {
+    const cls = ["plastic-progress__track plastic-progress__track--segmented", className ?? ""]
+      .filter(Boolean)
+      .join(" ");
+    const cells: ReactNode[] = [];
+    for (let i = 0; i < segments.count; i += 1) {
+      cells.push(
+        <div
+          key={i}
+          className="plastic-progress__seg"
+          data-filled={i < segments.filled ? "true" : "false"}
+          data-variant={variant}
+        />,
+      );
+    }
+    return (
+      <div className={cls} {...(style ? { style } : {})}>
+        {cells}
+      </div>
+    );
+  }
+
+  const cls = ["plastic-progress__track", className ?? ""].filter(Boolean).join(" ");
+  return (
+    <div className={cls} {...(style ? { style } : {})}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/Progress/ProgressValueText.tsx
+++ b/src/components/Progress/ProgressValueText.tsx
@@ -1,0 +1,43 @@
+import type { ProgressValueTextProps } from "./Progress.types";
+import { useProgressContext } from "./ProgressContext";
+
+export function ProgressValueText(props: ProgressValueTextProps) {
+  const { format, className, style } = props;
+  const { mode, value, max, formatLabel, shape, labelPlacement, size } = useProgressContext();
+
+  if (mode === "indeterminate") return null;
+  if (value == null) return null;
+
+  const fn = format ?? formatLabel;
+  const content = fn(value, max);
+
+  if (shape === "circular") {
+    const cls = ["plastic-progress__center", className ?? ""].filter(Boolean).join(" ");
+    return (
+      <div className={cls} {...(style ? { style } : {})}>
+        {content}
+      </div>
+    );
+  }
+
+  const effectivePlacement =
+    labelPlacement === "inside" && size !== "sm" ? "inside" : "outside";
+
+  const cls = [
+    "plastic-progress__value-text",
+    effectivePlacement === "inside"
+      ? "plastic-progress__value-text--inside"
+      : "plastic-progress__value-text--outside",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <span className={cls} {...(style ? { style } : {})}>
+      {content}
+    </span>
+  );
+}
+
+ProgressValueText.displayName = "Progress.ValueText";

--- a/src/components/Progress/index.ts
+++ b/src/components/Progress/index.ts
@@ -1,0 +1,16 @@
+export { Progress } from "./Progress";
+export type {
+  ProgressProps,
+  ProgressRootProps,
+  ProgressTrackProps,
+  ProgressIndicatorProps,
+  ProgressLabelProps,
+  ProgressValueTextProps,
+  ProgressCommonProps,
+  ProgressTheme,
+  ProgressShape,
+  ProgressSize,
+  ProgressVariant,
+  ProgressLabelPlacement,
+  ProgressStrokeLinecap,
+} from "./Progress.types";

--- a/src/components/Progress/theme.ts
+++ b/src/components/Progress/theme.ts
@@ -1,0 +1,44 @@
+import type { ProgressTheme, ProgressVariant } from "./Progress.types";
+
+export interface ProgressVariantPalette {
+  fill: string;
+  buffer: string;
+}
+
+export interface ProgressPalette {
+  track: string;
+  trackSegmented: string;
+  labelFg: string;
+  valueTextFg: string;
+  valueTextFgOut: string;
+  variants: Record<ProgressVariant, ProgressVariantPalette>;
+}
+
+export const progressPalette: Record<ProgressTheme, ProgressPalette> = {
+  light: {
+    track: "rgba(0,0,0,0.08)",
+    trackSegmented: "rgba(0,0,0,0.05)",
+    labelFg: "#374151",
+    valueTextFg: "#ffffff",
+    valueTextFgOut: "#374151",
+    variants: {
+      default: { fill: "#2563eb", buffer: "rgba(37,99,235,0.30)" },
+      success: { fill: "#16a34a", buffer: "rgba(22,163,74,0.30)" },
+      warning: { fill: "#d97706", buffer: "rgba(217,119,6,0.30)" },
+      error: { fill: "#dc2626", buffer: "rgba(220,38,38,0.30)" },
+    },
+  },
+  dark: {
+    track: "rgba(255,255,255,0.10)",
+    trackSegmented: "rgba(255,255,255,0.06)",
+    labelFg: "#e5e7eb",
+    valueTextFg: "#0b1220",
+    valueTextFgOut: "#e5e7eb",
+    variants: {
+      default: { fill: "#60a5fa", buffer: "rgba(96,165,250,0.30)" },
+      success: { fill: "#34d399", buffer: "rgba(52,211,153,0.30)" },
+      warning: { fill: "#fbbf24", buffer: "rgba(251,191,36,0.30)" },
+      error: { fill: "#f87171", buffer: "rgba(248,113,113,0.30)" },
+    },
+  },
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export * from "./HexView";
 export * from "./PathInput";
 export * from "./PipelineGraph";
 export * from "./Popover";
+export * from "./Progress";
 export * from "./Select";
 export * from "./Stepper";
 export * from "./Toast";


### PR DESCRIPTION
## Summary
- Progress 컴포넌트 (Root/Track/Indicator/Label/ValueText 컴파운드 + ProgressShortcut 단일 API)
- linear/circular shape, indeterminate, buffer, segments
- variant (default/success/warning/danger), striped + animated
- size 토큰, light/dark 팔레트
- ARIA progressbar (valuenow/valuemin/valuemax/aria-label)
- 데모 13섹션

## Issues
#402-#418

## Test plan
- [ ] `npx tsc --noEmit` 통과 확인
- [ ] `npm run build` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)