### PR TITLE
feat(Combobox): 컴포넌트 + 데모 추가 (#249-#278)

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -13,8 +13,9 @@ import CommandPalettePage from "./pages/CommandPalettePage";
 import HexViewPage from "./pages/HexViewPage";
 import { PipelineGraphPage } from "./pages/PipelineGraphPage";
 import SelectPage from "./pages/SelectPage";
+import ComboboxPage from "./pages/ComboboxPage";
 
-type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select";
+type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select" | "combobox";
 
 interface SubItem { label: string; id: string }
 
@@ -183,6 +184,15 @@ const NAV: { id: Page; label: string; description: string; sections: SubItem[] }
     { label: "Props", id: "props" },
     { label: "Usage", id: "usage" },
     { label: "Playground", id: "playground" },
+  ]},
+  { id: "combobox", label: "Combobox", description: "검색형 선택 입력", sections: [
+    { label: "Basic", id: "basic" },
+    { label: "Grouped", id: "grouped" },
+    { label: "Multiple", id: "multiple" },
+    { label: "Controlled", id: "controlled" },
+    { label: "Freeform", id: "freeform" },
+    { label: "Dark Theme", id: "dark" },
+    { label: "Usage", id: "usage" },
   ]},
   { id: "dialog", label: "Dialog", description: "모달 다이얼로그", sections: [
     { label: "Basic", id: "basic" },
@@ -436,6 +446,7 @@ export function App() {
         {current === "hexview" && <HexViewPage />}
         {current === "pipelinegraph" && <PipelineGraphPage />}
         {current === "select" && <SelectPage />}
+        {current === "combobox" && <ComboboxPage />}
       </main>
     </div>
   );

--- a/demo/src/pages/ComboboxPage.tsx
+++ b/demo/src/pages/ComboboxPage.tsx
@@ -1,0 +1,302 @@
+import { useState, type ReactNode } from "react";
+import { CodeView, Combobox, type ComboboxOption } from "plastic";
+
+function Section({
+  id,
+  title,
+  desc,
+  children,
+}: {
+  id?: string;
+  title: string;
+  desc?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} className="mb-10">
+      <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-2">
+        {title}
+      </p>
+      {desc && <p className="text-sm text-gray-500 mb-3">{desc}</p>}
+      {children}
+    </section>
+  );
+}
+
+function Card({ children }: { children: ReactNode }) {
+  return (
+    <div className="p-6 bg-white rounded-lg border border-gray-200">
+      {children}
+    </div>
+  );
+}
+
+function DarkCard({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="p-6 rounded-lg border"
+      style={{ background: "#0b0c10", borderColor: "#23262d" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+const FRUITS: ComboboxOption[] = [
+  { value: "apple", label: "Apple" },
+  { value: "apricot", label: "Apricot" },
+  { value: "banana", label: "Banana" },
+  { value: "blueberry", label: "Blueberry" },
+  { value: "cherry", label: "Cherry" },
+  { value: "coconut", label: "Coconut" },
+  { value: "date", label: "Date" },
+  { value: "fig", label: "Fig" },
+  { value: "grape", label: "Grape" },
+  { value: "kiwi", label: "Kiwi" },
+  { value: "lemon", label: "Lemon" },
+  { value: "lime", label: "Lime" },
+  { value: "mango", label: "Mango" },
+  { value: "melon", label: "Melon" },
+  { value: "orange", label: "Orange" },
+  { value: "papaya", label: "Papaya" },
+  { value: "peach", label: "Peach" },
+  { value: "pear", label: "Pear" },
+  { value: "pineapple", label: "Pineapple" },
+  { value: "plum", label: "Plum" },
+];
+
+const GROUPED: ComboboxOption[] = [
+  { value: "react", label: "React", group: "Frontend" },
+  { value: "vue", label: "Vue", group: "Frontend" },
+  { value: "svelte", label: "Svelte", group: "Frontend" },
+  { value: "node", label: "Node.js", group: "Backend" },
+  { value: "deno", label: "Deno", group: "Backend" },
+  { value: "bun", label: "Bun", group: "Backend" },
+  { value: "postgres", label: "PostgreSQL", group: "Database" },
+  { value: "redis", label: "Redis", group: "Database" },
+];
+
+function BasicSection() {
+  return (
+    <Card>
+      <Combobox.Root options={FRUITS} placeholder="Pick a fruit…">
+        <Combobox.Input />
+        <Combobox.Content>
+          {FRUITS.map((opt) => (
+            <Combobox.Item key={opt.value} value={opt.value}>
+              {opt.label}
+            </Combobox.Item>
+          ))}
+          <Combobox.Empty>No matches</Combobox.Empty>
+        </Combobox.Content>
+      </Combobox.Root>
+    </Card>
+  );
+}
+
+function GroupedSection() {
+  const groups = Array.from(new Set(GROUPED.map((o) => o.group ?? "other")));
+  return (
+    <Card>
+      <Combobox.Root options={GROUPED} placeholder="Pick a tech…">
+        <Combobox.Input />
+        <Combobox.Content>
+          {groups.map((g) => (
+            <Combobox.Group key={g} heading={g}>
+              {GROUPED.filter((o) => (o.group ?? "other") === g).map((opt) => (
+                <Combobox.Item key={opt.value} value={opt.value}>
+                  {opt.label}
+                </Combobox.Item>
+              ))}
+            </Combobox.Group>
+          ))}
+          <Combobox.Empty>No matches</Combobox.Empty>
+        </Combobox.Content>
+      </Combobox.Root>
+    </Card>
+  );
+}
+
+function MultipleSection() {
+  return (
+    <Card>
+      <Combobox.Root multiple options={FRUITS} placeholder="Pick fruits…">
+        <Combobox.Input />
+        <Combobox.Content>
+          {FRUITS.map((opt) => (
+            <Combobox.Item key={opt.value} value={opt.value}>
+              {opt.label}
+            </Combobox.Item>
+          ))}
+          <Combobox.Empty>No matches</Combobox.Empty>
+        </Combobox.Content>
+      </Combobox.Root>
+    </Card>
+  );
+}
+
+function ControlledSection() {
+  const [value, setValue] = useState<string | null>("apple");
+  return (
+    <Card>
+      <div className="flex items-center gap-2 mb-3 text-xs text-gray-500">
+        <span>value:</span>
+        <code className="px-1.5 py-0.5 bg-gray-100 rounded">
+          {value ?? "null"}
+        </code>
+      </div>
+      <Combobox.Root
+        options={FRUITS}
+        value={value}
+        onValueChange={setValue}
+        placeholder="Pick a fruit…"
+      >
+        <Combobox.Input />
+        <Combobox.Content>
+          {FRUITS.map((opt) => (
+            <Combobox.Item key={opt.value} value={opt.value}>
+              {opt.label}
+            </Combobox.Item>
+          ))}
+        </Combobox.Content>
+      </Combobox.Root>
+    </Card>
+  );
+}
+
+function FreeformSection() {
+  const [value, setValue] = useState<string | null>(null);
+  return (
+    <Card>
+      <p className="text-xs text-gray-500 mb-2">
+        freeform: 옵션에 없는 값도 입력 가능. value: <code>{value ?? "null"}</code>
+      </p>
+      <Combobox.Root
+        freeform
+        options={FRUITS}
+        value={value}
+        onValueChange={setValue}
+        placeholder="Type or pick…"
+      >
+        <Combobox.Input />
+        <Combobox.Content>
+          {FRUITS.map((opt) => (
+            <Combobox.Item key={opt.value} value={opt.value}>
+              {opt.label}
+            </Combobox.Item>
+          ))}
+        </Combobox.Content>
+      </Combobox.Root>
+    </Card>
+  );
+}
+
+function DarkSection() {
+  return (
+    <DarkCard>
+      <Combobox.Root options={FRUITS} theme="dark" placeholder="Pick a fruit…">
+        <Combobox.Input />
+        <Combobox.Content>
+          {FRUITS.map((opt) => (
+            <Combobox.Item key={opt.value} value={opt.value}>
+              {opt.label}
+            </Combobox.Item>
+          ))}
+        </Combobox.Content>
+      </Combobox.Root>
+    </DarkCard>
+  );
+}
+
+const USAGE_BASIC = `import { Combobox } from "plastic";
+
+<Combobox.Root options={options} placeholder="Pick…">
+  <Combobox.Input />
+  <Combobox.Content>
+    {options.map((o) => (
+      <Combobox.Item key={o.value} value={o.value}>
+        {o.label}
+      </Combobox.Item>
+    ))}
+    <Combobox.Empty>No matches</Combobox.Empty>
+  </Combobox.Content>
+</Combobox.Root>`;
+
+const USAGE_MULTIPLE = `<Combobox.Root multiple options={options} />`;
+
+const USAGE_CONTROLLED = `<Combobox.Root
+  value={value}
+  onValueChange={setValue}
+  options={options}
+/>`;
+
+export default function ComboboxPage() {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <header className="mb-10">
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">Combobox</h1>
+        <p className="text-sm text-gray-500">
+          입력 가능한 옵션 선택. single/multiple, grouped, controlled, freeform,
+          dark theme 지원.
+        </p>
+      </header>
+
+      <Section id="basic" title="Basic">
+        <BasicSection />
+      </Section>
+
+      <Section id="grouped" title="Grouped">
+        <GroupedSection />
+      </Section>
+
+      <Section id="multiple" title="Multiple selection">
+        <MultipleSection />
+      </Section>
+
+      <Section id="controlled" title="Controlled">
+        <ControlledSection />
+      </Section>
+
+      <Section
+        id="freeform"
+        title="Freeform"
+        desc="freeform 모드에서 사용자 입력값도 그대로 채택."
+      >
+        <FreeformSection />
+      </Section>
+
+      <Section id="dark" title="Dark Theme">
+        <DarkSection />
+      </Section>
+
+      <Section id="usage" title="Usage">
+        <div className="space-y-4">
+          <Card>
+            <p className="text-xs text-gray-500 mb-2">Basic</p>
+            <CodeView
+              code={USAGE_BASIC}
+              language="tsx"
+              showLineNumbers={false}
+            />
+          </Card>
+          <Card>
+            <p className="text-xs text-gray-500 mb-2">Multiple</p>
+            <CodeView
+              code={USAGE_MULTIPLE}
+              language="tsx"
+              showLineNumbers={false}
+            />
+          </Card>
+          <Card>
+            <p className="text-xs text-gray-500 mb-2">Controlled</p>
+            <CodeView
+              code={USAGE_CONTROLLED}
+              language="tsx"
+              showLineNumbers={false}
+            />
+          </Card>
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -1,0 +1,19 @@
+import { ComboboxRoot } from "./ComboboxRoot";
+import { ComboboxInput } from "./ComboboxInput";
+import { ComboboxTrigger } from "./ComboboxTrigger";
+import { ComboboxContent } from "./ComboboxContent";
+import { ComboboxItem } from "./ComboboxItem";
+import { ComboboxGroup } from "./ComboboxGroup";
+import { ComboboxEmpty } from "./ComboboxEmpty";
+import { ComboboxLoading } from "./ComboboxLoading";
+
+export const Combobox = {
+  Root: ComboboxRoot,
+  Input: ComboboxInput,
+  Trigger: ComboboxTrigger,
+  Content: ComboboxContent,
+  Item: ComboboxItem,
+  Group: ComboboxGroup,
+  Empty: ComboboxEmpty,
+  Loading: ComboboxLoading,
+};

--- a/src/components/Combobox/Combobox.types.ts
+++ b/src/components/Combobox/Combobox.types.ts
@@ -1,0 +1,164 @@
+import type {
+  CSSProperties,
+  HTMLAttributes,
+  InputHTMLAttributes,
+  ButtonHTMLAttributes,
+  ReactNode,
+} from "react";
+
+export type ComboboxTheme = "light" | "dark";
+
+export interface ComboboxOption<Meta = unknown> {
+  value: string;
+  label: string;
+  group?: string | undefined;
+  disabled?: boolean | undefined;
+  keywords?: string[] | undefined;
+  meta?: Meta | undefined;
+}
+
+export interface ComboboxMatchResult {
+  option: ComboboxOption;
+  score: number;
+  labelMatches: number[];
+}
+
+export type ComboboxFilter = (
+  query: string,
+  options: ComboboxOption[],
+) => ComboboxOption[] | ComboboxMatchResult[];
+
+export interface ComboboxRootPropsSingle
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange" | "defaultValue"> {
+  multiple?: false | undefined;
+
+  value?: string | null | undefined;
+  defaultValue?: string | null | undefined;
+  onValueChange?: ((next: string | null) => void) | undefined;
+
+  options?: ComboboxOption[] | undefined;
+
+  inputValue?: string | undefined;
+  defaultInputValue?: string | undefined;
+  onInputValueChange?: ((next: string) => void) | undefined;
+
+  open?: boolean | undefined;
+  defaultOpen?: boolean | undefined;
+  onOpenChange?: ((open: boolean) => void) | undefined;
+
+  filter?: ComboboxFilter | undefined;
+  onSearch?: ((query: string) => Promise<ComboboxOption[]>) | undefined;
+  searchDebounce?: number | undefined;
+  minChars?: number | undefined;
+  maxResults?: number | undefined;
+
+  freeform?: boolean | undefined;
+  strict?: boolean | undefined;
+
+  disabled?: boolean | undefined;
+  readOnly?: boolean | undefined;
+  placeholder?: string | undefined;
+
+  theme?: ComboboxTheme | undefined;
+
+  getOptionLabel?: ((value: string) => string) | undefined;
+
+  children?: ReactNode | undefined;
+}
+
+export interface ComboboxRootPropsMultiple
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange" | "defaultValue"> {
+  multiple: true;
+
+  value?: string[] | undefined;
+  defaultValue?: string[] | undefined;
+  onValueChange?: ((next: string[]) => void) | undefined;
+
+  options?: ComboboxOption[] | undefined;
+
+  inputValue?: string | undefined;
+  defaultInputValue?: string | undefined;
+  onInputValueChange?: ((next: string) => void) | undefined;
+
+  open?: boolean | undefined;
+  defaultOpen?: boolean | undefined;
+  onOpenChange?: ((open: boolean) => void) | undefined;
+
+  filter?: ComboboxFilter | undefined;
+  onSearch?: ((query: string) => Promise<ComboboxOption[]>) | undefined;
+  searchDebounce?: number | undefined;
+  minChars?: number | undefined;
+  maxResults?: number | undefined;
+
+  freeform?: boolean | undefined;
+  strict?: boolean | undefined;
+
+  disabled?: boolean | undefined;
+  readOnly?: boolean | undefined;
+  placeholder?: string | undefined;
+
+  theme?: ComboboxTheme | undefined;
+
+  getOptionLabel?: ((value: string) => string) | undefined;
+
+  children?: ReactNode | undefined;
+}
+
+export type ComboboxRootProps =
+  | ComboboxRootPropsSingle
+  | ComboboxRootPropsMultiple;
+
+export interface ComboboxInputProps
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    "value" | "onChange" | "type" | "disabled" | "readOnly"
+  > {
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface ComboboxTriggerProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick"> {
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  plain?: boolean | undefined;
+}
+
+export interface ComboboxContentProps extends HTMLAttributes<HTMLDivElement> {
+  maxHeight?: number | string | undefined;
+  offset?: number | undefined;
+  placement?: "bottom-start" | "top-start" | "auto" | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+  children?: ReactNode | undefined;
+}
+
+export interface ComboboxItemProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onSelect"> {
+  value: string;
+  label?: string | undefined;
+  disabled?: boolean | undefined;
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface ComboboxGroupProps extends HTMLAttributes<HTMLDivElement> {
+  heading: string;
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface ComboboxEmptyProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}
+
+export interface ComboboxLoadingProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode | undefined;
+  className?: string | undefined;
+  style?: CSSProperties | undefined;
+}

--- a/src/components/Combobox/ComboboxContent.tsx
+++ b/src/components/Combobox/ComboboxContent.tsx
@@ -1,0 +1,7 @@
+import type { ComboboxContentProps } from "./Combobox.types";
+
+export function ComboboxContent(_props: ComboboxContentProps) {
+  return null;
+}
+
+ComboboxContent.displayName = "Combobox.Content";

--- a/src/components/Combobox/ComboboxContent.tsx
+++ b/src/components/Combobox/ComboboxContent.tsx
@@ -1,7 +1,245 @@
-import type { ComboboxContentProps } from "./Combobox.types";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  Children,
+  isValidElement,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import { useComboboxContext } from "./ComboboxContext";
+import { comboboxPalette } from "./colors";
+import { ComboboxItem } from "./ComboboxItem";
+import { ComboboxEmpty } from "./ComboboxEmpty";
+import { ComboboxLoading } from "./ComboboxLoading";
+import { ComboboxGroup } from "./ComboboxGroup";
+import type { ComboboxContentProps, ComboboxOption } from "./Combobox.types";
 
-export function ComboboxContent(_props: ComboboxContentProps) {
-  return null;
+function hasEmptyChild(children: ReactNode): boolean {
+  let found = false;
+  Children.forEach(children, (c) => {
+    if (isValidElement(c) && c.type === ComboboxEmpty) found = true;
+  });
+  return found;
+}
+
+function hasLoadingChild(children: ReactNode): boolean {
+  let found = false;
+  Children.forEach(children, (c) => {
+    if (isValidElement(c) && c.type === ComboboxLoading) found = true;
+  });
+  return found;
+}
+
+function hasItemOrGroupChild(children: ReactNode): boolean {
+  let found = false;
+  Children.forEach(children, (c) => {
+    if (isValidElement(c) && (c.type === ComboboxItem || c.type === ComboboxGroup)) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+function groupByGroup(options: ComboboxOption[]): Array<{
+  heading: string | null;
+  items: ComboboxOption[];
+}> {
+  const groups: Array<{ heading: string | null; items: ComboboxOption[] }> = [];
+  const indexByHeading = new Map<string | null, number>();
+  for (const o of options) {
+    const key = o.group ?? null;
+    const idx = indexByHeading.get(key);
+    if (idx === undefined) {
+      indexByHeading.set(key, groups.length);
+      groups.push({ heading: key, items: [o] });
+    } else {
+      const g = groups[idx];
+      if (g) g.items.push(o);
+    }
+  }
+  return groups;
+}
+
+export function ComboboxContent(props: ComboboxContentProps) {
+  const {
+    maxHeight,
+    offset = 4,
+    placement: placementProp = "bottom-start",
+    className,
+    style,
+    children,
+    ...rest
+  } = props;
+
+  const ctx = useComboboxContext();
+  const {
+    open,
+    theme,
+    anchorRef,
+    listRef,
+    listId,
+    results,
+    isLoading,
+    multiple,
+  } = ctx;
+  const p = comboboxPalette[theme];
+
+  const [coords, setCoords] = useState<{
+    top: number;
+    left: number;
+    width: number;
+    placement: "bottom-start" | "top-start";
+  }>({ top: 0, left: 0, width: 0, placement: "bottom-start" });
+
+  const computePosition = useCallback(() => {
+    const anchor = anchorRef.current;
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    const listEl = listRef.current;
+    const listH = listEl ? listEl.offsetHeight : 160;
+
+    let place: "bottom-start" | "top-start" = "bottom-start";
+    if (placementProp === "top-start") place = "top-start";
+    else if (placementProp === "auto") {
+      place =
+        spaceBelow < Math.min(listH + offset, 160) && spaceAbove > spaceBelow
+          ? "top-start"
+          : "bottom-start";
+    } else {
+      if (spaceBelow < listH + offset && spaceAbove > spaceBelow) {
+        place = "top-start";
+      }
+    }
+
+    const top =
+      place === "bottom-start" ? rect.bottom + offset : rect.top - listH - offset;
+    setCoords({ top, left: rect.left, width: rect.width, placement: place });
+  }, [anchorRef, listRef, offset, placementProp]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    computePosition();
+  }, [open, computePosition]);
+
+  useEffect(() => {
+    if (!open) return;
+    const anchor = anchorRef.current;
+    if (!anchor) return;
+    const onScroll = () => computePosition();
+    window.addEventListener("resize", onScroll, { passive: true });
+    window.addEventListener("scroll", onScroll, { passive: true, capture: true });
+    const ro = new ResizeObserver(() => computePosition());
+    ro.observe(anchor);
+    const listEl = listRef.current;
+    if (listEl) ro.observe(listEl);
+    return () => {
+      window.removeEventListener("resize", onScroll);
+      window.removeEventListener("scroll", onScroll, { capture: true } as EventListenerOptions);
+      ro.disconnect();
+    };
+  }, [open, computePosition, anchorRef, listRef]);
+
+  const listRefCallback = useCallback(
+    (node: HTMLDivElement | null) => {
+      (listRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+    },
+    [listRef],
+  );
+
+  if (!open) return null;
+
+  const renderFallback = () => {
+    const groups = groupByGroup(results);
+    const nodes: ReactNode[] = [];
+    for (const g of groups) {
+      if (g.heading !== null) {
+        nodes.push(
+          <ComboboxGroup key={`g-${g.heading}`} heading={g.heading}>
+            {g.items.map((o) => (
+              <ComboboxItem
+                key={o.value}
+                value={o.value}
+                label={o.label}
+                disabled={o.disabled ?? false}
+              />
+            ))}
+          </ComboboxGroup>,
+        );
+      } else {
+        for (const o of g.items) {
+          nodes.push(
+            <ComboboxItem
+              key={o.value}
+              value={o.value}
+              label={o.label}
+              disabled={o.disabled ?? false}
+            />,
+          );
+        }
+      }
+    }
+    return nodes;
+  };
+
+  const userHasItemOrGroup = hasItemOrGroupChild(children);
+  const userHasEmpty = hasEmptyChild(children);
+  const userHasLoading = hasLoadingChild(children);
+  const showEmpty = !isLoading && results.length === 0;
+  const showLoading = isLoading;
+
+  const maxH =
+    maxHeight === undefined
+      ? "min(320px, 40vh)"
+      : typeof maxHeight === "number"
+        ? `${maxHeight}px`
+        : maxHeight;
+
+  const containerStyle: CSSProperties = {
+    position: "fixed",
+    top: coords.top,
+    left: coords.left,
+    width: coords.width,
+    maxHeight: maxH,
+    overflowY: "auto",
+    background: p.contentBg,
+    border: `1px solid ${p.contentBorder}`,
+    borderRadius: 6,
+    boxShadow: p.contentShadow,
+    padding: 4,
+    zIndex: 9999,
+    boxSizing: "border-box",
+    ...style,
+  };
+
+  return (
+    <div
+      ref={listRefCallback}
+      id={listId}
+      role="listbox"
+      tabIndex={-1}
+      aria-multiselectable={multiple || undefined}
+      data-state={open ? "open" : "closed"}
+      data-placement={coords.placement}
+      className={className}
+      style={containerStyle}
+      {...rest}
+    >
+      {showLoading && !userHasLoading && (
+        <ComboboxLoading>Loading...</ComboboxLoading>
+      )}
+      {showLoading && userHasLoading && children}
+      {!showLoading && showEmpty && !userHasEmpty && (
+        <ComboboxEmpty>No results</ComboboxEmpty>
+      )}
+      {!showLoading && showEmpty && userHasEmpty && children}
+      {!showLoading && !showEmpty && (userHasItemOrGroup ? children : renderFallback())}
+      {!showLoading && !showEmpty && !userHasItemOrGroup && userHasEmpty && null}
+    </div>
+  );
 }
 
 ComboboxContent.displayName = "Combobox.Content";

--- a/src/components/Combobox/ComboboxContext.ts
+++ b/src/components/Combobox/ComboboxContext.ts
@@ -1,0 +1,60 @@
+import { createContext, useContext } from "react";
+import type { RefObject } from "react";
+import type {
+  ComboboxOption,
+  ComboboxMatchResult,
+  ComboboxTheme,
+} from "./Combobox.types";
+
+export interface ComboboxContextValue {
+  listId: string;
+  getItemId: (value: string) => string;
+  theme: ComboboxTheme;
+  disabled: boolean;
+  readOnly: boolean;
+
+  multiple: boolean;
+  freeform: boolean;
+  strict: boolean;
+
+  placeholder: string | undefined;
+  minChars: number;
+  maxResults: number;
+
+  value: string[] | string | null;
+  open: boolean;
+  setOpen: (next: boolean) => void;
+  inputValue: string;
+  setInputValue: (next: string) => void;
+
+  options: ComboboxOption[];
+  results: ComboboxOption[];
+  matches: Map<string, ComboboxMatchResult>;
+  isLoading: boolean;
+  activeIndex: number;
+  setActiveIndex: (i: number) => void;
+
+  selectOption: (opt: ComboboxOption) => void;
+  commitFreeform: (text: string) => void;
+  removeValue: (v: string) => void;
+  clearAll: () => void;
+
+  inputRef: RefObject<HTMLInputElement | null>;
+  anchorRef: RefObject<HTMLDivElement | null>;
+  listRef: RefObject<HTMLDivElement | null>;
+  getOptionLabel: (value: string) => string;
+
+  registerItemNode: (value: string, node: HTMLElement | null) => void;
+}
+
+export const ComboboxContext = createContext<ComboboxContextValue | null>(null);
+
+export function useComboboxContext(): ComboboxContextValue {
+  const ctx = useContext(ComboboxContext);
+  if (ctx === null) {
+    throw new Error(
+      "Combobox compound components must be used within <Combobox.Root>",
+    );
+  }
+  return ctx;
+}

--- a/src/components/Combobox/ComboboxEmpty.tsx
+++ b/src/components/Combobox/ComboboxEmpty.tsx
@@ -1,0 +1,7 @@
+import type { ComboboxEmptyProps } from "./Combobox.types";
+
+export function ComboboxEmpty(_props: ComboboxEmptyProps) {
+  return null;
+}
+
+ComboboxEmpty.displayName = "Combobox.Empty";

--- a/src/components/Combobox/ComboboxGroup.tsx
+++ b/src/components/Combobox/ComboboxGroup.tsx
@@ -1,7 +1,43 @@
+import { useId, type CSSProperties } from "react";
+import { useComboboxContext } from "./ComboboxContext";
+import { comboboxPalette } from "./colors";
 import type { ComboboxGroupProps } from "./Combobox.types";
 
-export function ComboboxGroup(_props: ComboboxGroupProps) {
-  return null;
+export function ComboboxGroup(props: ComboboxGroupProps) {
+  const { heading, children, className, style, ...rest } = props;
+  const ctx = useComboboxContext();
+  const p = comboboxPalette[ctx.theme];
+  const headingId = useId();
+
+  const groupStyle: CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    ...style,
+  };
+
+  const headingStyle: CSSProperties = {
+    fontSize: 11,
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+    color: p.groupHeadingFg,
+    padding: "6px 8px 4px 8px",
+    fontWeight: 500,
+  };
+
+  return (
+    <div
+      role="group"
+      aria-labelledby={headingId}
+      className={className}
+      style={groupStyle}
+      {...rest}
+    >
+      <div id={headingId} style={headingStyle}>
+        {heading}
+      </div>
+      {children}
+    </div>
+  );
 }
 
 ComboboxGroup.displayName = "Combobox.Group";

--- a/src/components/Combobox/ComboboxGroup.tsx
+++ b/src/components/Combobox/ComboboxGroup.tsx
@@ -1,0 +1,7 @@
+import type { ComboboxGroupProps } from "./Combobox.types";
+
+export function ComboboxGroup(_props: ComboboxGroupProps) {
+  return null;
+}
+
+ComboboxGroup.displayName = "Combobox.Group";

--- a/src/components/Combobox/ComboboxInput.tsx
+++ b/src/components/Combobox/ComboboxInput.tsx
@@ -1,0 +1,7 @@
+import type { ComboboxInputProps } from "./Combobox.types";
+
+export function ComboboxInput(_props: ComboboxInputProps) {
+  return null;
+}
+
+ComboboxInput.displayName = "Combobox.Input";

--- a/src/components/Combobox/ComboboxInput.tsx
+++ b/src/components/Combobox/ComboboxInput.tsx
@@ -1,7 +1,435 @@
+import {
+  useCallback,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ChangeEvent,
+  type FocusEvent as ReactFocusEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import { useComboboxContext } from "./ComboboxContext";
+import { comboboxPalette } from "./colors";
 import type { ComboboxInputProps } from "./Combobox.types";
 
-export function ComboboxInput(_props: ComboboxInputProps) {
-  return null;
+interface ChipProps {
+  value: string;
+  label: string;
+  disabled: boolean;
+  onRemove: () => void;
+}
+
+function Chip({ value, label, disabled, onRemove }: ChipProps) {
+  const ctx = useComboboxContext();
+  const p = comboboxPalette[ctx.theme];
+  const [hovered, setHovered] = useState(false);
+
+  const chipStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 4,
+    height: 22,
+    padding: "0 6px",
+    borderRadius: 4,
+    background: p.chipBg,
+    border: `1px solid ${p.chipBorder}`,
+    color: p.chipFg,
+    fontSize: 12,
+    lineHeight: 1,
+    userSelect: "none",
+    opacity: disabled ? 0.5 : 1,
+  };
+
+  const removeStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 14,
+    height: 14,
+    borderRadius: 3,
+    border: "none",
+    background: hovered ? "rgba(0,0,0,0.06)" : "transparent",
+    color: p.chipRemoveFg,
+    cursor: disabled ? "not-allowed" : "pointer",
+    padding: 0,
+    fontSize: 11,
+    lineHeight: 1,
+  };
+
+  const handleClick = (e: ReactMouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (disabled) return;
+    onRemove();
+  };
+
+  return (
+    <span style={chipStyle} data-value={value}>
+      <span>{label}</span>
+      <button
+        type="button"
+        aria-label={`Remove ${label}`}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={handleClick}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        disabled={disabled}
+        style={removeStyle}
+        tabIndex={-1}
+      >
+        {"\u00D7"}
+      </button>
+    </span>
+  );
+}
+
+export function ComboboxInput(props: ComboboxInputProps) {
+  const {
+    className,
+    style,
+    placeholder: placeholderProp,
+    onKeyDown: userKeyDown,
+    onFocus: userFocus,
+    onBlur: userBlur,
+    onCompositionStart: userCompositionStart,
+    onCompositionEnd: userCompositionEnd,
+    ...rest
+  } = props;
+
+  const ctx = useComboboxContext();
+  const {
+    theme,
+    disabled,
+    readOnly,
+    multiple,
+    placeholder: ctxPlaceholder,
+    inputValue,
+    setInputValue,
+    open,
+    setOpen,
+    value,
+    removeValue,
+    getOptionLabel,
+    inputRef,
+    listId,
+    getItemId,
+    results,
+    activeIndex,
+  } = ctx;
+
+  const p = comboboxPalette[theme];
+  const composingRef = useRef(false);
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+
+  const placeholder = placeholderProp ?? ctxPlaceholder;
+
+  const chips = multiple && Array.isArray(value) ? value : [];
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (readOnly || disabled) return;
+    setInputValue(e.target.value);
+    if (!open) setOpen(true);
+  };
+
+  const handleFocus = (e: ReactFocusEvent<HTMLInputElement>) => {
+    userFocus?.(e);
+    setFocused(true);
+    if (!disabled && !open) setOpen(true);
+  };
+
+  const handleBlur = (e: ReactFocusEvent<HTMLInputElement>) => {
+    userBlur?.(e);
+    setFocused(false);
+  };
+
+  const handleCompositionStart = (
+    e: React.CompositionEvent<HTMLInputElement>,
+  ) => {
+    composingRef.current = true;
+    userCompositionStart?.(e);
+  };
+
+  const handleCompositionEnd = (
+    e: React.CompositionEvent<HTMLInputElement>,
+  ) => {
+    composingRef.current = false;
+    userCompositionEnd?.(e);
+  };
+
+  const handleAnchorMouseDown = useCallback(
+    (e: ReactMouseEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      if (e.target === inputRef.current) return;
+      const input = inputRef.current;
+      if (input && document.activeElement !== input) {
+        e.preventDefault();
+        input.focus();
+      }
+    },
+    [disabled, inputRef],
+  );
+
+  const isComposing = () => composingRef.current;
+
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLInputElement>) => {
+      userKeyDown?.(e);
+      if (e.defaultPrevented) return;
+      if (isComposing()) return;
+      if (disabled) return;
+
+      const N = results.length;
+
+      switch (e.key) {
+        case "ArrowDown": {
+          e.preventDefault();
+          if (!open) {
+            setOpen(true);
+            ctx.setActiveIndex(0);
+            return;
+          }
+          if (N > 0) {
+            ctx.setActiveIndex((activeIndex + 1) % N);
+          }
+          return;
+        }
+        case "ArrowUp": {
+          if (!open) return;
+          e.preventDefault();
+          if (N > 0) {
+            ctx.setActiveIndex((activeIndex - 1 + N) % N);
+          }
+          return;
+        }
+        case "Home": {
+          if (!open) return;
+          e.preventDefault();
+          ctx.setActiveIndex(0);
+          return;
+        }
+        case "End": {
+          if (!open) return;
+          e.preventDefault();
+          ctx.setActiveIndex(Math.max(0, N - 1));
+          return;
+        }
+        case "PageDown": {
+          if (!open) return;
+          e.preventDefault();
+          ctx.setActiveIndex(Math.min(N - 1, activeIndex + 10));
+          return;
+        }
+        case "PageUp": {
+          if (!open) return;
+          e.preventDefault();
+          ctx.setActiveIndex(Math.max(0, activeIndex - 10));
+          return;
+        }
+        case "Enter": {
+          if (open && N > 0 && activeIndex >= 0 && activeIndex < N) {
+            e.preventDefault();
+            const opt = results[activeIndex];
+            if (opt) ctx.selectOption(opt);
+            return;
+          }
+          if (open && N === 0 && ctx.freeform) {
+            e.preventDefault();
+            ctx.commitFreeform(inputValue);
+            return;
+          }
+          if (!open && ctx.freeform) {
+            e.preventDefault();
+            ctx.commitFreeform(inputValue);
+            return;
+          }
+          return;
+        }
+        case "Escape": {
+          if (open) {
+            e.preventDefault();
+            setOpen(false);
+            return;
+          }
+          if (multiple && inputValue) {
+            e.preventDefault();
+            setInputValue("");
+            return;
+          }
+          if (!multiple && ctx.strict) {
+            const v = typeof value === "string" ? value : null;
+            if (v != null) {
+              setInputValue(getOptionLabel(v));
+            } else {
+              setInputValue("");
+            }
+            return;
+          }
+          return;
+        }
+        case "Tab": {
+          if (
+            open &&
+            N > 0 &&
+            activeIndex >= 0 &&
+            activeIndex < N
+          ) {
+            const opt = results[activeIndex];
+            if (opt) {
+              const lower = opt.label.toLowerCase();
+              const q = inputValue.toLowerCase();
+              if (lower.startsWith(q) && q.length > 0 && q.length < opt.label.length) {
+                e.preventDefault();
+                setInputValue(opt.label);
+                return;
+              }
+            }
+          }
+          if (open) setOpen(false);
+          if (!multiple && ctx.strict) {
+            const v = typeof value === "string" ? value : null;
+            const label = v != null ? getOptionLabel(v) : "";
+            if (inputValue !== label) setInputValue(label);
+          }
+          return;
+        }
+        case "Backspace": {
+          if (multiple && inputValue === "" && Array.isArray(value) && value.length > 0) {
+            e.preventDefault();
+            const last = value[value.length - 1];
+            if (last !== undefined) removeValue(last);
+            return;
+          }
+          return;
+        }
+        default: {
+          if (e.altKey && e.key === "ArrowDown") {
+            e.preventDefault();
+            setOpen(true);
+            return;
+          }
+          if (e.altKey && e.key === "ArrowUp") {
+            e.preventDefault();
+            setOpen(false);
+            return;
+          }
+          return;
+        }
+      }
+    },
+    [
+      userKeyDown,
+      disabled,
+      results,
+      open,
+      setOpen,
+      activeIndex,
+      ctx,
+      inputValue,
+      setInputValue,
+      multiple,
+      value,
+      getOptionLabel,
+      removeValue,
+    ],
+  );
+
+  const inputRefCallback = useCallback(
+    (node: HTMLInputElement | null) => {
+      (inputRef as React.MutableRefObject<HTMLInputElement | null>).current =
+        node;
+    },
+    [inputRef],
+  );
+
+  const borderColor = disabled
+    ? p.anchorBorder
+    : focused
+      ? p.anchorBorderFocus
+      : hovered
+        ? p.anchorBorderHover
+        : p.anchorBorder;
+
+  const anchorStyle: CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: 4,
+    flexWrap: "wrap",
+    minHeight: 36,
+    padding: "4px 10px",
+    borderRadius: 6,
+    background: p.anchorBg,
+    border: `1px solid ${borderColor}`,
+    boxShadow: focused ? `0 0 0 2px ${p.focusRing}33` : "none",
+    transition: "border-color 120ms ease, box-shadow 120ms ease",
+    cursor: disabled ? "not-allowed" : "text",
+    opacity: disabled ? 0.6 : 1,
+    boxSizing: "border-box",
+    width: "100%",
+  };
+
+  const inputStyle: CSSProperties = {
+    flex: 1,
+    minWidth: 60,
+    height: 26,
+    border: "none",
+    outline: "none",
+    background: "transparent",
+    color: p.anchorFg,
+    fontSize: 14,
+    fontFamily: "inherit",
+    padding: 0,
+    ...style,
+  };
+
+  const activeValue =
+    open && results[activeIndex] ? results[activeIndex].value : undefined;
+  const activeId = activeValue !== undefined ? getItemId(activeValue) : undefined;
+
+  return (
+    <div
+      style={anchorStyle}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onMouseDown={handleAnchorMouseDown}
+      data-state={open ? "open" : "closed"}
+    >
+      {multiple &&
+        chips.map((v) => (
+          <Chip
+            key={v}
+            value={v}
+            label={getOptionLabel(v)}
+            disabled={disabled}
+            onRemove={() => removeValue(v)}
+          />
+        ))}
+      <input
+        ref={inputRefCallback}
+        className={className}
+        type="text"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-activedescendant={activeId}
+        aria-disabled={disabled || undefined}
+        aria-readonly={readOnly || undefined}
+        disabled={disabled}
+        readOnly={readOnly}
+        placeholder={chips.length > 0 ? undefined : placeholder}
+        value={inputValue}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onCompositionStart={handleCompositionStart}
+        onCompositionEnd={handleCompositionEnd}
+        style={inputStyle}
+        {...rest}
+      />
+    </div>
+  );
 }
 
 ComboboxInput.displayName = "Combobox.Input";

--- a/src/components/Combobox/ComboboxItem.tsx
+++ b/src/components/Combobox/ComboboxItem.tsx
@@ -1,0 +1,7 @@
+import type { ComboboxItemProps } from "./Combobox.types";
+
+export function ComboboxItem(_props: ComboboxItemProps) {
+  return null;
+}
+
+ComboboxItem.displayName = "Combobox.Item";

--- a/src/components/Combobox/ComboboxItem.tsx
+++ b/src/components/Combobox/ComboboxItem.tsx
@@ -1,7 +1,184 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
+import { useComboboxContext } from "./ComboboxContext";
+import { comboboxPalette } from "./colors";
 import type { ComboboxItemProps } from "./Combobox.types";
 
-export function ComboboxItem(_props: ComboboxItemProps) {
-  return null;
+function renderHighlighted(
+  label: string,
+  indices: number[],
+  markColor: string,
+): ReactNode {
+  if (indices.length === 0) return label;
+  const out: ReactNode[] = [];
+  let cursor = 0;
+  const markStyle: CSSProperties = {
+    background: "transparent",
+    color: markColor,
+    fontWeight: 600,
+    textDecoration: "underline",
+    textUnderlineOffset: 2,
+  };
+  for (const idx of indices) {
+    if (idx > cursor) out.push(label.slice(cursor, idx));
+    out.push(
+      <mark key={`m-${idx}`} style={markStyle}>
+        {label[idx]}
+      </mark>,
+    );
+    cursor = idx + 1;
+  }
+  if (cursor < label.length) out.push(label.slice(cursor));
+  return out;
+}
+
+export function ComboboxItem(props: ComboboxItemProps) {
+  const {
+    value,
+    label: labelProp,
+    disabled = false,
+    className,
+    style,
+    children,
+    onClick: userClick,
+    ...rest
+  } = props;
+
+  const ctx = useComboboxContext();
+  const {
+    theme,
+    results,
+    activeIndex,
+    setActiveIndex,
+    selectOption,
+    matches,
+    getItemId,
+    listRef,
+    multiple,
+    value: ctxValue,
+    registerItemNode,
+  } = ctx;
+  const p = comboboxPalette[theme];
+
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+  const index = results.findIndex((o) => o.value === value);
+  const isActive = index !== -1 && index === activeIndex;
+
+  const isSelected = multiple
+    ? Array.isArray(ctxValue) && ctxValue.includes(value)
+    : ctxValue === value;
+
+  const refCallback = useCallback(
+    (node: HTMLDivElement | null) => {
+      nodeRef.current = node;
+      registerItemNode(value, node);
+    },
+    [registerItemNode, value],
+  );
+
+  useEffect(() => {
+    return () => {
+      registerItemNode(value, null);
+    };
+  }, [value, registerItemNode]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const node = nodeRef.current;
+    const list = listRef.current;
+    if (!node || !list) return;
+    const nRect = node.getBoundingClientRect();
+    const lRect = list.getBoundingClientRect();
+    if (nRect.top < lRect.top || nRect.bottom > lRect.bottom) {
+      node.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  }, [isActive, listRef]);
+
+  const handleClick = useCallback(
+    (e: ReactMouseEvent<HTMLDivElement>) => {
+      userClick?.(e);
+      if (disabled) return;
+      const opt = results[index];
+      if (opt) selectOption(opt);
+    },
+    [userClick, disabled, results, index, selectOption],
+  );
+
+  const handleMouseMove = useCallback(() => {
+    if (disabled) return;
+    if (index !== -1 && index !== activeIndex) {
+      setActiveIndex(index);
+    }
+  }, [disabled, index, activeIndex, setActiveIndex]);
+
+  const match = matches.get(value);
+  const resolvedLabel = labelProp ?? (typeof children === "string" ? children : value);
+
+  const itemStyle: CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    height: 32,
+    padding: "0 8px",
+    borderRadius: 4,
+    fontSize: 14,
+    lineHeight: "20px",
+    cursor: disabled ? "not-allowed" : "pointer",
+    color: disabled ? p.itemFgDisabled : p.itemFg,
+    background: isActive && !disabled ? p.itemBgActive : "transparent",
+    userSelect: "none",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    ...style,
+  };
+
+  const content =
+    children !== undefined && typeof children !== "string" ? (
+      children
+    ) : (
+      <span
+        style={{
+          flex: 1,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {match && match.labelMatches.length > 0
+          ? renderHighlighted(resolvedLabel, match.labelMatches, p.itemMarkFg)
+          : resolvedLabel}
+      </span>
+    );
+
+  return (
+    <div
+      ref={refCallback}
+      id={getItemId(value)}
+      role="option"
+      aria-selected={isSelected}
+      aria-disabled={disabled || undefined}
+      data-active={isActive || undefined}
+      data-disabled={disabled || undefined}
+      data-selected={isSelected || undefined}
+      data-value={value}
+      className={className}
+      style={itemStyle}
+      onClick={handleClick}
+      onMouseMove={handleMouseMove}
+      onMouseDown={(e) => e.preventDefault()}
+      title={resolvedLabel}
+      {...rest}
+    >
+      {content}
+    </div>
+  );
 }
 
 ComboboxItem.displayName = "Combobox.Item";

--- a/src/components/Combobox/ComboboxLoading.tsx
+++ b/src/components/Combobox/ComboboxLoading.tsx
@@ -1,0 +1,7 @@
+import type { ComboboxLoadingProps } from "./Combobox.types";
+
+export function ComboboxLoading(_props: ComboboxLoadingProps) {
+  return null;
+}
+
+ComboboxLoading.displayName = "Combobox.Loading";

--- a/src/components/Combobox/ComboboxRoot.tsx
+++ b/src/components/Combobox/ComboboxRoot.tsx
@@ -1,7 +1,387 @@
-import type { ComboboxRootProps } from "./Combobox.types";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useControllable } from "../_shared/useControllable";
+import { ComboboxContext, type ComboboxContextValue } from "./ComboboxContext";
+import { filterOptions } from "./filter";
+import type {
+  ComboboxMatchResult,
+  ComboboxOption,
+  ComboboxRootProps,
+  ComboboxRootPropsMultiple,
+  ComboboxRootPropsSingle,
+  ComboboxTheme,
+} from "./Combobox.types";
 
-export function ComboboxRoot(_props: ComboboxRootProps) {
-  return null;
+function isMultipleProps(
+  p: ComboboxRootProps,
+): p is ComboboxRootPropsMultiple {
+  return p.multiple === true;
+}
+
+export function ComboboxRoot(props: ComboboxRootProps) {
+  const multiple = isMultipleProps(props);
+  const {
+    options: propOptions,
+    inputValue: controlledInputValue,
+    defaultInputValue,
+    onInputValueChange,
+    open: controlledOpen,
+    defaultOpen,
+    onOpenChange,
+    filter,
+    onSearch,
+    searchDebounce = 200,
+    minChars = 0,
+    maxResults = 50,
+    freeform = false,
+    strict,
+    disabled = false,
+    readOnly = false,
+    placeholder,
+    theme = "light" as ComboboxTheme,
+    getOptionLabel: getOptionLabelProp,
+    children,
+    style,
+    className,
+  } = props;
+
+  const options = useMemo<ComboboxOption[]>(
+    () => propOptions ?? [],
+    [propOptions],
+  );
+
+  const isFreeform = freeform === true && strict !== true;
+  const isStrict = !isFreeform;
+
+  const listId = useId();
+  const itemIdPrefix = useId();
+
+  const getItemId = useCallback(
+    (value: string) => `${itemIdPrefix}-${value}`,
+    [itemIdPrefix],
+  );
+
+  const [internalValueSingle, setInternalValueSingle] = useState<string | null>(
+    () => {
+      if (multiple) return null;
+      const sp = props as ComboboxRootPropsSingle;
+      return sp.defaultValue ?? null;
+    },
+  );
+  const [internalValueMulti, setInternalValueMulti] = useState<string[]>(() => {
+    if (!multiple) return [];
+    const mp = props as ComboboxRootPropsMultiple;
+    return mp.defaultValue ?? [];
+  });
+
+  const singleControlled = !multiple
+    ? (props as ComboboxRootPropsSingle).value !== undefined
+    : false;
+  const multiControlled = multiple
+    ? (props as ComboboxRootPropsMultiple).value !== undefined
+    : false;
+
+  const valueRaw: string | string[] | null = multiple
+    ? multiControlled
+      ? ((props as ComboboxRootPropsMultiple).value ?? [])
+      : internalValueMulti
+    : singleControlled
+      ? ((props as ComboboxRootPropsSingle).value ?? null)
+      : internalValueSingle;
+
+  const singleOnChangeRef = useRef<
+    ((next: string | null) => void) | undefined
+  >(undefined);
+  const multiOnChangeRef = useRef<((next: string[]) => void) | undefined>(
+    undefined,
+  );
+  singleOnChangeRef.current = !multiple
+    ? (props as ComboboxRootPropsSingle).onValueChange
+    : undefined;
+  multiOnChangeRef.current = multiple
+    ? (props as ComboboxRootPropsMultiple).onValueChange
+    : undefined;
+
+  const setValueSingle = useCallback(
+    (next: string | null) => {
+      if (!singleControlled) setInternalValueSingle(next);
+      singleOnChangeRef.current?.(next);
+    },
+    [singleControlled],
+  );
+
+  const setValueMulti = useCallback(
+    (next: string[]) => {
+      if (!multiControlled) setInternalValueMulti(next);
+      multiOnChangeRef.current?.(next);
+    },
+    [multiControlled],
+  );
+
+  const [inputValue, setInputValue] = useControllable<string>(
+    controlledInputValue,
+    defaultInputValue ?? "",
+    onInputValueChange,
+  );
+
+  const [open, setOpen] = useControllable<boolean>(
+    controlledOpen,
+    defaultOpen ?? false,
+    onOpenChange,
+  );
+
+  const [asyncResults, setAsyncResults] = useState<ComboboxOption[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const searchSeqRef = useRef(0);
+
+  useEffect(() => {
+    if (!onSearch) return;
+    const q = inputValue;
+    if (q.trim().length < minChars) {
+      searchSeqRef.current++;
+      setAsyncResults([]);
+      setIsLoading(false);
+      return;
+    }
+    const seq = ++searchSeqRef.current;
+    setIsLoading(true);
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const res = await onSearch(q);
+          if (seq !== searchSeqRef.current) return;
+          setAsyncResults(res);
+        } catch {
+          if (seq !== searchSeqRef.current) return;
+          setAsyncResults([]);
+        } finally {
+          if (seq === searchSeqRef.current) setIsLoading(false);
+        }
+      })();
+    }, searchDebounce);
+    return () => clearTimeout(timer);
+  }, [inputValue, onSearch, searchDebounce, minChars]);
+
+  const { results, matches } = useMemo<{
+    results: ComboboxOption[];
+    matches: Map<string, ComboboxMatchResult>;
+  }>(() => {
+    const map = new Map<string, ComboboxMatchResult>();
+    if (onSearch) {
+      const arr = asyncResults;
+      for (const o of arr) {
+        map.set(o.value, { option: o, score: 0, labelMatches: [] });
+      }
+      return { results: arr, matches: map };
+    }
+    const q = inputValue;
+    if (filter) {
+      const raw = filter(q, options);
+      const out: ComboboxOption[] = [];
+      for (const entry of raw) {
+        if ("option" in entry) {
+          out.push(entry.option);
+          map.set(entry.option.value, entry);
+        } else {
+          out.push(entry);
+          map.set(entry.value, { option: entry, score: 0, labelMatches: [] });
+        }
+      }
+      return { results: out.slice(0, maxResults), matches: map };
+    }
+    const matched = filterOptions(q, options, maxResults);
+    const out: ComboboxOption[] = [];
+    for (const m of matched) {
+      out.push(m.option);
+      map.set(m.option.value, m);
+    }
+    return { results: out, matches: map };
+  }, [onSearch, asyncResults, inputValue, filter, options, maxResults]);
+
+  useEffect(() => {
+    setActiveIndex((prev) => {
+      if (results.length === 0) return 0;
+      if (prev < 0) return 0;
+      if (prev >= results.length) return results.length - 1;
+      return prev;
+    });
+  }, [results]);
+
+  const getOptionLabel = useCallback(
+    (value: string) => {
+      if (getOptionLabelProp) return getOptionLabelProp(value);
+      const found = options.find((o) => o.value === value);
+      return found ? found.label : value;
+    },
+    [getOptionLabelProp, options],
+  );
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const itemNodeMapRef = useRef<Map<string, HTMLElement>>(new Map());
+
+  const registerItemNode = useCallback(
+    (value: string, node: HTMLElement | null) => {
+      if (node === null) {
+        itemNodeMapRef.current.delete(value);
+      } else {
+        itemNodeMapRef.current.set(value, node);
+      }
+    },
+    [],
+  );
+
+  const selectOption = useCallback(
+    (opt: ComboboxOption) => {
+      if (opt.disabled) return;
+      if (multiple) {
+        const cur = (valueRaw as string[]) ?? [];
+        if (cur.includes(opt.value)) return;
+        setValueMulti([...cur, opt.value]);
+        setInputValue("");
+        setActiveIndex(0);
+        requestAnimationFrame(() => inputRef.current?.focus());
+      } else {
+        setValueSingle(opt.value);
+        setInputValue(opt.label);
+        setOpen(false);
+      }
+    },
+    [multiple, valueRaw, setValueMulti, setValueSingle, setInputValue, setOpen],
+  );
+
+  const commitFreeform = useCallback(
+    (text: string) => {
+      const t = text.trim();
+      if (!t) return;
+      if (multiple) {
+        const cur = (valueRaw as string[]) ?? [];
+        if (cur.includes(t)) return;
+        setValueMulti([...cur, t]);
+        setInputValue("");
+      } else {
+        setValueSingle(t);
+        setInputValue(t);
+        setOpen(false);
+      }
+    },
+    [multiple, valueRaw, setValueMulti, setValueSingle, setInputValue, setOpen],
+  );
+
+  const removeValue = useCallback(
+    (v: string) => {
+      if (multiple) {
+        const cur = (valueRaw as string[]) ?? [];
+        setValueMulti(cur.filter((x) => x !== v));
+      } else {
+        setValueSingle(null);
+        setInputValue("");
+      }
+    },
+    [multiple, valueRaw, setValueMulti, setValueSingle, setInputValue],
+  );
+
+  const clearAll = useCallback(() => {
+    if (multiple) {
+      setValueMulti([]);
+    } else {
+      setValueSingle(null);
+    }
+    setInputValue("");
+  }, [multiple, setValueMulti, setValueSingle, setInputValue]);
+
+  const ctxValue = useMemo<ComboboxContextValue>(
+    () => ({
+      listId,
+      getItemId,
+      theme,
+      disabled,
+      readOnly,
+      multiple,
+      freeform: isFreeform,
+      strict: isStrict,
+      placeholder,
+      minChars,
+      maxResults,
+      value: valueRaw,
+      open,
+      setOpen,
+      inputValue,
+      setInputValue,
+      options,
+      results,
+      matches,
+      isLoading,
+      activeIndex,
+      setActiveIndex,
+      selectOption,
+      commitFreeform,
+      removeValue,
+      clearAll,
+      inputRef,
+      anchorRef,
+      listRef,
+      getOptionLabel,
+      registerItemNode,
+    }),
+    [
+      listId,
+      getItemId,
+      theme,
+      disabled,
+      readOnly,
+      multiple,
+      isFreeform,
+      isStrict,
+      placeholder,
+      minChars,
+      maxResults,
+      valueRaw,
+      open,
+      setOpen,
+      inputValue,
+      setInputValue,
+      options,
+      results,
+      matches,
+      isLoading,
+      activeIndex,
+      selectOption,
+      commitFreeform,
+      removeValue,
+      clearAll,
+      getOptionLabel,
+      registerItemNode,
+    ],
+  );
+
+  const rootStyle = {
+    position: "relative" as const,
+    ...style,
+  };
+
+  return (
+    <ComboboxContext.Provider value={ctxValue}>
+      <div
+        className={className}
+        style={rootStyle}
+        data-theme={theme}
+        data-disabled={disabled || undefined}
+        data-readonly={readOnly || undefined}
+      >
+        {children}
+      </div>
+    </ComboboxContext.Provider>
+  );
 }
 
 ComboboxRoot.displayName = "Combobox.Root";

--- a/src/components/Combobox/ComboboxRoot.tsx
+++ b/src/components/Combobox/ComboboxRoot.tsx
@@ -364,6 +364,14 @@ export function ComboboxRoot(props: ComboboxRootProps) {
     ],
   );
 
+  const anchorRefCallback = useCallback(
+    (node: HTMLDivElement | null) => {
+      (anchorRef as React.MutableRefObject<HTMLDivElement | null>).current =
+        node;
+    },
+    [],
+  );
+
   const rootStyle = {
     position: "relative" as const,
     ...style,
@@ -372,6 +380,7 @@ export function ComboboxRoot(props: ComboboxRootProps) {
   return (
     <ComboboxContext.Provider value={ctxValue}>
       <div
+        ref={anchorRefCallback}
         className={className}
         style={rootStyle}
         data-theme={theme}

--- a/src/components/Combobox/ComboboxRoot.tsx
+++ b/src/components/Combobox/ComboboxRoot.tsx
@@ -1,0 +1,7 @@
+import type { ComboboxRootProps } from "./Combobox.types";
+
+export function ComboboxRoot(_props: ComboboxRootProps) {
+  return null;
+}
+
+ComboboxRoot.displayName = "Combobox.Root";

--- a/src/components/Combobox/ComboboxTrigger.tsx
+++ b/src/components/Combobox/ComboboxTrigger.tsx
@@ -1,0 +1,7 @@
+import type { ComboboxTriggerProps } from "./Combobox.types";
+
+export function ComboboxTrigger(_props: ComboboxTriggerProps) {
+  return null;
+}
+
+ComboboxTrigger.displayName = "Combobox.Trigger";

--- a/src/components/Combobox/ComboboxTrigger.tsx
+++ b/src/components/Combobox/ComboboxTrigger.tsx
@@ -1,7 +1,74 @@
+import type { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
+import { useComboboxContext } from "./ComboboxContext";
+import { comboboxPalette } from "./colors";
 import type { ComboboxTriggerProps } from "./Combobox.types";
 
-export function ComboboxTrigger(_props: ComboboxTriggerProps) {
-  return null;
+export function ComboboxTrigger(props: ComboboxTriggerProps) {
+  const { className, style, children, plain = false, ...rest } = props;
+  const ctx = useComboboxContext();
+  const { theme, open, setOpen, disabled, inputRef } = ctx;
+  const p = comboboxPalette[theme];
+
+  const handleClick = (e: ReactMouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (disabled) return;
+    setOpen(!open);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  };
+
+  const baseStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 24,
+    height: 24,
+    border: "none",
+    background: "transparent",
+    color: p.triggerFg,
+    cursor: disabled ? "not-allowed" : "pointer",
+    padding: 0,
+    borderRadius: 4,
+    transition: "transform 120ms ease, color 120ms ease",
+    transform: open ? "rotate(180deg)" : "rotate(0deg)",
+    ...style,
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="Toggle options"
+      data-state={open ? "open" : "closed"}
+      tabIndex={-1}
+      onClick={handleClick}
+      onMouseDown={(e) => e.preventDefault()}
+      disabled={disabled}
+      className={className}
+      style={baseStyle}
+      {...rest}
+    >
+      {plain ? (
+        children
+      ) : children !== undefined ? (
+        children
+      ) : (
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M3 4.5L6 7.5L9 4.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      )}
+    </button>
+  );
 }
 
 ComboboxTrigger.displayName = "Combobox.Trigger";

--- a/src/components/Combobox/colors.ts
+++ b/src/components/Combobox/colors.ts
@@ -1,0 +1,97 @@
+import type { ComboboxTheme } from "./Combobox.types";
+
+export interface ComboboxPalette {
+  anchorBg: string;
+  anchorBorder: string;
+  anchorBorderHover: string;
+  anchorBorderFocus: string;
+  anchorFg: string;
+  placeholderFg: string;
+  triggerFg: string;
+
+  contentBg: string;
+  contentBorder: string;
+  contentShadow: string;
+  itemBg: string;
+  itemBgActive: string;
+  itemBgHover: string;
+  itemFg: string;
+  itemFgDisabled: string;
+  itemMarkFg: string;
+
+  groupHeadingFg: string;
+
+  chipBg: string;
+  chipBorder: string;
+  chipFg: string;
+  chipRemoveFg: string;
+
+  emptyFg: string;
+  loadingFg: string;
+  focusRing: string;
+}
+
+export const comboboxPalette: Record<ComboboxTheme, ComboboxPalette> = {
+  light: {
+    anchorBg: "#ffffff",
+    anchorBorder: "rgba(0,0,0,0.12)",
+    anchorBorderHover: "rgba(0,0,0,0.24)",
+    anchorBorderFocus: "#2563eb",
+    anchorFg: "#111827",
+    placeholderFg: "#9ca3af",
+    triggerFg: "#6b7280",
+
+    contentBg: "#ffffff",
+    contentBorder: "rgba(0,0,0,0.08)",
+    contentShadow:
+      "0 8px 24px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.06)",
+    itemBg: "transparent",
+    itemBgActive: "#eff6ff",
+    itemBgHover: "#f3f4f6",
+    itemFg: "#111827",
+    itemFgDisabled: "#9ca3af",
+    itemMarkFg: "#2563eb",
+
+    groupHeadingFg: "#6b7280",
+
+    chipBg: "#eff6ff",
+    chipBorder: "#bfdbfe",
+    chipFg: "#1e40af",
+    chipRemoveFg: "#1e3a8a",
+
+    emptyFg: "#6b7280",
+    loadingFg: "#6b7280",
+    focusRing: "#2563eb",
+  },
+  dark: {
+    anchorBg: "#1f2937",
+    anchorBorder: "rgba(255,255,255,0.10)",
+    anchorBorderHover: "rgba(255,255,255,0.20)",
+    anchorBorderFocus: "#60a5fa",
+    anchorFg: "#e5e7eb",
+    placeholderFg: "#6b7280",
+    triggerFg: "#9ca3af",
+
+    contentBg: "#1f2937",
+    contentBorder: "rgba(255,255,255,0.08)",
+    contentShadow:
+      "0 8px 24px rgba(0,0,0,0.4), 0 2px 6px rgba(0,0,0,0.3)",
+    itemBg: "transparent",
+    itemBgActive: "rgba(59,130,246,0.18)",
+    itemBgHover: "rgba(255,255,255,0.05)",
+    itemFg: "#e5e7eb",
+    itemFgDisabled: "#6b7280",
+    itemMarkFg: "#93c5fd",
+
+    groupHeadingFg: "#9ca3af",
+
+    chipBg: "rgba(59,130,246,0.15)",
+    chipBorder: "rgba(96,165,250,0.3)",
+    chipFg: "#93c5fd",
+    chipRemoveFg: "#60a5fa",
+
+    emptyFg: "#9ca3af",
+    loadingFg: "#9ca3af",
+    focusRing: "#60a5fa",
+  },
+};

--- a/src/components/Combobox/filter.ts
+++ b/src/components/Combobox/filter.ts
@@ -1,0 +1,72 @@
+import { fuzzyMatchOptimized } from "../CommandPalette/fuzzyMatch";
+import type {
+  ComboboxOption,
+  ComboboxMatchResult,
+} from "./Combobox.types";
+
+const LABEL_WEIGHT = 2.0;
+const KEYWORDS_WEIGHT = 0.8;
+
+export function scoreOption(
+  query: string,
+  option: ComboboxOption,
+): ComboboxMatchResult | null {
+  if (option.disabled) return null;
+  if (query.trim() === "") {
+    return { option, score: 0, labelMatches: [] };
+  }
+
+  let bestScore = -Infinity;
+  let labelMatches: number[] = [];
+  let matched = false;
+
+  const labelResult = fuzzyMatchOptimized(query, option.label);
+  if (labelResult !== null) {
+    matched = true;
+    const weighted = labelResult[0] * LABEL_WEIGHT;
+    if (weighted > bestScore) {
+      bestScore = weighted;
+      labelMatches = labelResult[1];
+    }
+  }
+
+  if (option.keywords !== undefined) {
+    for (const kw of option.keywords) {
+      const kwResult = fuzzyMatchOptimized(query, kw);
+      if (kwResult !== null) {
+        matched = true;
+        const weighted = kwResult[0] * KEYWORDS_WEIGHT;
+        if (weighted > bestScore) {
+          bestScore = weighted;
+        }
+      }
+    }
+  }
+
+  if (!matched) return null;
+  return { option, score: bestScore, labelMatches };
+}
+
+export function filterOptions(
+  query: string,
+  options: ComboboxOption[],
+  maxResults = 50,
+): ComboboxMatchResult[] {
+  const out: ComboboxMatchResult[] = [];
+
+  if (query.trim() === "") {
+    for (const option of options) {
+      if (option.disabled) continue;
+      out.push({ option, score: 0, labelMatches: [] });
+      if (out.length >= maxResults) break;
+    }
+    return out;
+  }
+
+  for (const option of options) {
+    const r = scoreOption(query, option);
+    if (r !== null) out.push(r);
+  }
+  out.sort((a, b) => b.score - a.score);
+  return out.slice(0, maxResults);
+}

--- a/src/components/Combobox/index.ts
+++ b/src/components/Combobox/index.ts
@@ -1,0 +1,17 @@
+export { Combobox } from "./Combobox";
+export type {
+  ComboboxRootProps,
+  ComboboxRootPropsSingle,
+  ComboboxRootPropsMultiple,
+  ComboboxInputProps,
+  ComboboxTriggerProps,
+  ComboboxContentProps,
+  ComboboxItemProps,
+  ComboboxGroupProps,
+  ComboboxEmptyProps,
+  ComboboxLoadingProps,
+  ComboboxOption,
+  ComboboxMatchResult,
+  ComboboxFilter,
+  ComboboxTheme,
+} from "./Combobox.types";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@ export * from "./Actionable";
 export * from "./Button";
 export * from "./Card";
 export * from "./CodeView";
+export * from "./Combobox";
 export * from "./CommandPalette";
 export * from "./DataTable";
 export * from "./Dialog";


### PR DESCRIPTION
## Summary
- Combobox 컴파운드 컴포넌트 (Root/Input/Trigger/Content/Item/Group/Empty/Loading)
- single/multiple, controlled/uncontrolled value + inputValue + open
- 동기 필터 (기본) + async onSearch + freeform/strict
- ARIA combobox + listbox + activedescendant
- 데모 페이지 7섹션 (Basic/Grouped/Multiple/Controlled/Freeform/Dark/Usage)

## Issues
#249-#278

## Test plan
- [ ] `npx tsc --noEmit` 통과 확인
- [ ] `npm run build` 통과 확인
- [ ] 데모 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)