### PR TITLE
fix(CodeView): WKWebView textarea fresh-mount quirk 회피 (#451)

### DIFF
--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useRef } from "react";
 import { Highlight, themes } from "prism-react-renderer";
 import type { CodeViewProps } from "./CodeView.types";
 import { renderWithInvisibles } from "./CodeView.invisibles";
@@ -163,6 +163,25 @@ export function CodeView({
   // 편집 UI 활성 여부 (textarea 렌더/이벤트).
   const isEditingActive =
     editable === "enable" || (editable === "click" && isEditingClick);
+
+  // ── WKWebView (Tauri / macOS) textarea fresh-mount quirk 회피 ──────────────
+  // textarea 가 *consecutive `\n` 을 포함한 multi-line value* 로 fresh-mount 되면
+  // WKWebView 의 internal selection-anchor 가 stale 상태로 stuck 되어, 빈 줄에서
+  // 두 글자 연속 입력 시 두 번째 글자가 첫 번째를 replace 하는 bug 가 발생한다.
+  // (https://github.com/pihitpihit/plastic/issues/451)
+  //
+  // mount 시점에는 빈 value 로 textarea 를 mount → useLayoutEffect 에서 즉시
+  // actual value 로 swap. issue 보고서 §3.4 에서 setEditValue 호출(=React
+  // controlled value 갱신)은 quirk 를 트리거하지 않음이 검증되었다.
+  // useLayoutEffect 는 paint 직전 동기 실행이므로 사용자는 primer 상태를 보지 못함.
+  const [taPrimed, setTaPrimed] = useState(false);
+  useLayoutEffect(() => {
+    if (isEditingActive && !taPrimed) setTaPrimed(true);
+  }, [isEditingActive, taPrimed]);
+  useEffect(() => {
+    // textarea unmount(편집 비활성)되면 primer 상태 reset → 다음 mount 시 재 primer
+    if (!isEditingActive && taPrimed) setTaPrimed(false);
+  }, [isEditingActive, taPrimed]);
 
   // click 모드에서 편집 진입 직후 textarea 에 포커스 + 클릭 위치로 caret 이동
   useEffect(() => {
@@ -579,7 +598,16 @@ export function CodeView({
                   // bundled 모드: PUA 치환 문자열을 textarea 에 보여 폰트가
                   // 3ch glyph 로 렌더하게 한다. 1:1 substitution 이므로
                   // selectionStart/End 는 raw 인덱스와 동일.
-                  value={useBundledFont ? toPuaDisplay(editValue) : editValue}
+                  //
+                  // !taPrimed 인 첫 render 에서는 빈 value 로 mount 하여
+                  // WKWebView 의 multi-line+empty-line fresh-mount quirk 를 회피.
+                  // useLayoutEffect 가 같은 paint 사이클 내에서 taPrimed=true 로
+                  // 전환하므로 두 번째 render 에서 즉시 actual value 로 swap 된다.
+                  value={
+                    taPrimed
+                      ? (useBundledFont ? toPuaDisplay(editValue) : editValue)
+                      : ""
+                  }
                   onChange={handleChange}
                   onCopy={(e) => {
                     if (!useBundledFont) return;


### PR DESCRIPTION
Closes #451 시도 (실환경 검증 필요)

## 배경

Tauri / macOS WKWebView 환경에서 `<CodeView editable="enable">` 가 빈 줄을 포함한 multi-line value 로 fresh-mount 되면, 빈 줄에서 두 글자 연속 입력 시 두 번째 글자가 첫 번째를 replace 하는 bug 가 발생함 (#451).

보고서가 매우 정밀하게 분석되어 있고, root cause 가설은 다음과 같음:
- WKWebView 의 textarea internal selection-anchor 가 fresh-mount 시 multi-line+empty-line value 로 stuck
- consumer-side workaround (synthetic event, focus cycle, mount lifecycle 조작) 모두 실패 — `event.isTrusted: true` 만 anchor refresh 가능

## 해결 방향

보고서가 직접 제안한 **Option B — mount-time value swap** 채택.

§3.4 의 trigger matrix 에서 검증된 사실:
| 시나리오 | quirk |
|---------|-------|
| Fresh React mount + multi-line value | **재현** |
| `setEditValue` 호출 (= controlled value 갱신) | **비-trigger** |

→ textarea 를 빈 value 로 mount 한 뒤 `useLayoutEffect` 에서 즉시 actual value 로 swap. paint 전 동기 실행이므로 사용자에게는 primer 상태가 보이지 않음.

## 변경 (30 줄)

```tsx
const [taPrimed, setTaPrimed] = useState(false);
useLayoutEffect(() => {
  if (isEditingActive && !taPrimed) setTaPrimed(true);
}, [isEditingActive, taPrimed]);
useEffect(() => {
  if (!isEditingActive && taPrimed) setTaPrimed(false);
}, [isEditingActive, taPrimed]);

// textarea
value={
  taPrimed
    ? (useBundledFont ? toPuaDisplay(editValue) : editValue)
    : ""
}
```

## 회귀 가능성

매우 낮음. `taPrimed=true` 이후의 모든 경로 (=일반 사용) 는 기존과 100% 동일.

점검:
- click 모드 caret 위치 (`pendingClickCaretRef`) — useEffect 는 useLayoutEffect 사이클 종료 후 실행되므로 setSelectionRange 시점에 textarea.value = actualValue. 안전
- IME composition — useLayoutEffect 동기 실행으로 사용자 키 입력 전에 prime 완료
- PUA 매핑 (`useBundledFont` / `toPuaDisplay`) — `taPrimed=true` 후에만 적용되므로 영향 없음
- `onChange` — React controlled input 은 프로그램 value 갱신에 onChange 비발화. `handleChange` 비호출 보장
- React StrictMode — `if (isEditingActive && !taPrimed)` 가드로 effect 이중 실행 idempotent

비용: textarea mount 당 1 회 추가 render (paint 전 동기, 측정 가능 수준 아님).

## 한계 / 검증 요청

이 PR 은 보고서 hypothesis 위에 구축됨. 다음은 실환경 검증 없이는 확신 불가:

1. **WKWebView 의 anchor 초기화 시점** — mount-time 인지 focus-time 인지. mount-time 이면 fix 유효, focus-time 이면 무효
2. **§3.4 의 비-trigger 검증의 일반화** — "setEditValue 는 비-trigger" 가 *빈 value → multi-line value* 의 첫 swap 에도 그대로 적용되는지
3. **React 18 자동 batching** — prime 사이클이 단일 render 로 합쳐져 textarea 가 "" 상태를 거치지 않을 가능성

→ 보고자에게 본 PR 빌드를 적용한 dev build 로 §3.2 절차 재현 시험을 요청해야 함.

Fix 가 무효한 것으로 판명되면 다음 단계:
- §4.2 의 다른 trigger 후보 (`invisibleFontStrategy="overlay"` / `color: transparent` / `gridArea overlap`) 격리 시험

## Test plan

- [ ] Tauri / macOS WKWebView 에서 #451 §3.2 절차 재현 안 됨 확인 ← **필수**
- [ ] `editable="enable"` / `editable="click"` 양쪽에서 정상 입력 확인
- [ ] IME (한글) 조합 입력 정상 확인
- [ ] click 모드에서 caret 클릭 위치 정확히 잡히는지 확인
- [ ] 일반 데스크톱 브라우저 (Chromium, Firefox) 회귀 없음 확인

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY)_