### PR TITLE
fix(demo): SelectPage Button variant "outline" → "secondary"

### DIFF
--- a/demo/src/pages/SelectPage.tsx
+++ b/demo/src/pages/SelectPage.tsx
@@ -303,13 +303,13 @@ function ControlledDemo() {
   const [value, setValue] = useState<string>("ts");
   return (
     <div className="flex items-center gap-3 flex-wrap">
-      <Button variant="outline" onClick={() => setValue("ts")}>
+      <Button variant="secondary" onClick={() => setValue("ts")}>
         TS
       </Button>
-      <Button variant="outline" onClick={() => setValue("py")}>
+      <Button variant="secondary" onClick={() => setValue("py")}>
         Python
       </Button>
-      <Button variant="outline" onClick={() => setValue("go")}>
+      <Button variant="secondary" onClick={() => setValue("go")}>
         Go
       </Button>
       <Select.Root value={value} onValueChange={setValue}>


### PR DESCRIPTION
## Summary

- `demo/src/pages/SelectPage.tsx`의 `ControlledDemo`에서 존재하지 않는 `variant="outline"`을 사용 → `tsc -b` 실패 → CI `deploy-demo` 워크플로우 중단
- `ButtonVariant`가 허용하는 값은 `"primary" | "secondary" | "ghost"`만이며, 3개의 언어 선택 버튼을 `variant="secondary"`로 교체

## Failing run

[deploy-demo run #25037543065](https://github.com/pihitpihit/plastic/actions/runs/25037543065)

```
src/pages/SelectPage.tsx(306,15): error TS2322: Type '"outline"' is not assignable to type 'ButtonVariant | undefined'.
src/pages/SelectPage.tsx(309,15): error TS2322: Type '"outline"' is not assignable to type 'ButtonVariant | undefined'.
src/pages/SelectPage.tsx(312,15): error TS2322: Type '"outline"' is not assignable to type 'ButtonVariant | undefined'.
```

## Test plan

- [x] `cd demo && npm run build` 성공
- [ ] merge 후 deploy-demo 워크플로우 정상 실행 확인

https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6kPEuwx9ES6vYPDK76JrY)_