### PR TITLE
feat(Calendar): 월 그리드 단독 컴포넌트 + DatePicker 통합 + 17개 plan 문서

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -22,8 +22,9 @@ import ProgressPage from "./pages/ProgressPage";
 import SkeletonPage from "./pages/SkeletonPage";
 import AccordionPage from "./pages/AccordionPage";
 import { SplitPanePage } from "./pages/SplitPanePage";
+import CalendarPage from "./pages/CalendarPage";
 
-type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select" | "tree" | "contextmenu" | "datepicker" | "tabs" | "combobox" | "progress" | "skeleton" | "accordion" | "splitpane";
+type Page = "button" | "card" | "codeview" | "actionable" | "pathinput" | "toast" | "dialog" | "tooltip" | "datatable" | "stepper" | "commandpalette" | "hexview" | "pipelinegraph" | "select" | "tree" | "contextmenu" | "datepicker" | "calendar" | "tabs" | "combobox" | "progress" | "skeleton" | "accordion" | "splitpane";
 
 interface SubItem { label: string; id: string }
 
@@ -234,6 +235,16 @@ const NAV: { id: Page; label: string; description: string; sections: SubItem[] }
     { label: "Min/Max", id: "min-max" },
     { label: "Dark Theme", id: "dark" },
     { label: "Usage", id: "usage" },
+  ]},
+  { id: "calendar", label: "Calendar", description: "월 그리드 단독 컴포넌트", sections: [
+    { label: "Single mode", id: "single" },
+    { label: "Range mode", id: "range" },
+    { label: "Multiple mode", id: "multiple" },
+    { label: "Constrained", id: "constrained" },
+    { label: "Locale (ko-KR)", id: "locale-ko" },
+    { label: "Custom day render", id: "custom-day" },
+    { label: "Dark theme", id: "dark" },
+    { label: "Disabled", id: "disabled" },
   ]},
   { id: "combobox", label: "Combobox", description: "검색형 선택 입력", sections: [
     { label: "Basic", id: "basic" },
@@ -549,6 +560,7 @@ export function App() {
         {current === "tree" && <TreePage />}
         {current === "contextmenu" && <ContextMenuPage />}
         {current === "datepicker" && <DatePickerPage />}
+        {current === "calendar" && <CalendarPage />}
         {current === "tabs" && <TabsPage />}
         {current === "combobox" && <ComboboxPage />}
         {current === "progress" && <ProgressPage />}

--- a/demo/src/pages/CalendarPage.tsx
+++ b/demo/src/pages/CalendarPage.tsx
@@ -1,0 +1,215 @@
+import { useState, type ReactNode } from "react";
+import { Calendar, weekdayOf } from "plastic";
+import type {
+  CalendarDate,
+  CalendarRangeValue,
+  CalendarMultipleValue,
+  CalendarSingleValue,
+} from "plastic";
+
+function Section({
+  id,
+  title,
+  desc,
+  children,
+}: {
+  id?: string;
+  title: string;
+  desc?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} className="mb-10">
+      <p className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-2">
+        {title}
+      </p>
+      {desc && <p className="text-sm text-gray-500 mb-3">{desc}</p>}
+      {children}
+    </section>
+  );
+}
+
+function Card({ children }: { children: ReactNode }) {
+  return (
+    <div className="p-6 bg-white rounded-lg border border-gray-200">
+      {children}
+    </div>
+  );
+}
+
+function DarkCard({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="p-6 rounded-lg border"
+      style={{ background: "#0b0c10", borderColor: "#23262d" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function fmt(v: CalendarDate | null): string {
+  if (!v) return "(none)";
+  return `${v.year}-${String(v.month).padStart(2, "0")}-${String(v.day).padStart(2, "0")}`;
+}
+
+export default function CalendarPage() {
+  const [single, setSingle] = useState<CalendarSingleValue>(null);
+  const [range, setRange] = useState<CalendarRangeValue>({ start: null, end: null });
+  const [multi, setMulti] = useState<CalendarMultipleValue>([]);
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold mb-1">Calendar</h1>
+        <p className="text-sm text-gray-500">
+          월 그리드 단독 컴포넌트. DatePicker가 내부에서 사용함.
+        </p>
+      </header>
+
+      <Section id="single" title="Single mode" desc="단일 날짜 선택">
+        <Card>
+          <Calendar.Root mode="single" value={single} onValueChange={setSingle}>
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-year" />
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+              <Calendar.Nav direction="next-year" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader />
+            <Calendar.Grid />
+          </Calendar.Root>
+          <p className="mt-3 text-sm">Selected: <strong>{fmt(single)}</strong></p>
+        </Card>
+      </Section>
+
+      <Section id="range" title="Range mode" desc="시작/종료 두 날짜 선택. 호버 시 미리보기 음영.">
+        <Card>
+          <Calendar.Root mode="range" value={range} onValueChange={setRange}>
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader />
+            <Calendar.Grid />
+          </Calendar.Root>
+          <p className="mt-3 text-sm">
+            Range: <strong>{fmt(range.start)}</strong> ~ <strong>{fmt(range.end)}</strong>
+          </p>
+        </Card>
+      </Section>
+
+      <Section id="multiple" title="Multiple mode" desc="여러 날짜 동시 선택 (toggle).">
+        <Card>
+          <Calendar.Root mode="multiple" value={multi} onValueChange={setMulti}>
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader />
+            <Calendar.Grid />
+          </Calendar.Root>
+          <p className="mt-3 text-sm">Selected: {multi.length} dates — {multi.map(fmt).join(", ") || "(none)"}</p>
+        </Card>
+      </Section>
+
+      <Section id="constrained" title="Constrained" desc="minDate/maxDate + 일요일 비활성">
+        <Card>
+          <Calendar.Root
+            mode="single"
+            minDate={{ year: 2026, month: 4, day: 10 }}
+            maxDate={{ year: 2026, month: 6, day: 20 }}
+            isDisabled={(d) => weekdayOf(d) === 0}
+          >
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader />
+            <Calendar.Grid />
+          </Calendar.Root>
+        </Card>
+      </Section>
+
+      <Section id="locale-ko" title="Locale (ko-KR, weekStartsOn=1)" desc="한국어 월/요일 라벨, 월요일 시작">
+        <Card>
+          <Calendar.Root mode="single" locale="ko-KR" weekStartsOn={1}>
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader format="narrow" />
+            <Calendar.Grid />
+          </Calendar.Root>
+        </Card>
+      </Section>
+
+      <Section id="custom-day" title="Custom day render" desc="render prop으로 셀 컨텐츠 커스터마이징 (이벤트 마킹 등).">
+        <Card>
+          <Calendar.Root mode="single">
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader />
+            <Calendar.Grid>
+              {(day) => (
+                <div style={{ position: "relative" }}>
+                  <Calendar.Day day={day} />
+                  {[5, 12, 19].includes(day.date.day) && day.inCurrentMonth && (
+                    <span
+                      aria-hidden
+                      style={{
+                        position: "absolute",
+                        bottom: 2,
+                        right: 4,
+                        width: 4,
+                        height: 4,
+                        borderRadius: "50%",
+                        background: "#dc2626",
+                      }}
+                    />
+                  )}
+                </div>
+              )}
+            </Calendar.Grid>
+          </Calendar.Root>
+        </Card>
+      </Section>
+
+      <Section id="dark" title="Dark theme">
+        <DarkCard>
+          <Calendar.Root mode="single" theme="dark">
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader />
+            <Calendar.Grid />
+          </Calendar.Root>
+        </DarkCard>
+      </Section>
+
+      <Section id="disabled" title="Disabled (전체 비활성)">
+        <Card>
+          <Calendar.Root mode="single" disabled>
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader />
+            <Calendar.Grid />
+          </Calendar.Root>
+        </Card>
+      </Section>
+    </div>
+  );
+}

--- a/docs/candidates.md
+++ b/docs/candidates.md
@@ -1,0 +1,316 @@
+# Component Candidates
+
+이 문서는 컴포넌트 후보를 추적합니다. plan 문서가 작성되면 `Plan 작성 완료` 섹션으로 이동하고, 구현이 완료되면 `docs/plans/complete/`로 이동합니다.
+
+---
+
+## 상태 표기
+
+| 상태 | 의미 |
+|---|---|
+| Plan 작성 완료 | `docs/plans/NNN-*.md` 작성됨, 구현 대기 |
+| 잠정 후보 | 진행 의사 표시됨, plan 문서 작성 대기 |
+| 검토 대상 | 후보로 거론되었으나 아직 결정 보류 |
+| 후순위 | 가치는 인정되나 우선순위 낮음, 나중 라운드 검토 |
+| 드롭 | 명시적으로 진행 안 하기로 결정 |
+
+---
+
+## Plan 작성 완료 (Plan Documents Written)
+
+의존 순서 기반으로 023~039 번호 배정.
+
+### Tier 0 — 인프라 / 추출
+| # | 컴포넌트 | Plan 문서 |
+|---|---|---|
+| 023 | `Icon` + `IconRegistry` (foundation) | [023-icon-component.md](plans/023-icon-component.md) |
+| 024 | `LineNumbers` (CodeView 추출) | [024-linenumbers-component.md](plans/024-linenumbers-component.md) |
+| 025 | `Calendar` (DatePicker 추출) | [025-calendar-component.md](plans/025-calendar-component.md) |
+| 026 | `CopyButton` + `useCopyToClipboard` (HexView 마이그레이션 포함) | [026-copybutton-component.md](plans/026-copybutton-component.md) |
+
+### Tier 1 — 독립 primitive
+| # | 컴포넌트 | Plan 문서 |
+|---|---|---|
+| 027 | `Tag` / `Chip` | [027-tag-component.md](plans/027-tag-component.md) |
+| 028 | `NumberInput` | [028-numberinput-component.md](plans/028-numberinput-component.md) |
+| 029 | `Stack` / `HStack` / `VStack` / `Grid` | [029-stack-grid-component.md](plans/029-stack-grid-component.md) |
+| 030 | `FileUpload` / `Dropzone` | [030-fileupload-component.md](plans/030-fileupload-component.md) |
+| 031 | `Image` | [031-image-component.md](plans/031-image-component.md) |
+| 032 | `ConfirmInline` | [032-confirminline-component.md](plans/032-confirminline-component.md) |
+| 033 | `ErrorBoundary` wrapper | [033-errorboundary-component.md](plans/033-errorboundary-component.md) |
+| 034 | `SmartSearch` | [034-smartsearch-component.md](plans/034-smartsearch-component.md) |
+| 035 | `QRCode` | [035-qrcode-component.md](plans/035-qrcode-component.md) |
+| 036 | `Changelog` | [036-changelog-component.md](plans/036-changelog-component.md) |
+
+### Tier 2 — severity 의존
+| # | 컴포넌트 | Plan 문서 |
+|---|---|---|
+| 037 | `Alert` (Phase 0: `_shared/severity.ts` 추출 포함) | [037-alert-component.md](plans/037-alert-component.md) |
+| 038 | `Banner` | [038-banner-component.md](plans/038-banner-component.md) |
+
+### Tier 3 — 다른 후보 의존
+| # | 컴포넌트 | Plan 문서 |
+|---|---|---|
+| 039 | `Sidebar` + `Header` + `Footer` (AppShell parts) | [039-appshell-parts-component.md](plans/039-appshell-parts-component.md) |
+
+---
+
+## 잠정 후보 (Tentative Candidates)
+
+(없음 — 17개 모두 plan 작성 완료)
+
+---
+
+## 횡단 추상 (Cross-cutting Abstractions)
+
+### `_shared/severity.ts` — 심각도 토큰
+plan 037 Phase 0에서 추출 예정. 알림류 컴포넌트(Toast / Alert / Banner / InlineMessage / Field error / ConfirmDialog destructive 등) 전반을 가로지르는 횡단 추상.
+
+#### severity가 담는 것
+| 측면 | 내용 |
+|---|---|
+| **레벨** | `success` / `error` / `warning` / `info` / `default` (필요 시 `critical` 추가) |
+| **색상 팔레트** | 배경·테두리·전경·아이콘 색 (light/dark 테마별) |
+| **기본 아이콘** | 체크/엑스/느낌표/i — 레벨에 매핑 |
+| **ARIA 시맨틱** | `error`/`warning` → `role="alert"`/`aria-live="assertive"`, `info`/`success` → `role="status"`/`aria-live="polite"` |
+
+#### 추출 시 효과
+1. **색·아이콘·접근성 정책 한 곳에서 관리** — 토큰 변경이 모든 알림 컴포넌트에 즉시 전파.
+2. **새 컴포넌트 진입 장벽 낮음** — 알림류 신설 시 토큰 import만으로 시각·접근성 일관 보장.
+3. **테마 전환 일관성** — light↔dark 매핑이 단일 파일.
+
+#### 함정
+- severity ≠ 모든 색상 시맨틱.
+  - **brand color**(primary/secondary), **카테고리 컬러**(예: 사용자 태그 색)는 severity와 **분리**되어야 함.
+  - severity는 "**상태/의미** 색상"이지 "**시각 강조** 색상"이 아님.
+  - Button의 primary는 brand 영역, severity 아님.
+
+#### 수반되는 부품 추출 (강도 2 패턴 — plan 037 Phase 0)
+```
+_shared/severity.ts             ← 토큰 (palette + icon mapping)
+_shared/SeverityIcon.tsx        ← severity → 아이콘 자동 매핑 컴포넌트
+_shared/DismissButton.tsx       ← X 버튼 (Toast·Banner·Alert·Dialog 공유)
+```
+- Banner·Alert는 외곽 컨테이너 + 내부 레이아웃만 자기가 작성, 부품은 공유.
+- Toast가 plan 037 Phase 0에서 동시 마이그레이션됨.
+
+---
+
+## 검토 대상 (Discussed, Not Yet Adopted)
+
+이전 라운드에서 거론되었으나 잠정 후보로 채택되지 않은 것들. 향후 라운드에서 재검토 가능.
+
+### 폼 입력
+- `TextField` / `TextArea` / `Checkbox` / `Radio` / `Switch` / `Slider` (폼 기본 4~6종) — 라이브러리 사용 범위를 가장 크게 넓히는 묶음. 채택 시 `Field` / `Form` 컴포지션 계층과 함께 가는 게 자연스러움.
+- `Field` — label + control + helper + error + required 마커 wrapper.
+- `Form` — validation context + submit 핸들링.
+- `SegmentedControl` — pill 형태 단일값 선택.
+- `ButtonGroup` — Button들을 한 덩어리로 시각적 결합.
+- `SearchInput` — 검색 아이콘 + clear + debounce.
+- `MultiSelect` — Select의 다중 변형.
+- `ColorPicker` — 색 swatch + hex/rgb 입력.
+- `PasswordInput` — show/hide 토글 + caps lock 경고.
+- `ToggleGroup` — pill 토글 모음, 단일/다중.
+- `RangeSlider` — 두 thumb (min/max).
+- `MaskedInput` — 전화번호/카드/날짜 포맷 마스크.
+- `OtpInput` / `PinInput` — 숫자 칸 N개, 자동 다음 칸 이동.
+- `Editable` — 텍스트 클릭 시 인라인 편집.
+- `FieldArray` — 반복 필드.
+- `ConditionalField` — 조건부 표시 필드.
+- `UnsavedChanges` 경고 + `AutoSave` 인디케이터.
+- `WordCount` / `MaxLengthIndicator`.
+- `AutoExpand` textarea.
+
+### 표시 / 데이터
+- `Avatar` + `AvatarGroup` — 이미지/이니셜/fallback, AvatarGroup은 max 처리.
+- `Spinner` — 로딩 인디케이터 (Skeleton과 보완).
+- `Badge` — 카운트/라벨.
+- `EmptyState` — "데이터 없음" 일러스트 + 메시지 + 액션.
+- `Stat` / `Metric` — 큰 숫자 + 라벨 + 추세.
+- `KeyValueList` / `DescriptionList` — 단일 record의 필드 나열.
+- `InlineCode` — `<code>` 인라인.
+- `Markdown` — md → React.
+- `Highlight` / `Mark` — 검색 매치 강조.
+- `Truncate` / `Ellipsis` — 긴 텍스트 + 옵션 Tooltip.
+- `Number` / `Duration` / `UnitDisplay` / `TimeAgo` — 표시 포맷터 묶음.
+- `Sparkline` — 셀 사이즈 미니 차트.
+- `Heatmap` — GitHub 활동 그리드 스타일.
+- `Status` indicator — 생사 도트/필.
+- `Pulse` — 활성/실시간 펄스.
+- `Inspector` / `PropertyGrid` — IDE 인스펙터.
+- `KeyValueEditor` — KEY=VALUE 행 편집.
+- `OperationLog` — 최근 작업 + 상태.
+
+### 레이아웃 / 네비
+- `AspectRatio` — 비율 고정.
+- `Container` — max-width centered.
+- `Box` — 단일 styled div.
+- `Center` / `Spacer` — flex micro 유틸.
+- `Sticky` / `StickyContainer` — sticky 포지셔닝 helper.
+- `ScrollArea` — 커스텀 스크롤바 (현재 우선순위 낮음, 가시 문제 발생 시 도입).
+- `AppShell` — 사이드바 + 헤더 + 컨텐츠 grid (plan 039의 부품들이 들어감).
+- `PageHeader` — 제목 + 부제 + 브레드크럼 + 액션.
+- `Anchor` / `SectionNav` — 스크롤 추적 사이드 내비.
+- `Breadcrumbs` — 경로 표시.
+- `Pagination` — DataTable 짝.
+- `Link` — styled `<a>`.
+- `Toolbar` 가족 — Toolbar + Group + Button + Separator.
+- `Panel` / `SidePanel` — collapsible/resizable 패널.
+- `FullBleed` — 부모 폭 넘기.
+- `FormSection` / `FormGrid` — 폼 레이아웃.
+
+### 오버레이
+- `Sheet` / `Drawer` — 사이드 패널 (Dialog 인프라 80% 재사용).
+- `BottomSheet` — 하단 시트.
+- `HoverCard` — Tooltip의 부자 버전.
+- `DropdownMenu` — 액션 메뉴 (Select=값, DropdownMenu=행동).
+- `SplitButton` — 기본 액션 + 우측 드롭다운.
+- `ConfirmDialog` — promise 기반 확인 다이얼로그.
+- `Lightbox` / `ImageViewer` — 이미지 확대 모달.
+- `LoadingOverlay` + `Backdrop`.
+- `ActionSheet` — iOS 시트.
+- `Tour` / `Coachmark` / `Spotlight` — 온보딩.
+- `WhatsNew` / `OnboardingChecklist`.
+
+### 인터랙션
+- `Sortable` — 드래그-앤-드롭 재정렬.
+- `Carousel` — 슬라이드 전환.
+- `MentionsInput` — `@` 자동완성.
+- `VirtualList` — 가상 스크롤 컨테이너.
+- `TagInput` / `ChipInput` — 다중 값 입력.
+- `Draggable` + `DropTarget` — 일반 DnD primitive.
+- `LongPress` / `DoubleClick`.
+- `PullToRefresh` / `SwipeAction`.
+
+### 알림
+- `InlineMessage` — 한 줄 인라인 알림 (Alert보다 가벼움).
+- `Notifications` center — 헤더 벨 + 누적 알림 보관.
+- `NotificationDot` — 작은 빨간 점 + 카운트.
+- `Note` / `Callout` — 문서 스타일 노트 박스.
+
+### Date / Time 변종
+- `DateRangePicker` — 두 날짜 선택. `Calendar` 분리 후 자연스러움.
+- `TimePicker` — 시간만.
+- `DatePresets` — "최근 7일/지난달" 빠른 선택 칩.
+- `WeekView` / `MonthView` / `AgendaView` — Calendar derivatives.
+- `DurationPicker` — 시간 길이 선택.
+- `TimezonePicker`.
+- `Countdown`.
+
+### 개발자 도구 색깔
+- `KbdHint` / `Shortcut` — 단일 키캡 시각화.
+- `KbdShortcuts` overlay — `?` 키로 전체 단축키 모달.
+- `KeyBinding` display + editor.
+- `HelpHint` — `(?)` 아이콘 + Tooltip 합성.
+- `StatusBar` / `Toolbar` — IDE-like 셸.
+- `Timeline` / `ActivityLog` — 시계열 이벤트.
+- `HttpStatusChip` — 200/404/500 색상 칩.
+- `EnvBadge` — dev/staging/prod 환경 라벨.
+- `ThemeToggle` — light/dark 전환 스위치.
+- `RegexInput` — 실시간 매칭 미리보기.
+- `CodeFold` / `BlameAnnotation` / `Minimap` — CodeView 확장.
+
+### 채팅 / AI
+- `ChatBubble` + `MessageThread`.
+- `StreamingText`.
+- `MessageInput` + `TypingIndicator` + `MessageReaction`.
+
+### 협업 / 실시간
+- `Presence` / `Cursor` / `LiveSelection`.
+
+### 시스템 / 메타
+- `OnlineStatus` / `IdleTimer`.
+- `RetryButton` / `RetryState`.
+- `SaveBar` — 폼 dirty 시 하단 액션 바.
+- `FloatingActionButton` (FAB) / `BackToTop`.
+- `Wizard` — 다단계 폼.
+
+### 미디어
+- `BeforeAfter` — 두 이미지 비교 슬라이더.
+- `AudioPlayer` / `VideoPlayer` / `WaveformDisplay`.
+- `Gauge` — 속도계 게이지.
+
+### 문서 / 도움말
+- `Detail` / `Disclosure` — `<details>` 래퍼.
+- `Quote` / `Blockquote`.
+- `Definition` / `Glossary` / `FAQ`.
+- `Prose` / `Article` — typography wrapper.
+- `TableOfContents` — heading 자동 목차.
+- `ReadingProgress` — 페이지 진행률.
+- `Printable` / `PrintOnly` / `ScreenOnly`.
+
+### 동의 / 마케팅
+- `CookieBanner` — 쿠키 동의.
+- `NewsletterSignup`.
+
+### 비동기 / 데이터
+- `InfiniteScroll` / `LoadMore`.
+- `AsyncSelect` / `AsyncCombobox`.
+- `ExportButton` — PDF/CSV/JSON 드롭다운.
+- `PrintPreview`.
+
+### 접근성 / 메타
+- `VisuallyHidden` / `SkipLink` / `LiveRegion`.
+- `ThemeProvider` + `useTheme`.
+- `MediaQuery` / `Hidden` / `Show` (반응형 primitive).
+
+### 작은 인터랙션 / 시각 피드백
+- `Ripple` / `Shake` / `Confetti`.
+- `Collapse` / `Fade` / `Slide` / `Reveal` / `ScrollReveal` — 애니메이션 primitive.
+- `ButtonToggle` / `IconToggle`.
+- `Sound` / `Haptic`.
+
+### DataTable 액세서리
+- `DataTable.Column.Resizable` / `DataTable.GroupBy` / `DataTable.SubRows`.
+- `BulkActions` / `ColumnConfigurator` / `RowExpander` / `DataTable.Toolbar`.
+
+### 컴포지션 / 합성
+- `SettingsPanel` — 카테고리 설정.
+- `Comparison` / `FeatureMatrix`.
+- `Widget` / `WidgetGrid` — 대시보드.
+- `List` / `SelectableList`.
+- `ChatBubble` / `MessageThread`.
+
+### 기타
+- `Rating` — 별점.
+- `SignaturePad` — canvas 서명.
+- `Knob` — 회전식 컨트롤.
+- `WeekdayPicker` — M T W T F S S 토글.
+- `EmojiPicker`.
+- `EmailInput` / `URLInput` / `PhoneInput` (도메인 전용 입력).
+- `FilterBuilder` / `FilterBar`.
+
+---
+
+## 드롭 (Dropped)
+
+### `DiffView`
+- **이유**: 너무 고급 기능, 현 시점 논의 불필요.
+
+### `JsonView` / `TreeDataView`
+- **이유**: 현 시점 우선순위 낮음.
+
+### `LogView`
+- **이유**: 현 시점 우선순위 낮음.
+
+---
+
+## 큰 작업 (참고만)
+
+라이브러리 정체성을 크게 바꿀 수 있어 별도 결정 필요한 항목들.
+
+| 항목 | 설명 |
+|---|---|
+| `Charts` 라이브러리 (`LineChart` / `BarChart` / `PieChart` / `AreaChart`) | recharts·visx 의존 vs 자체 구현 결정 필요. 큰 스코프, 라이브러리 정체성 변화. |
+| `RichTextEditor` | Tiptap·ProseMirror 의존 필수. 매우 큰 작업. |
+| `MapView` | Leaflet/Mapbox 의존. 라이브러리 범위 넘어섬. |
+
+---
+
+## 기록 정책
+
+- 새 후보가 거론되어 잠정 후보로 채택되면 → **잠정 후보** 섹션에 추가.
+- 거론되었으나 채택 보류 → **검토 대상** 섹션에 추가.
+- 명시적으로 드롭됨 → **드롭** 섹션으로 이동 + 사유 기록.
+- 잠정 후보가 plan 문서로 승격되면 → **Plan 작성 완료** 섹션으로 이동 + plan 링크.
+- 구현이 완료되어 PR merge되면 → 이 파일에서 제거 + plan 문서가 `docs/plans/complete/`로 이동.

--- a/docs/plans/023-icon-component.md
+++ b/docs/plans/023-icon-component.md
@@ -1,0 +1,1089 @@
+# Icon + IconRegistry 컴포넌트 설계문서
+
+## Context
+
+plastic 라이브러리에 **일반 `Icon` 컴포넌트와 `IconRegistry` 시스템**을 도입한다. 현재 라이브러리는 컴포넌트마다 SVG를 inline으로 직접 그리고 있어 다음 문제가 누적되어 있다:
+
+1. **중복 구현**: 같은 의미의 아이콘(check, X close, spinner, warning, chevron-down)이 컴포넌트마다 viewBox·stroke·크기 다른 형태로 3~4개씩 존재
+2. **시각 일관성 결여**: viewBox는 `8x5`, `12x12`, `20x20`, `24x24` 4종이 혼재; stroke 폭은 `1.5`, `2`, `2.5`가 혼재; size는 `8`, `12`, `14`, `16`, `20` 5종이 혼재
+3. **애니메이션 중복**: spinner의 `@keyframes`가 컴포넌트별로 별도 정의 (`plastic-toast-spin`, `pathinput-spin` 등)
+4. **사용자 커스터마이징 불가**: 라이브러리 사용자가 특정 아이콘만 자기 디자인 시스템 아이콘으로 교체할 방법이 없음
+5. **번들 사이즈 비효율**: 사용자가 Toast만 import해도 SelectIcon의 chevron-down SVG는 같이 번들됨 (tree-shaking은 컴포넌트 단위, 아이콘 단위 아님)
+
+본 작업의 1차 목적은 **공통 `Icon` 컴포넌트 + `IconRegistry`**를 도입해 위 문제를 모두 흡수하고, 향후 추가 컴포넌트들이 자동으로 같은 아이콘 어휘를 따르게 만드는 것이다.
+
+참고 (prior art — 아이콘 시스템):
+- **Lucide React** — `<ChevronDown size={16} strokeWidth={2} />` 컴포넌트별 named export 패턴. tree-shaking 친화적. 1000+ 아이콘.
+- **Phosphor Icons** — `<Phosphor.ChevronDown weight="regular" />` weight variants(thin/light/regular/bold/fill/duotone).
+- **React Icons** — 여러 셋(FontAwesome, Material, etc.)을 prefix로 통합. `import { FaUser } from "react-icons/fa"`. 번들 사이즈 무거움.
+- **Iconify** — JSON 메타데이터 + 동적 로드. 100,000+ 아이콘 통합. CDN/번들 모두 지원.
+- **Radix Icons** — 작은 셋(~300), 단일 viewBox(`0 0 15 15`), `currentColor` 통일. 시각 일관성 강함.
+- **Heroicons** — Tailwind 팀의 공식 셋. 두 variant(outline/solid).
+- **Material Symbols** — variable font 기반, weight·grade·optical-size axis.
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/Toast/ToastIcon.tsx` — variant별 success/error/warning/info/default 5종 + spinner. viewBox `0 0 20 20`, stroke 1.5.
+- `src/components/Toast/ToastClose.tsx` — X close 아이콘.
+- `src/components/PathInput/PathInputStatus.tsx` — valid/invalid/warning/spinner 4종. viewBox `0 0 24 24`, stroke 2.5. **spinner keyframes를 자체 `<style>` 태그로 주입**.
+- `src/components/Select/SelectIcon.tsx` — chevron-down. viewBox `0 0 12 12`, stroke 1.5.
+- `src/components/Select/SelectItemIndicator.tsx` — check 아이콘. viewBox `0 0 12 12`, stroke 1.75.
+- `src/components/Combobox/ComboboxTrigger.tsx` — chevron-down (Select와 동일하지만 별도 구현).
+- `src/components/Popover/PopoverClose.tsx` — X close (ToastClose와 동일하지만 별도).
+- `src/components/Dialog/DialogClose.tsx` — X close (또 다른 별도 구현).
+- `src/components/Stepper/StepperStep.tsx`, `StepperNextButton.tsx` — 단계 표시 아이콘들.
+- `src/components/CommandPalette/CommandPaletteInput.tsx`, `CommandPaletteEmpty.tsx`, `CommandPaletteLoading.tsx`, `CommandPaletteItem.tsx` — search/empty/loading/chevron 4종.
+- `src/components/DataTable/DataTableHeader.tsx`, `DataTableEmpty.tsx` — sort arrows + empty state.
+- `src/components/Accordion/Accordion.tsx` (line 202) — chevron 토글.
+- `src/components/Progress/ProgressTrackCircular.tsx` — 원형 progress (아이콘 아닌 SVG, 본 작업 대상 아님).
+- `src/components/PipelineGraph/PipelineGraphEdge.tsx` — 엣지 path (본 작업 대상 아님, 그래프 그리기).
+- `src/components/Actionable/ActionableRevealTrigger.tsx` — reveal trigger 아이콘.
+- `src/index.ts` / `src/components/index.ts` — public API 진입점, Icon 추가 위치.
+- `tsconfig.json` — `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax`, `strict` 제약.
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+// 1. 가장 단순한 사용 — 등록된 아이콘 이름으로 호출
+<Icon name="chevron-down" />              // 16x16, currentColor
+<Icon name="chevron-down" size={20} />    // 명시적 사이즈
+<Icon name="x" size="sm" />               // 사이즈 토큰 ("xs"|"sm"|"md"|"lg"|"xl")
+
+// 2. 색상은 currentColor (부모 color 따라감)
+<button style={{ color: "red" }}>
+  <Icon name="trash" /> Delete
+</button>
+
+// 3. 회전·뒤집기·애니메이션
+<Icon name="spinner" spin />              // 회전 애니메이션 (1s linear infinite)
+<Icon name="chevron-right" rotate={90} /> // 90도 회전 (= chevron-down)
+<Icon name="arrow-right" flipH />         // 좌우 반전
+
+// 4. 라벨 (스크린리더용)
+<Icon name="trash" label="Delete item" /> // role=img + aria-label
+<Icon name="chevron-down" />              // 라벨 없으면 aria-hidden=true (장식)
+
+// 5. 사용자 정의 아이콘 등록
+import { registerIcon } from "@pihitpihit/plastic";
+
+registerIcon("custom-logo", (
+  <path d="M ..." />
+));
+
+<Icon name="custom-logo" />               // 등록된 아이콘 사용
+
+// 6. 외부 SVG 즉석 사용 (등록 없이)
+<Icon size={16}>
+  <path d="M ..." />
+</Icon>
+```
+
+핵심 설계 원칙:
+- **단일 viewBox 표준**: 모든 등록 아이콘은 `0 0 24 24`. 사용자 정의 아이콘은 `viewBox` prop으로 override 가능.
+- **`currentColor` 강제**: stroke/fill에 `currentColor`만 사용. 부모 `color`로 색상 상속. 컴포넌트가 자체 색상 prop을 가지지 않음 (CSS로 충분).
+- **사이즈 토큰 + 자유 값**: `xs(12) | sm(14) | md(16) | lg(20) | xl(24)` 토큰 + 임의 number/string도 허용.
+- **레지스트리 패턴**: 내장 아이콘 셋(아래 §6 목록)을 모듈 로드 시 자동 등록. 사용자는 `registerIcon(name, svgChildren)`로 자기 아이콘 추가.
+- **runtime-zero 핵심 아이콘**: 내장 아이콘은 SVG `<path>` JSX로 정의(외부 의존 0). 외부 셋(Lucide 등) 채택은 **명시적으로 거절**(§9 결정 사항 참조).
+- **headless 정신**: `className`/`style`로 모든 시각 속성 override 가능.
+- **accessibility**: `label` prop 있으면 `role="img" aria-label={label}`, 없으면 `aria-hidden="true"` (장식).
+- **마이그레이션 점진적**: 기존 컴포넌트 inline SVG는 **이번 작업 범위 내에서 모두 교체**. 단 PipelineGraph/Progress의 비-아이콘 SVG(엣지 path, 원형 progress)는 대상 아님.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. `<Icon name="..." />` 단일 컴포넌트로 모든 아이콘 사용.
+2. 내장 아이콘 셋 — **약 24종** (현 라이브러리 사용 + 향후 후보 컴포넌트 예상 분):
+   - Navigation: `chevron-up`, `chevron-down`, `chevron-left`, `chevron-right`
+   - Actions: `x`, `check`, `trash`, `copy`, `download`, `upload`, `external-link`, `more-horizontal`, `more-vertical`
+   - Status: `info`, `warning`, `error`, `success`, `help`
+   - Misc: `search`, `loader` (spinner), `plus`, `minus`, `arrow-right`, `arrow-left`
+3. **사이즈 토큰**: `xs(12) | sm(14) | md(16) | lg(20) | xl(24)` + 임의 number/string.
+4. **회전/반전**: `rotate?: 0 | 90 | 180 | 270`, `flipH?: boolean`, `flipV?: boolean`.
+5. **애니메이션**: `spin?: boolean` (1s linear infinite). spinner 전용이 아니라 임의 아이콘에 적용 가능.
+6. **`label` prop 기반 a11y**: 있으면 `role="img" aria-label={label}`, 없으면 `aria-hidden="true"`.
+7. **사용자 정의 아이콘 등록**: `registerIcon(name, children)`, `unregisterIcon(name)`, `hasIcon(name)`, `getIconNames()`.
+8. **inline 사용자 SVG**: `<Icon size={16}>{customSvgChildren}</Icon>` — `name` 없이 `children`만으로 사용 가능.
+9. **viewBox override**: `<Icon viewBox="0 0 32 32">{...}</Icon>` — 사용자 SVG의 viewBox 다를 때.
+10. **TypeScript 자동완성**: 내장 아이콘 이름이 `name` prop의 union type. 사용자 등록 아이콘은 module augmentation으로 확장 가능.
+11. **기존 컴포넌트 마이그레이션**: 위 §Context 의 기존 inline SVG 11개 파일을 모두 `<Icon />` 사용으로 교체.
+12. **단일 spinner keyframes**: `plastic-toast-spin`, `pathinput-spin` 중복 제거. `Icon`이 자체 keyframes 1개만 정의(`plastic-icon-spin`).
+13. 배럴 export — `export { Icon, registerIcon, unregisterIcon, hasIcon, getIconNames } from "./Icon"`.
+
+### Non-goals (v1 제외)
+- **외부 아이콘 셋 의존** (Lucide/Phosphor/Heroicons 채택). v1은 자체 24종. 사용자가 외부 셋을 쓰고 싶으면 `registerIcon`으로 직접 등록.
+- **다중 weight/style variants** (Phosphor의 `thin/light/regular/bold/fill/duotone`). v1은 단일 weight.
+- **아이콘 검색/카탈로그 UI** (Storybook의 icon gallery 같은). 데모 페이지에 단순 그리드만 표시.
+- **아이콘 lazy load** (Iconify 식 동적 fetch). v1 모든 내장 아이콘은 정적 번들.
+- **animated icons** (Lottie 등). v1은 `spin` 단일 애니메이션만.
+- **컬러 아이콘** (다중 색 fill). v1은 currentColor 단일 색만.
+- **아이콘 사이즈에 따른 자동 hairline 보정** (Material Symbols의 optical-size 같은). 모든 사이즈에서 동일 stroke.
+- **PipelineGraph 엣지 path / Progress 원형 SVG** 마이그레이션. 이들은 "아이콘"이 아니라 도식 SVG.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Icon/Icon.types.ts`
+
+```ts
+import type { CSSProperties, ReactNode, SVGAttributes } from "react";
+
+/**
+ * 사이즈 토큰. 토큰 값은 §2.2 SIZE_MAP 참조.
+ * - xs: 12px (작은 인디케이터, 인라인 텍스트 옆)
+ * - sm: 14px (PathInput 같은 폼 status)
+ * - md: 16px (기본값, 대부분의 버튼/메뉴 항목)
+ * - lg: 20px (Toast 아이콘, Dialog close)
+ * - xl: 24px (큰 강조)
+ */
+export type IconSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+/** 회전 각도. CSS rotate. */
+export type IconRotate = 0 | 90 | 180 | 270;
+
+/**
+ * 내장 아이콘 이름 — 모듈 로드 시 자동 등록.
+ * 사용자가 추가 아이콘 등록 시 module augmentation으로 확장 가능:
+ *
+ *   declare module "@pihitpihit/plastic" {
+ *     interface IconNameMap {
+ *       "custom-logo": true;
+ *       "custom-arrow": true;
+ *     }
+ *   }
+ */
+export interface IconNameMap {
+  // Navigation
+  "chevron-up": true;
+  "chevron-down": true;
+  "chevron-left": true;
+  "chevron-right": true;
+  "arrow-up": true;
+  "arrow-down": true;
+  "arrow-left": true;
+  "arrow-right": true;
+
+  // Actions
+  "x": true;
+  "check": true;
+  "trash": true;
+  "copy": true;
+  "download": true;
+  "upload": true;
+  "external-link": true;
+  "more-horizontal": true;
+  "more-vertical": true;
+  "plus": true;
+  "minus": true;
+
+  // Status
+  "info": true;
+  "warning": true;
+  "error": true;
+  "success": true;
+  "help": true;
+
+  // Misc
+  "search": true;
+  "loader": true;
+}
+
+/** Icon name = IconNameMap의 키 union. */
+export type IconName = keyof IconNameMap;
+
+export interface IconProps extends Omit<SVGAttributes<SVGSVGElement>, "children"> {
+  /**
+   * 등록된 아이콘 이름. 미지정 시 `children` 필수.
+   * `name`과 `children` 동시 지정 시 `children` 우선 (사용자 inline SVG가 등록 아이콘 override).
+   */
+  name?: IconName | (string & {}); // (string & {}) — 사용자 등록 이름 자동완성 + 자유 string 허용
+
+  /**
+   * 사이즈. 토큰 또는 임의 number(px)/string(CSS 길이).
+   * 기본 "md" (16px).
+   */
+  size?: IconSize | number | string;
+
+  /** 회전 각도. CSS transform: rotate(deg). */
+  rotate?: IconRotate;
+
+  /** 좌우 반전 (CSS transform: scaleX(-1)). */
+  flipH?: boolean;
+
+  /** 상하 반전 (CSS transform: scaleY(-1)). */
+  flipV?: boolean;
+
+  /** 회전 애니메이션. 기본 false. true면 1s linear infinite. */
+  spin?: boolean;
+
+  /**
+   * 스크린리더 라벨.
+   * - 지정 시: role="img" + aria-label.
+   * - 미지정 시: aria-hidden="true" (장식 아이콘).
+   */
+  label?: string;
+
+  /**
+   * viewBox override. 기본 "0 0 24 24".
+   * 사용자 inline SVG가 다른 viewBox일 때 지정.
+   */
+  viewBox?: string;
+
+  /**
+   * 사용자 inline SVG content (path/circle/g 등 자식 요소).
+   * `name` 미지정 시 필수.
+   */
+  children?: ReactNode;
+
+  className?: string;
+  style?: CSSProperties;
+}
+
+/** Registry entry — 아이콘 SVG content + viewBox. */
+export interface IconDefinition {
+  /** SVG 자식 요소 (path/circle/g 등). */
+  children: ReactNode;
+  /** viewBox. 기본 "0 0 24 24". 등록 시 다른 값 지정 가능. */
+  viewBox?: string;
+}
+```
+
+### 2.2 사이즈 토큰 매핑 — `src/components/Icon/Icon.tsx`
+
+```ts
+const SIZE_MAP: Record<IconSize, number> = {
+  xs: 12,
+  sm: 14,
+  md: 16,
+  lg: 20,
+  xl: 24,
+};
+
+function resolveSize(size: IconSize | number | string | undefined): string {
+  if (size === undefined) return "16px";
+  if (typeof size === "number") return `${size}px`;
+  if (typeof size === "string" && size in SIZE_MAP) {
+    return `${SIZE_MAP[size as IconSize]}px`;
+  }
+  // CSS 길이 그대로 (e.g., "1.5em", "20px", "1rem")
+  return size as string;
+}
+```
+
+### 2.3 레지스트리 API — `src/components/Icon/registry.ts`
+
+```ts
+import type { IconDefinition } from "./Icon.types";
+
+/** 모든 등록된 아이콘 저장소. 모듈 스코프. */
+const registry = new Map<string, IconDefinition>();
+
+/**
+ * 아이콘 등록.
+ *
+ * @example
+ *   registerIcon("custom-logo", (
+ *     <path d="M ..." />
+ *   ));
+ *   // 또는 viewBox 지정:
+ *   registerIcon("custom-logo", {
+ *     children: <path d="M ..." />,
+ *     viewBox: "0 0 32 32",
+ *   });
+ */
+export function registerIcon(
+  name: string,
+  definition: IconDefinition | IconDefinition["children"],
+): void {
+  if (typeof definition === "object" && definition !== null && "children" in definition) {
+    registry.set(name, definition);
+  } else {
+    registry.set(name, { children: definition as IconDefinition["children"] });
+  }
+}
+
+/** 아이콘 등록 해제. */
+export function unregisterIcon(name: string): boolean {
+  return registry.delete(name);
+}
+
+/** 아이콘 등록 여부 확인. */
+export function hasIcon(name: string): boolean {
+  return registry.has(name);
+}
+
+/** 등록된 모든 아이콘 이름 반환. */
+export function getIconNames(): string[] {
+  return Array.from(registry.keys());
+}
+
+/** @internal 내부에서만 사용 — Icon 컴포넌트가 호출. */
+export function getIconDefinition(name: string): IconDefinition | undefined {
+  return registry.get(name);
+}
+```
+
+### 2.4 내장 아이콘 등록 — `src/components/Icon/built-in.ts`
+
+```ts
+import { registerIcon } from "./registry";
+
+// 모듈 로드 시 즉시 모든 내장 아이콘 등록.
+// 사용자는 `import "@pihitpihit/plastic"` 만으로 모든 내장 아이콘 사용 가능.
+
+registerIcon("chevron-down", (
+  <path
+    d="M6 9l6 6 6-6"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  />
+));
+
+registerIcon("chevron-up", (
+  <path
+    d="M18 15l-6-6-6 6"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  />
+));
+
+// ... (24종 모두, §6 아이콘 catalog 참조)
+```
+
+### 2.5 Icon 컴포넌트 — `src/components/Icon/Icon.tsx`
+
+```tsx
+import type { CSSProperties, ReactElement } from "react";
+import { getIconDefinition } from "./registry";
+import type { IconProps } from "./Icon.types";
+
+const SIZE_MAP = { xs: 12, sm: 14, md: 16, lg: 20, xl: 24 } as const;
+
+const SPIN_KEYFRAMES_ID = "plastic-icon-spin-keyframes";
+const SPIN_KEYFRAMES = `@keyframes plastic-icon-spin{to{transform:rotate(360deg)}}`;
+
+function ensureSpinKeyframes() {
+  if (typeof document === "undefined") return;
+  if (document.getElementById(SPIN_KEYFRAMES_ID)) return;
+  const style = document.createElement("style");
+  style.id = SPIN_KEYFRAMES_ID;
+  style.textContent = SPIN_KEYFRAMES;
+  document.head.appendChild(style);
+}
+
+function resolveSize(size: IconProps["size"]): string {
+  if (size === undefined) return "16px";
+  if (typeof size === "number") return `${size}px`;
+  if (typeof size === "string" && size in SIZE_MAP) {
+    return `${SIZE_MAP[size as keyof typeof SIZE_MAP]}px`;
+  }
+  return size as string;
+}
+
+function buildTransform(
+  rotate: IconProps["rotate"],
+  flipH: boolean,
+  flipV: boolean,
+): string | undefined {
+  const parts: string[] = [];
+  if (rotate !== undefined && rotate !== 0) parts.push(`rotate(${rotate}deg)`);
+  if (flipH) parts.push(`scaleX(-1)`);
+  if (flipV) parts.push(`scaleY(-1)`);
+  return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+export function Icon(props: IconProps): ReactElement | null {
+  const {
+    name,
+    size,
+    rotate,
+    flipH = false,
+    flipV = false,
+    spin = false,
+    label,
+    viewBox: viewBoxProp,
+    children: childrenProp,
+    className,
+    style,
+    ...rest
+  } = props;
+
+  // children 우선; 없으면 registry에서 lookup
+  let children = childrenProp;
+  let resolvedViewBox = viewBoxProp;
+
+  if (children === undefined && name !== undefined) {
+    const def = getIconDefinition(name);
+    if (def !== undefined) {
+      children = def.children;
+      resolvedViewBox = viewBoxProp ?? def.viewBox ?? "0 0 24 24";
+    } else {
+      // 등록되지 않은 아이콘 — 개발 환경에서 경고
+      if (process.env.NODE_ENV !== "production") {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[Icon] Icon "${name}" is not registered. Use registerIcon() first.`,
+        );
+      }
+      return null;
+    }
+  }
+
+  if (children === undefined) {
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(`[Icon] Either "name" or "children" must be provided.`);
+    }
+    return null;
+  }
+
+  resolvedViewBox = resolvedViewBox ?? "0 0 24 24";
+
+  const px = resolveSize(size);
+  const transform = buildTransform(rotate, flipH, flipV);
+
+  // spin keyframes 보장 (마운트 시 1회만)
+  if (spin) ensureSpinKeyframes();
+
+  const a11yProps = label
+    ? { role: "img" as const, "aria-label": label }
+    : { "aria-hidden": true as const };
+
+  const mergedStyle: CSSProperties = {
+    display: "inline-block",
+    verticalAlign: "middle",
+    flexShrink: 0,
+    color: "currentColor",
+    ...(transform !== undefined ? { transform } : {}),
+    ...(spin ? { animation: "plastic-icon-spin 1s linear infinite" } : {}),
+    ...style,
+  };
+
+  return (
+    <svg
+      width={px}
+      height={px}
+      viewBox={resolvedViewBox}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      style={mergedStyle}
+      {...a11yProps}
+      {...rest}
+    >
+      {children}
+    </svg>
+  );
+}
+
+Icon.displayName = "Icon";
+```
+
+### 2.6 배럴 — `src/components/Icon/index.ts`
+
+```ts
+import "./built-in"; // side-effect: 내장 아이콘 자동 등록
+export { Icon } from "./Icon";
+export {
+  registerIcon,
+  unregisterIcon,
+  hasIcon,
+  getIconNames,
+} from "./registry";
+export type {
+  IconProps,
+  IconName,
+  IconNameMap,
+  IconSize,
+  IconRotate,
+  IconDefinition,
+} from "./Icon.types";
+```
+
+### 2.7 컴포넌트 배럴 추가 — `src/components/index.ts`
+
+```ts
+// ... 기존 export 위에 추가:
+export * from "./Icon";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/Icon/
+├── Icon.tsx              ← 메인 컴포넌트
+├── Icon.types.ts         ← 타입 정의 + IconNameMap
+├── registry.ts           ← register/unregister/has/getNames/getDefinition
+├── built-in.ts           ← 내장 아이콘 24종 등록 (side-effect)
+└── index.ts              ← 배럴
+```
+
+**왜 `built-in.ts`가 별도 파일인가**: tree-shaking 측면에서 `index.ts`가 `import "./built-in"`을 side-effect import로 표시하면, 사용자가 `Icon`만 import해도 모든 내장 아이콘이 번들에 포함된다. 이는 v1 의도된 동작이다 — 24종은 매우 작고(아이콘당 ~150바이트), tree-shaking 복잡성 도입 비용이 이득보다 큼.
+
+향후 내장 아이콘이 100종+로 늘어나면 v2에서 named export 패턴으로 리팩토링 검토(`import { ChevronDownIcon } from "@pihitpihit/plastic/icons"`).
+
+---
+
+## 4. 동작 명세
+
+### 4.1 아이콘 lookup 순서
+
+`<Icon name="X" children={Y} />` 호출 시:
+
+1. `children` (Y)가 정의되어 있으면 그것을 사용. (사용자 inline SVG 우선)
+2. `children` 없고 `name` (X)이 정의되어 있으면 `getIconDefinition(X)` lookup.
+3. 둘 다 없으면 `console.warn` + `null` 반환 (개발 모드에서만 경고).
+4. lookup 실패 시 (등록 안 된 이름) `console.warn` + `null` 반환.
+
+### 4.2 viewBox 결정 순서
+
+1. `viewBox` prop이 명시되면 그것 사용.
+2. registry definition의 viewBox가 있으면 그것 사용.
+3. 둘 다 없으면 `"0 0 24 24"` (기본).
+
+### 4.3 사이즈 결정
+
+| 입력 | 결과 |
+|---|---|
+| undefined | `16px` (기본 md) |
+| `"xs"` ~ `"xl"` | SIZE_MAP 매핑값 + "px" |
+| number (e.g., 32) | `32px` |
+| string (e.g., `"1.5em"`, `"20px"`, `"1rem"`) | 그대로 |
+
+### 4.4 색상
+
+- SVG 자체에 `fill="none"` 기본 적용.
+- 모든 path/stroke는 `currentColor` 사용 (built-in 아이콘 정의에 강제).
+- `style.color`로 색상 제어. 부모 `color` 자동 상속.
+- `Icon` 자체는 색상 prop 없음.
+
+### 4.5 회전 / 반전
+
+`rotate` + `flipH` + `flipV`는 CSS `transform`으로 합성:
+- `rotate(90deg)` + `scaleX(-1)` → `transform: rotate(90deg) scaleX(-1)`
+- 모두 0/false면 `transform` 미설정.
+
+### 4.6 spin 애니메이션
+
+- `spin={true}` 시 `animation: plastic-icon-spin 1s linear infinite` 적용.
+- 첫 spin 사용 시 `<style id="plastic-icon-spin-keyframes">` 태그를 `document.head`에 1회만 주입 (idempotent).
+- SSR 환경에서는 주입 skip (`typeof document === "undefined"`).
+- `prefers-reduced-motion: reduce` 처리는 v1 미포함 — 사용자가 직접 CSS로 override (향후 v1.1에서 자동 감지 검토).
+
+### 4.7 접근성
+
+```tsx
+// 장식 아이콘 (텍스트 옆 부수 요소)
+<button>
+  <Icon name="trash" /> Delete
+</button>
+// → <svg aria-hidden="true">
+
+// 의미 있는 아이콘 (단독 버튼)
+<button>
+  <Icon name="trash" label="Delete item" />
+</button>
+// → <svg role="img" aria-label="Delete item">
+```
+
+---
+
+## 5. 마이그레이션 — 기존 inline SVG 교체
+
+현재 11개 파일에 35개 inline SVG가 존재. 이 작업의 일부로 모두 `<Icon />`으로 교체한다.
+
+### 5.1 교체 매핑 표
+
+| 파일 | 현재 SVG | 교체 후 |
+|---|---|---|
+| `Toast/ToastIcon.tsx` | success/error/warning/info/default 5종 + spinner | `<Icon name="success" />` 등 5종 + `<Icon name="loader" spin />` |
+| `Toast/ToastClose.tsx` | X close (16x16) | `<Icon name="x" size="md" />` |
+| `PathInput/PathInputStatus.tsx` | valid(check)/invalid(X-circle)/warning + spinner | `<Icon name="check" size="sm" />`, `<Icon name="error" size="sm" />`, `<Icon name="warning" size="sm" />`, `<Icon name="loader" size="sm" spin />` |
+| `Select/SelectIcon.tsx` | chevron-down (12x12) | `<Icon name="chevron-down" size="xs" />` |
+| `Select/SelectItemIndicator.tsx` | check (12x12) | `<Icon name="check" size="xs" />` |
+| `Combobox/ComboboxTrigger.tsx` | chevron-down | `<Icon name="chevron-down" size="xs" />` |
+| `Popover/PopoverClose.tsx` | X close | `<Icon name="x" size="sm" />` |
+| `Dialog/DialogClose.tsx` | X close | `<Icon name="x" size="md" />` |
+| `Stepper/StepperStep.tsx` | check + 단계 표시 | `<Icon name="check" size="sm" />` 등 |
+| `Stepper/StepperNextButton.tsx` | arrow-right | `<Icon name="arrow-right" size="sm" />` |
+| `Accordion/Accordion.tsx:202` | chevron 토글 | `<Icon name="chevron-down" rotate={open ? 180 : 0} />` |
+| `Actionable/ActionableRevealTrigger.tsx` | reveal trigger | `<Icon name="more-horizontal" size="sm" />` (또는 신규 등록) |
+| `CommandPalette/CommandPaletteInput.tsx` | search | `<Icon name="search" size="sm" />` |
+| `CommandPalette/CommandPaletteItem.tsx` | chevron | `<Icon name="chevron-right" size="xs" />` |
+| `CommandPalette/CommandPaletteEmpty.tsx` | empty illustration | (단순 아이콘 아님 — `<Icon name="search" size="xl" />` 등으로 대체 또는 유지) |
+| `CommandPalette/CommandPaletteLoading.tsx` | spinner | `<Icon name="loader" spin />` |
+| `DataTable/DataTableHeader.tsx` | sort up/down arrows (8x5) | `<Icon name="chevron-up" size="xs" />`, `<Icon name="chevron-down" size="xs" />` |
+| `DataTable/DataTableEmpty.tsx` | empty illustration | (검토 필요 — 일러스트인지 아이콘인지) |
+
+**제외 (마이그레이션 대상 아님):**
+- `PipelineGraph/PipelineGraphEdge.tsx` — 그래프 엣지 path
+- `Progress/ProgressTrackCircular.tsx` — 원형 progress 트랙
+
+### 5.2 마이그레이션 시 주의사항
+
+1. **사이즈 매핑 신중히**: 기존 width/height (8/12/14/16/20)를 가장 가까운 토큰으로. 8x5는 "xs" (12) 또는 inline number(`size={10}`).
+2. **색상 처리**: 기존 컴포넌트가 `style.color`로 색상 제어 중인 경우 그대로 작동. 컴포넌트가 SVG에 직접 색상 prop 넘기던 경우(`<svg fill="#dc2626">`)는 부모 `style.color`로 옮겨야 함.
+3. **애니메이션 keyframes 정리**: PathInput의 `<style>{`@keyframes pathinput-spin...`}</style>`, Toast의 `plastic-toast-spin` 정의 모두 **삭제**. Icon이 자체 keyframes 관리.
+4. **spinner 컴포넌트 정의도 정리**: `Toast/ToastIcon.tsx`의 `SpinnerIcon` named export, `PathInput/PathInputStatus.tsx`의 `SpinnerIcon` 등 더 이상 필요 없으면 삭제.
+
+### 5.3 마이그레이션 검증
+
+각 컴포넌트 데모 페이지(`demo/src/pages/*.tsx`)에서 다음 항목 시각 회귀 확인:
+- 아이콘 사이즈가 이전과 동일하게 보이는가
+- 색상이 이전과 동일한가 (호버/액티브/disabled 상태별)
+- 회전 애니메이션(spinner)이 이전과 동일한 속도/방향인가
+- 다크 테마에서도 정상인가
+
+---
+
+## 6. 내장 아이콘 카탈로그 (§4 모든 24종 SVG path)
+
+각 아이콘은 `0 0 24 24` viewBox, stroke="currentColor", fill="none" 또는 fill="currentColor" 기준.
+
+### Navigation (8종)
+
+```tsx
+"chevron-up":     <path d="M18 15l-6-6-6 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+"chevron-down":   <path d="M6 9l6 6 6-6"   stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+"chevron-left":   <path d="M15 18l-6-6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+"chevron-right":  <path d="M9 18l6-6-6-6"  stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+"arrow-up":       <path d="M12 19V5M5 12l7-7 7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+"arrow-down":     <path d="M12 5v14M19 12l-7 7-7-7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+"arrow-left":     <path d="M19 12H5M12 19l-7-7 7-7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+"arrow-right":    <path d="M5 12h14M12 5l7 7-7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+```
+
+### Actions (11종)
+
+```tsx
+"x":              <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+"check":          <path d="M20 6L9 17l-5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+"trash":          <>
+                    <path d="M3 6h18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                    <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                  </>
+"copy":           <>
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                  </>
+"download":       <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+"upload":         <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M17 8l-5-5-5 5M12 3v12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+"external-link":  <>
+                    <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    <polyline points="15 3 21 3 21 9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    <line x1="10" y1="14" x2="21" y2="3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                  </>
+"more-horizontal": <>
+                    <circle cx="12" cy="12" r="1" fill="currentColor" />
+                    <circle cx="19" cy="12" r="1" fill="currentColor" />
+                    <circle cx="5" cy="12" r="1" fill="currentColor" />
+                  </>
+"more-vertical":  <>
+                    <circle cx="12" cy="12" r="1" fill="currentColor" />
+                    <circle cx="12" cy="5" r="1" fill="currentColor" />
+                    <circle cx="12" cy="19" r="1" fill="currentColor" />
+                  </>
+"plus":           <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+"minus":          <path d="M5 12h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+```
+
+### Status (5종)
+
+```tsx
+"info":           <>
+                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+                    <line x1="12" y1="16" x2="12" y2="12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                    <line x1="12" y1="8" x2="12.01" y2="8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  </>
+"warning":        <>
+                    <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    <line x1="12" y1="9" x2="12" y2="13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                    <line x1="12" y1="17" x2="12.01" y2="17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  </>
+"error":          <>
+                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+                    <line x1="15" y1="9" x2="9" y2="15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                    <line x1="9" y1="9" x2="15" y2="15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  </>
+"success":        <>
+                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+                    <path d="M9 12l2 2 4-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                  </>
+"help":           <>
+                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+                    <path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    <line x1="12" y1="17" x2="12.01" y2="17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  </>
+```
+
+### Misc (2종)
+
+```tsx
+"search":         <>
+                    <circle cx="11" cy="11" r="8" stroke="currentColor" strokeWidth="2" />
+                    <line x1="21" y1="21" x2="16.65" y2="16.65" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  </>
+"loader":         <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+```
+
+**기준 디자인**: Lucide / Feather 스타일 (linear, stroke-based, 24x24 viewBox, stroke 2). 시각 일관성 위해 모든 아이콘이 동일 viewBox·stroke·linecap·linejoin 사용.
+
+---
+
+## 7. 데모 페이지 — `demo/src/pages/IconPage.tsx`
+
+```tsx
+import { Card, Icon, getIconNames } from "@pihitpihit/plastic";
+
+export function IconPage() {
+  return (
+    <div>
+      <h1>Icon</h1>
+
+      {/* 섹션 1: 모든 내장 아이콘 그리드 */}
+      <Card.Root>
+        <Card.Header>Built-in Icons (24)</Card.Header>
+        <Card.Body>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(6, 1fr)", gap: 16 }}>
+            {getIconNames().map((name) => (
+              <div key={name} style={{ textAlign: "center" }}>
+                <Icon name={name} size="xl" />
+                <div style={{ fontSize: 11, marginTop: 6, color: "#666" }}>{name}</div>
+              </div>
+            ))}
+          </div>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 2: 사이즈 토큰 */}
+      <Card.Root>
+        <Card.Header>Sizes</Card.Header>
+        <Card.Body>
+          <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+            <Icon name="check" size="xs" /> xs (12)
+            <Icon name="check" size="sm" /> sm (14)
+            <Icon name="check" size="md" /> md (16, default)
+            <Icon name="check" size="lg" /> lg (20)
+            <Icon name="check" size="xl" /> xl (24)
+            <Icon name="check" size={48} /> 48 (custom)
+          </div>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 3: 색상 (currentColor 상속) */}
+      <Card.Root>
+        <Card.Header>Color (inherits via currentColor)</Card.Header>
+        <Card.Body>
+          <div style={{ color: "red" }}><Icon name="error" /> Red error</div>
+          <div style={{ color: "green" }}><Icon name="success" /> Green success</div>
+          <div style={{ color: "#2563eb" }}><Icon name="info" /> Blue info</div>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 4: 회전 / 반전 */}
+      <Card.Root>
+        <Card.Header>Rotate / Flip</Card.Header>
+        <Card.Body>
+          <Icon name="chevron-down" rotate={0} /> 0°
+          <Icon name="chevron-down" rotate={90} /> 90°
+          <Icon name="chevron-down" rotate={180} /> 180°
+          <Icon name="chevron-down" rotate={270} /> 270°
+          <Icon name="arrow-right" flipH /> flipH
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 5: spin */}
+      <Card.Root>
+        <Card.Header>Spin animation</Card.Header>
+        <Card.Body>
+          <Icon name="loader" spin />
+          <Icon name="loader" size="lg" spin />
+          <Icon name="loader" size="xl" spin />
+          {/* 임의 아이콘에도 적용 가능 */}
+          <Icon name="check" spin />
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 6: 사용자 등록 + inline */}
+      <Card.Root>
+        <Card.Header>Custom registration / inline children</Card.Header>
+        <Card.Body>
+          {/* inline */}
+          <Icon size={24} viewBox="0 0 24 24" label="Custom shape">
+            <rect x="4" y="4" width="16" height="16" stroke="currentColor" strokeWidth="2" fill="none" />
+          </Icon>
+
+          {/* 등록된 사용자 아이콘 — registerIcon은 컴포넌트 외부에서 호출 */}
+          <Icon name="my-custom" />
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 7: a11y */}
+      <Card.Root>
+        <Card.Header>Accessibility</Card.Header>
+        <Card.Body>
+          {/* 장식 — aria-hidden */}
+          <button><Icon name="trash" /> Delete</button>
+
+          {/* 의미 있는 단독 아이콘 — role=img + aria-label */}
+          <button><Icon name="trash" label="Delete item" /></button>
+        </Card.Body>
+      </Card.Root>
+    </div>
+  );
+}
+```
+
+데모 라우팅 등록 — `demo/src/App.tsx`의 NAV에 `Icon` 항목 추가:
+
+```tsx
+const PAGES = [
+  // ... 기존 페이지들
+  { id: "icon", label: "Icon", component: IconPage },
+];
+```
+
+---
+
+## 8. 접근성 (a11y)
+
+### 8.1 `label` 미지정 (장식 아이콘)
+```tsx
+<svg aria-hidden="true">
+```
+스크린리더가 무시. 부모 요소(보통 button)의 텍스트 라벨이 의미 전달 책임을 가짐.
+
+### 8.2 `label` 지정 (의미 있는 아이콘)
+```tsx
+<svg role="img" aria-label="Delete item">
+```
+스크린리더가 라벨 읽음. 단독 아이콘 버튼/링크에 사용.
+
+### 8.3 검증 항목
+- [ ] VoiceOver (macOS): label 있는 아이콘 → 라벨 읽음, 없으면 무시.
+- [ ] NVDA (Windows): 동일.
+- [ ] JAWS (Windows): 동일.
+- [ ] axe-core 자동 검사 (개발 시): role/aria 속성 일관성.
+
+### 8.4 색상 대비
+- 아이콘 색상 자체는 컴포넌트 책임 아님 (currentColor → 부모 책임).
+- 다만 데모 페이지에서 light/dark 테마 모두 명확히 보이는지 시각 확인 필요.
+
+---
+
+## 9. 설계 결정 사항 (rationale)
+
+### 9.1 외부 아이콘 셋(Lucide 등) 채택 안 함
+**이유**:
+- 현재 사용 중인 아이콘 종류가 24개 미만 → 외부 셋(1000+) 의존은 과한 부담.
+- 외부 셋의 디자인 언어가 plastic의 기존 컴포넌트 시각과 100% 일치하지 않음 (특히 viewBox/stroke).
+- 추가 npm 의존성 = peer 호환성 문제·번들 사이즈·버전 관리 부담.
+- 사용자가 외부 셋을 쓰고 싶으면 `registerIcon`으로 자유롭게 추가 가능 — 채택을 강제하지 않음.
+
+**v2 검토 조건**: 내장 아이콘이 100종+가 되거나, 사용자가 외부 셋 채택을 강하게 요구하는 경우 재검토.
+
+### 9.2 단일 viewBox `0 0 24 24` 강제
+**이유**: 시각 일관성. 현재 4종의 viewBox(8x5, 12x12, 20x20, 24x24)가 혼재해 stroke 두께가 사이즈마다 달라 보이는 문제를 해결. Lucide·Feather·Material Symbols 모두 24 기반.
+
+**예외**: 사용자 inline SVG는 `viewBox` prop으로 다른 값 지정 가능.
+
+### 9.3 색상 prop 안 둠
+**이유**: `currentColor` + 부모 `color` 패턴이 React/CSS 생태계 표준. `color` prop 추가는 이중 진실 원천 만듦. 사용자가 직접 `style={{ color: "..." }}` 쓰는 게 명확.
+
+### 9.4 spinner를 별도 컴포넌트로 안 만들고 `<Icon spin />`로 해결
+**이유**: spinner는 단지 "회전하는 아이콘"이고 아이콘 모양은 다양함(loader, refresh, etc.). spin 동작은 직교 prop으로 분리하는 게 합성성 좋음. 또한 keyframes 중복 제거 효과 큼.
+
+### 9.5 registry를 모듈 스코프 Map으로
+**이유**: React Context로 만들 수도 있지만, 아이콘 등록은 앱 전역 단일 진실 원천이면 충분. Provider 트리 강제는 사용 부담만 늘림. 단점은 SSR에서 hydration 시 등록 타이밍 주의 필요 → built-in은 모듈 로드 시 즉시 등록되므로 안전, 사용자 등록은 컴포넌트 마운트 전(앱 진입점)에 호출 권장.
+
+### 9.6 `name`이 `IconName | (string & {})` 타입
+**이유**: TypeScript에서 union literal type + `string & {}` 패턴은 자동완성을 유지하면서 자유 string도 허용. 사용자가 module augmentation으로 IconNameMap을 확장하지 않고도 `<Icon name="my-custom" />` 사용 가능 (런타임 lookup만).
+
+---
+
+## 10. Edge cases
+
+### 10.1 등록 안 된 아이콘 호출
+```tsx
+<Icon name="nonexistent" />
+// → console.warn("[Icon] Icon \"nonexistent\" is not registered. Use registerIcon() first.")
+// → null 반환 (DOM에 아무것도 안 그림)
+```
+
+`null` 반환은 사용자 코드 깨뜨리지 않으면서 개발 시 빠르게 알아차리게 함.
+
+### 10.2 `name`도 `children`도 없음
+```tsx
+<Icon />
+// → console.warn("[Icon] Either \"name\" or \"children\" must be provided.")
+// → null 반환
+```
+
+### 10.3 SSR
+- `built-in.ts`의 `registerIcon` 호출은 모듈 로드 시 동기적으로 실행 → SSR에서 안전.
+- spin 사용 시 `ensureSpinKeyframes()`는 `typeof document === "undefined"` 가드 → SSR 안전.
+- 하이드레이션 후 클라이언트에서 첫 spin 호출 시 keyframes 주입 (1회).
+
+### 10.4 같은 이름 중복 등록
+```tsx
+registerIcon("check", svgA);
+registerIcon("check", svgB); // svgB가 svgA를 덮어씀 (Map.set)
+```
+**이유**: 사용자가 내장 아이콘을 의도적으로 override하는 케이스 지원. 경고 안 함 (의도적 동작).
+
+### 10.5 사용자 inline SVG가 잘못된 viewBox
+```tsx
+<Icon size={16}>
+  <path d="M ..." /> {/* viewBox 명시 안 함 → 기본 0 0 24 24 사용 → path가 24 좌표계 아니면 깨짐 */}
+</Icon>
+```
+**해결**: 문서에 명시 — inline children 사용 시 path 좌표가 24x24 기준이거나 `viewBox` prop으로 명시 필요.
+
+### 10.6 `rotate` + `spin` 동시 사용
+```tsx
+<Icon name="loader" spin rotate={45} />
+```
+CSS `animation`이 `transform`을 덮어씀 (spin keyframes 안에 `transform: rotate(360deg)` 있음). 결과: rotate prop 무시되고 spin만 적용. 이는 의도된 동작이며 v1에선 문서로 안내.
+
+향후 v1.1: `rotate` 시작 각도를 spin 시작점으로 사용하려면 `--icon-base-rotate` CSS variable 도입 검토.
+
+### 10.7 매우 큰 `size`
+```tsx
+<Icon name="check" size={1000} />
+```
+SVG는 viewBox 기반 벡터라 무한 확대 가능. 다만 stroke가 1000px 사이즈에서 매우 가늘어 보일 수 있음(stroke 2가 1000/24 = ~41배 작아짐). 의도적 — 디자인 수정은 사용자 책임.
+
+### 10.8 `registerIcon` 호출 타이밍
+사용자가 컴포넌트 렌더 후에 등록하면 첫 렌더 시 null 반환 → 등록 후 재렌더 필요. 권장: **앱 진입점(`main.tsx`/`App.tsx` top level)에서 한 번 등록**. 문서에 명시.
+
+---
+
+## 11. 구현 단계 (Phase)
+
+### Phase 1: 코어 (Icon + registry + 내장 아이콘)
+1. `src/components/Icon/Icon.types.ts` 작성
+2. `src/components/Icon/registry.ts` 작성
+3. `src/components/Icon/built-in.ts` — 24종 모두 등록
+4. `src/components/Icon/Icon.tsx` 작성
+5. `src/components/Icon/index.ts` 배럴 작성
+6. `src/components/index.ts`에 `export * from "./Icon"` 추가
+7. `npm run typecheck` 통과 확인
+8. `npm run build` 통과 확인
+
+### Phase 2: 데모 페이지
+1. `demo/src/pages/IconPage.tsx` 작성 (§7 템플릿 그대로)
+2. `demo/src/App.tsx` NAV에 Icon 항목 추가
+3. `cd demo && npm run dev` 후 브라우저에서 모든 섹션 시각 확인
+4. light/dark 테마 모두 확인
+
+### Phase 3: 마이그레이션 — 작은 컴포넌트부터
+순서: 의존도 적은 단일 SVG 컴포넌트 → 복잡한 다중 SVG 컴포넌트.
+
+1. `Select/SelectIcon.tsx` — chevron-down 1개. 가장 단순.
+2. `Select/SelectItemIndicator.tsx` — check 1개.
+3. `Combobox/ComboboxTrigger.tsx` — chevron-down 1개.
+4. `Popover/PopoverClose.tsx` — X 1개.
+5. `Dialog/DialogClose.tsx` — X 1개.
+6. `Accordion/Accordion.tsx` (line 202) — chevron 토글.
+7. `Stepper/StepperStep.tsx`, `StepperNextButton.tsx` — check + arrow.
+8. `Actionable/ActionableRevealTrigger.tsx`.
+9. `CommandPalette/CommandPaletteInput.tsx` — search.
+10. `CommandPalette/CommandPaletteItem.tsx` — chevron.
+11. `CommandPalette/CommandPaletteLoading.tsx` — spinner.
+12. `CommandPalette/CommandPaletteEmpty.tsx` — 검토 후 결정.
+13. `DataTable/DataTableHeader.tsx` — sort arrows.
+14. `DataTable/DataTableEmpty.tsx` — 검토 후 결정.
+15. `PathInput/PathInputStatus.tsx` — valid/invalid/warning + spinner. **자체 keyframes 삭제 주의**.
+16. `Toast/ToastIcon.tsx` — variant별 5종 + spinner. **`SpinnerIcon` named export 삭제, `plastic-toast-spin` keyframes 정의 삭제**.
+17. `Toast/ToastClose.tsx` — X.
+
+각 단계 완료 시:
+- `npm run typecheck`
+- 해당 컴포넌트 데모 페이지에서 시각 회귀 확인
+- 다크 테마 확인
+- 인터랙션(호버/액티브/포커스) 확인
+
+### Phase 4: 정리
+1. 더 이상 사용 안 되는 spinner keyframes 모두 검색·삭제 (`grep -r "@keyframes.*spin"`).
+2. 더 이상 사용 안 되는 SVG 헬퍼 함수(`SpinnerIcon`, `ValidIcon` 등) 삭제.
+3. `Toast`의 `iconColor` palette는 유지 (severity 토큰 추출 시 `_shared/severity.ts`로 이동 — 037 Alert plan 참조).
+4. README.md에 Icon 섹션 추가.
+
+---
+
+## 12. 테스팅
+
+본 라이브러리는 자동 테스트 없음. 수동 QA 항목:
+
+### 12.1 단위 동작
+- [ ] 등록된 모든 24종 아이콘이 데모 페이지에 정상 렌더
+- [ ] 모든 사이즈 토큰(xs/sm/md/lg/xl) 정확한 픽셀
+- [ ] 임의 number/string size 적용
+- [ ] currentColor가 부모 color 상속
+- [ ] rotate 4종(0/90/180/270) 정상
+- [ ] flipH/flipV 정상
+- [ ] spin 애니메이션 부드러움 (1초 1회전)
+
+### 12.2 a11y
+- [ ] label 없으면 `aria-hidden="true"` (DevTools 확인)
+- [ ] label 있으면 `role="img"` + `aria-label="..."` (DevTools 확인)
+- [ ] VoiceOver로 label 있는 아이콘 → 라벨 읽음
+- [ ] VoiceOver로 label 없는 아이콘 → 무시
+
+### 12.3 사용자 등록
+- [ ] `registerIcon("foo", <path .../>)` 후 `<Icon name="foo" />` 렌더
+- [ ] `unregisterIcon("foo")` 후 `<Icon name="foo" />` → null + 경고
+- [ ] `hasIcon("foo")` 정확
+- [ ] `getIconNames()` 등록 순서대로 반환
+
+### 12.4 마이그레이션 회귀
+각 마이그레이션된 컴포넌트의 데모 페이지에서:
+- [ ] 시각이 마이그레이션 전과 동일 (스크린샷 비교 권장)
+- [ ] 인터랙션(호버/액티브/포커스/disabled) 정상
+- [ ] 다크 테마 정상
+- [ ] spinner 회전 속도/방향 동일
+
+### 12.5 SSR (해당 시)
+- [ ] Node 환경에서 `Icon` import → 에러 없음
+- [ ] SSR 마크업에 spin keyframes 없음 (클라이언트에서 주입)
+
+---
+
+## 13. 향후 확장 (v1.1+)
+
+| 항목 | 설명 |
+|---|---|
+| `prefers-reduced-motion` 자동 감지 | spin을 자동 off |
+| weight variants | `weight?: "thin" \| "regular" \| "bold"` 추가 |
+| named icon export | `import { ChevronDownIcon } from "@pihitpihit/plastic/icons"` (tree-shaking 강화, 100+ 아이콘 시) |
+| 외부 셋 어댑터 | `import { fromLucide } from "@pihitpihit/plastic/icons/lucide"` 형태 |
+| icon catalog 데모 | 사용자가 검색·복사할 수 있는 카탈로그 페이지 |
+| animated icons | Lottie 통합 또는 자체 keyframes 시스템 |
+
+---
+
+## 14. 체크리스트 (작업 완료 기준)
+
+- [ ] `src/components/Icon/` 5개 파일 작성 완료
+- [ ] 24종 내장 아이콘 모두 시각 확인 완료
+- [ ] `npm run typecheck` 통과
+- [ ] `npm run build` 통과 (dist에 Icon 포함 확인)
+- [ ] `demo/src/pages/IconPage.tsx` 작성 + NAV 등록
+- [ ] 17개 컴포넌트 마이그레이션 완료 (§5.1 매핑 표)
+- [ ] 모든 spinner keyframes 중복 제거 완료
+- [ ] 모든 마이그레이션된 컴포넌트의 데모 페이지 시각 회귀 확인 (light/dark)
+- [ ] README.md에 Icon 섹션 추가
+- [ ] `docs/candidates.md`에서 17번 항목 제거 + 본 plan 링크로 교체
+- [ ] PR 디스크립션에 변경 요약 (신규 추가 + 마이그레이션 양 명시)

--- a/docs/plans/024-linenumbers-component.md
+++ b/docs/plans/024-linenumbers-component.md
@@ -1,0 +1,1017 @@
+# LineNumbers 컴포넌트 설계문서 (CodeView 추출)
+
+## Context
+
+`CodeView`(이미 구현됨) 내부에서 자체적으로 그리고 있는 **라인번호 컬럼(gutter)**을 단독 컴포넌트 `LineNumbers`로 추출한다. 추출 후 CodeView는 내부에서 이 컴포넌트를 사용하도록 리팩토링되며, 동시에 `LineNumbers`는 public API로 export되어 향후 추가될 라인 단위 표시 컴포넌트(LogView, Terminal, DiffView 등)가 같은 라인번호 어휘를 공유할 수 있게 한다.
+
+본 작업은 **새 컴포넌트 추가 + 기존 컴포넌트 내부 리팩토링**의 두 측면을 가진다. 행동(behavior)·시각(visual)·접근성(a11y) 모두 추출 전과 100% 동일해야 하며, CodeView의 textarea overlay 좌표 정렬, copy 로직(`data-gutter` 속성 의존), sticky 위치, 테마 인식 등 미세 디테일이 깨지지 않아야 한다.
+
+본 작업은 `Calendar`를 `DatePicker`에서 분리하는 것과 동일한 패턴(plan 025 참조). 기존 컴포넌트의 내부 일부를 export 가능한 단독 컴포넌트로 승격하면서, 원래 컴포넌트가 그것의 첫 번째 컨슈머가 되는 구조다.
+
+참고 (prior art — line number gutter):
+- **VS Code 에디터** — sticky-left 라인번호, 활성 라인 강조, breakpoint marker, fold marker 통합. 매우 풍부.
+- **Monaco editor** — `lineNumbers: "on" | "off" | "relative" | "interval" | function`. relative는 현재 라인 기준 상대 번호.
+- **CodeMirror 6** — `lineNumbers()` extension, `gutter()` 일반 시스템(라인번호도 한 종류). marker (브레이크포인트 등) 추가 가능.
+- **react-syntax-highlighter** — `showLineNumbers={true}` + `lineNumberStyle={...}`.
+- **Prism.js** — `<pre><code class="line-numbers">...` 자동 생성 plugin.
+- **GitHub diff/blame** — 라인번호 옆 blame 정보, 라인 클릭 시 URL 해시 변경.
+- **Source map navigation** — 라인번호 클릭 → "이 라인으로 이동" 또는 영구 링크.
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/CodeView/CodeView.tsx` (653줄) — 추출 대상.
+  - `lineNumberColor` 상수 (line 18-41) — 라인번호 텍스트/배경 색상 테마 매핑.
+  - `getGutterWidth(lineCount)` (line 43-48) — 자릿수 기반 너비 계산.
+  - `walkEffectiveNodes` (line 65-90) — copy 로직, `data-gutter="true"` 속성을 skip 마커로 사용.
+  - 렌더 부 (line 467-519) — `gutterStyle` 정의, 행별 `<span data-gutter>` 라인번호 렌더링.
+  - 라인번호 컬럼 너비를 textarea overlay의 `paddingLeft`에 반영 (line 521-524, 624).
+- `src/components/CodeView/CodeView.types.ts` — `gutterWidth?: string`, `gutterGap?: string`, `showLineNumbers?: boolean` props.
+- `src/components/CodeView/index.ts` — public API.
+- `src/components/index.ts` — 새 `LineNumbers` 추가 위치.
+- `src/components/Icon/` (plan 023) — 향후 LineNumbers의 marker 슬롯에서 사용 가능 (v1 범위 외).
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+// 1. 단독 사용 — 가장 단순한 형태
+<LineNumbers count={20} />
+// → 1, 2, 3, ..., 20 의 sticky-left 컬럼 렌더
+
+// 2. 시작 번호 지정 (페이지네이션, diff hunk 등)
+<LineNumbers count={50} start={101} />
+// → 101 부터 150
+
+// 3. 강조 라인 (활성 라인, 검색 매치 등)
+<LineNumbers count={20} highlightLines={[5, 7, 12]} />
+
+// 4. 라인 클릭 핸들러 (영구 링크 등)
+<LineNumbers count={20} onLineClick={(n) => location.hash = `#L${n}`} />
+
+// 5. 컨텐츠와 짝으로 사용 — 부모가 grid/flex 로 정렬
+<div style={{ display: "flex" }}>
+  <LineNumbers count={lines.length} />
+  <pre>{lines.join("\n")}</pre>
+</div>
+
+// 6. CodeView 내부 사용 (per-line) — single-cell 모드
+<LineNumbers.Cell lineNumber={li + 1} highlighted={highlightLines?.includes(li + 1)} />
+
+// 7. relative 라인번호 (현재 라인 기준)
+<LineNumbers count={20} relative activeLine={10} />
+// → ..., 3, 2, 1, 0(=10), 1, 2, 3, ... 형태
+```
+
+핵심 설계 원칙:
+- **두 모드 지원**: column 모드(`<LineNumbers count={N} />`)와 cell 모드(`<LineNumbers.Cell lineNumber={N} />`).
+  - column 모드: 단순 사용처 (LogView, 정적 코드 표시 등).
+  - cell 모드: CodeView처럼 행별로 직접 임베드해야 하는 복잡 레이아웃.
+- **CodeView 시각·동작 100% 보존**: 추출 후 CodeView 데모 페이지의 모든 항목이 시각적으로 동일해야 함. textarea overlay 정렬, copy 로직, sticky 위치, 테마, gutter width 자동 계산 모두 유지.
+- **`data-gutter="true"` 속성 유지**: CodeView의 copy 로직(`walkEffectiveNodes`)이 의존하므로 cell 모드에서도 이 속성을 출력해야 함.
+- **headless / 오버라이드 가능**: width, gap, color, padding 모두 prop 또는 className/style로 override 가능.
+- **theme 인식**: `theme="light" | "dark"`로 색상 자동 매핑 (기존 CodeView의 `lineNumberColor` 그대로 추출).
+- **width 자동 계산**: `width="auto"` (기본) 시 totalLines 자릿수 기반(`getGutterWidth` 그대로 추출).
+- **a11y**: `aria-hidden="true"` 기본 (라인번호는 콘텐츠가 아닌 메타데이터). `clickable` 시 `role="button"` 추가.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. `LineNumbers.Column` (또는 그냥 `LineNumbers`) — N개 라인번호를 세로 컬럼으로 렌더.
+2. `LineNumbers.Cell` — 단일 라인번호 셀. CodeView 같은 per-row 렌더링용.
+3. `count`, `start` (기본 1), `step` (기본 1) — 번호 시퀀스 제어.
+4. `width: "auto" | string | number` — 기본 "auto" (자릿수 자동 계산), 또는 명시적 CSS 길이/px.
+5. `gap: string | number` — 라인번호와 컨텐츠 사이 간격. 기본 `"1rem"`.
+6. `theme: "light" | "dark"` — 색상.
+7. `highlightLines: number[]` — 강조할 라인 번호 배열 (1-indexed).
+8. `relative: boolean` + `activeLine: number` — relative 모드 (vim 스타일).
+9. `onLineClick?: (lineNumber: number) => void` — 클릭 핸들러. 있으면 셀이 `cursor: pointer` + `role="button"` + 키보드 활성.
+10. `lineHeight: string | number` — 행 높이 (CodeView가 폰트 line-height inherit하므로 기본은 `"inherit"`).
+11. `align: "left" | "center" | "right"` — 라인번호 정렬. 기본 `"right"` (전통적).
+12. `sticky: boolean` — sticky-left 위치 (기본 true, CodeView 호환).
+13. `bg?: string` — 명시적 배경색 (sticky일 때 행 배경 가림용). 기본 theme 자동.
+14. `data-gutter="true"` 속성 출력 — CodeView copy 로직 호환.
+15. **CodeView 내부 리팩토링**: 기존 inline 라인번호 렌더링을 `<LineNumbers.Cell />`로 교체. 시각·동작 100% 동일.
+16. 배럴 — `export { LineNumbers } from "./LineNumbers"` + `export type { LineNumbersProps, LineNumbersCellProps } from ...`.
+
+### Non-goals (v1 제외)
+- **Gutter marker 시스템** — breakpoint/fold/changes 등 라인 옆 아이콘 마커. v1.1+. CodeMirror 6의 `gutter()` extension 같은 일반 시스템.
+- **라인 폴딩** (CodeFold 컴포넌트는 별도 후보, 본 plan 외).
+- **blame annotation** — 라인 옆 작성자/날짜 표시. 별도 컴포넌트 후보.
+- **라인 hover 시 anchor 링크 표시** (GitHub 스타일). v1.1.
+- **다중 컬럼 라인번호** (예: 좌측 old 번호 + 우측 new 번호 — DiffView용). DiffView 신설 시 같이 설계.
+- **virtualization** (가상 스크롤). 큰 파일은 부모 가상화 사용.
+- **자체 keyframes / 애니메이션**.
+- **테스트 자동화** — 라이브러리 전체에 없음.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/LineNumbers/LineNumbers.types.ts`
+
+```ts
+import type { CSSProperties, HTMLAttributes } from "react";
+
+export type LineNumbersTheme = "light" | "dark";
+
+export type LineNumbersAlign = "left" | "center" | "right";
+
+/**
+ * Column 모드 props — N개 라인번호를 세로 컬럼으로 렌더.
+ */
+export interface LineNumbersProps extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  /** 렌더할 라인 개수. 필수. */
+  count: number;
+
+  /** 시작 번호. 기본 1. */
+  start?: number;
+
+  /** 증감 단위. 기본 1. (음수도 허용 — 역순 표시 가능) */
+  step?: number;
+
+  /**
+   * 컬럼 너비.
+   * - "auto" (기본): count + start로 결정되는 최대 자릿수 기반 자동 계산.
+   * - string: CSS 길이 그대로 (e.g., "3rem", "48px").
+   * - number: px.
+   */
+  width?: "auto" | string | number;
+
+  /**
+   * 라인번호와 컨텐츠 사이 간격.
+   * 컬럼 자체의 paddingRight로 적용.
+   * 기본 "1rem".
+   */
+  gap?: string | number;
+
+  /** 테마. 기본 "light". */
+  theme?: LineNumbersTheme;
+
+  /** 강조할 라인 번호 배열 (1-indexed, 사용자가 보는 번호). */
+  highlightLines?: number[];
+
+  /** relative 모드. 기본 false. true면 activeLine 기준 상대 번호 표시. */
+  relative?: boolean;
+
+  /** relative 모드에서 "0"으로 표시될 라인. 기본 1. */
+  activeLine?: number;
+
+  /** 행 높이. 기본 "inherit" (부모 line-height 따라감). */
+  lineHeight?: string | number;
+
+  /** 라인번호 정렬. 기본 "right". */
+  align?: LineNumbersAlign;
+
+  /** sticky-left 위치 활성. 기본 true (가로 스크롤 시 라인번호 고정). */
+  sticky?: boolean;
+
+  /** 명시적 배경색. 미지정 시 theme 기반 자동. sticky=true일 때 행 배경 가림 용도. */
+  bg?: string;
+
+  /** 라인 클릭 핸들러. 있으면 각 셀이 클릭 가능 (role=button + cursor=pointer). */
+  onLineClick?: (lineNumber: number) => void;
+
+  className?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * Cell 모드 props — 단일 라인번호 셀.
+ * CodeView처럼 per-row 렌더링하는 컴포넌트가 사용.
+ */
+export interface LineNumbersCellProps extends Omit<HTMLAttributes<HTMLSpanElement>, "children"> {
+  /** 표시할 라인 번호. */
+  lineNumber: number;
+
+  /**
+   * 보이는 라벨 override.
+   * 기본은 lineNumber 그대로. relative 모드 등에서 "3"처럼 가공된 값 표시 시 사용.
+   */
+  label?: string | number;
+
+  /** 강조 여부. 기본 false. */
+  highlighted?: boolean;
+
+  /**
+   * 컬럼 너비. 부모 컴포넌트가 통일 너비 결정해 모든 셀에 동일 값 전달.
+   * column 모드와 다르게 "auto" 미지원 (per-cell로는 자릿수 결정 불가).
+   * 기본 "1.5rem".
+   */
+  width?: string | number;
+
+  /** 컨텐츠와의 간격. paddingRight로 적용. 기본 "1rem". */
+  gap?: string | number;
+
+  /** 테마. 기본 "light". */
+  theme?: LineNumbersTheme;
+
+  /** 행 높이. 기본 "inherit". */
+  lineHeight?: string | number;
+
+  /** 정렬. 기본 "right". */
+  align?: LineNumbersAlign;
+
+  /** sticky-left. 기본 true. */
+  sticky?: boolean;
+
+  /** 명시적 배경색. */
+  bg?: string;
+
+  /** 클릭 핸들러. */
+  onLineClick?: (lineNumber: number) => void;
+
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.2 메인 컴포넌트 — `src/components/LineNumbers/LineNumbers.tsx`
+
+```tsx
+import type { CSSProperties, KeyboardEvent } from "react";
+import { LineNumbersCell } from "./LineNumbersCell";
+import { resolveGutterWidth, themeColors } from "./utils";
+import type { LineNumbersProps } from "./LineNumbers.types";
+
+export function LineNumbers(props: LineNumbersProps) {
+  const {
+    count,
+    start = 1,
+    step = 1,
+    width = "auto",
+    gap = "1rem",
+    theme = "light",
+    highlightLines,
+    relative = false,
+    activeLine = 1,
+    lineHeight = "inherit",
+    align = "right",
+    sticky = true,
+    bg,
+    onLineClick,
+    className,
+    style,
+    ...rest
+  } = props;
+
+  // 가장 큰 표시 가능 라인번호로 너비 결정
+  const maxLine = start + (count - 1) * step;
+  const resolvedWidth =
+    width === "auto" ? resolveGutterWidth(Math.abs(maxLine)) : typeof width === "number" ? `${width}px` : width;
+  const resolvedGap = typeof gap === "number" ? `${gap}px` : gap;
+
+  const colors = themeColors[theme];
+  const resolvedBg = bg ?? colors.bg;
+
+  const containerStyle: CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    flexShrink: 0,
+    boxSizing: "content-box",
+    minWidth: resolvedWidth,
+    paddingRight: resolvedGap,
+    color: colors.text,
+    background: resolvedBg,
+    userSelect: "none",
+    pointerEvents: onLineClick ? "auto" : "none",
+    ...(sticky ? { position: "sticky", left: 0, zIndex: 1 } : {}),
+    ...style,
+  };
+
+  const cells: React.ReactElement[] = [];
+  for (let i = 0; i < count; i++) {
+    const realLineNumber = start + i * step;
+    const displayedLabel = relative
+      ? Math.abs(realLineNumber - activeLine).toString()
+      : realLineNumber.toString();
+
+    cells.push(
+      <LineNumbersCell
+        key={i}
+        lineNumber={realLineNumber}
+        label={displayedLabel}
+        highlighted={highlightLines?.includes(realLineNumber) ?? false}
+        width={resolvedWidth}
+        gap="0" // 컬럼 자체에 paddingRight 있으므로 셀은 0
+        theme={theme}
+        lineHeight={lineHeight}
+        align={align}
+        sticky={false} // 컬럼이 sticky이므로 셀은 false
+        bg={resolvedBg}
+        {...(onLineClick ? { onLineClick } : {})}
+      />,
+    );
+  }
+
+  return (
+    <div
+      data-gutter="true"
+      aria-hidden={onLineClick ? undefined : true}
+      className={className}
+      style={containerStyle}
+      {...rest}
+    >
+      {cells}
+    </div>
+  );
+}
+
+LineNumbers.displayName = "LineNumbers";
+
+// Static reference for compound API
+LineNumbers.Cell = LineNumbersCell;
+```
+
+### 2.3 셀 컴포넌트 — `src/components/LineNumbers/LineNumbersCell.tsx`
+
+```tsx
+import type { CSSProperties, KeyboardEvent } from "react";
+import { themeColors } from "./utils";
+import type { LineNumbersCellProps } from "./LineNumbers.types";
+
+export function LineNumbersCell(props: LineNumbersCellProps) {
+  const {
+    lineNumber,
+    label,
+    highlighted = false,
+    width = "1.5rem",
+    gap = "1rem",
+    theme = "light",
+    lineHeight = "inherit",
+    align = "right",
+    sticky = true,
+    bg,
+    onLineClick,
+    className,
+    style,
+    ...rest
+  } = props;
+
+  const colors = themeColors[theme];
+  const resolvedWidth = typeof width === "number" ? `${width}px` : width;
+  const resolvedGap = typeof gap === "number" ? `${gap}px` : gap;
+  const resolvedLineHeight = typeof lineHeight === "number" ? `${lineHeight}px` : lineHeight;
+  const resolvedBg = bg ?? colors.bg;
+
+  const isClickable = onLineClick !== undefined;
+
+  const cellStyle: CSSProperties = {
+    flexShrink: 0,
+    minWidth: resolvedWidth,
+    paddingRight: resolvedGap,
+    boxSizing: "content-box",
+    textAlign: align,
+    color: highlighted ? colors.textHighlight : colors.text,
+    fontSize: "0.85em",
+    lineHeight: resolvedLineHeight,
+    userSelect: "none",
+    background: resolvedBg,
+    cursor: isClickable ? "pointer" : "default",
+    pointerEvents: isClickable ? "auto" : "none",
+    ...(sticky ? { position: "sticky", left: 0, zIndex: 1 } : {}),
+    ...style,
+  };
+
+  const handleClick = isClickable ? () => onLineClick(lineNumber) : undefined;
+
+  const handleKeyDown = isClickable
+    ? (e: KeyboardEvent<HTMLSpanElement>) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onLineClick(lineNumber);
+        }
+      }
+    : undefined;
+
+  const a11yProps = isClickable
+    ? {
+        role: "button" as const,
+        tabIndex: 0,
+        "aria-label": `Line ${lineNumber}`,
+      }
+    : {
+        "aria-hidden": true as const,
+      };
+
+  return (
+    <span
+      data-gutter="true"
+      data-line-number={lineNumber}
+      data-highlighted={highlighted ? "" : undefined}
+      className={className}
+      style={cellStyle}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      {...a11yProps}
+      {...rest}
+    >
+      {label ?? lineNumber}
+    </span>
+  );
+}
+
+LineNumbersCell.displayName = "LineNumbers.Cell";
+```
+
+### 2.4 유틸 — `src/components/LineNumbers/utils.ts`
+
+```ts
+import type { LineNumbersTheme } from "./LineNumbers.types";
+
+/**
+ * 라인 수 기반 gutter 너비 자동 계산.
+ * CodeView의 기존 getGutterWidth를 그대로 추출.
+ */
+export function resolveGutterWidth(maxLine: number): string {
+  if (maxLine < 10) return "1.5rem";
+  if (maxLine < 100) return "2rem";
+  if (maxLine < 1000) return "2.75rem";
+  if (maxLine < 10000) return "3.5rem";
+  return "4.5rem"; // 5+ 자리
+}
+
+/**
+ * 테마별 색상.
+ * CodeView의 lineNumberColor를 확장:
+ * - bg / text: 기존 lineNumberColor 매핑
+ * - textHighlight: 강조 라인용 (highlight color, CodeView의 highlightRowColor와 짝)
+ */
+export const themeColors: Record<
+  LineNumbersTheme,
+  { bg: string; text: string; textHighlight: string }
+> = {
+  light: {
+    bg: "rgba(0,0,0,0.04)",
+    text: "rgba(0,0,0,0.45)",
+    textHighlight: "rgba(217,119,6,1)", // amber-600 — CodeView highlight 색상과 매칭
+  },
+  dark: {
+    bg: "rgba(255,255,255,0.08)",
+    text: "rgba(255,255,255,0.45)",
+    textHighlight: "rgba(251,191,36,1)", // amber-400
+  },
+};
+```
+
+### 2.5 배럴 — `src/components/LineNumbers/index.ts`
+
+```ts
+export { LineNumbers } from "./LineNumbers";
+export type {
+  LineNumbersProps,
+  LineNumbersCellProps,
+  LineNumbersTheme,
+  LineNumbersAlign,
+} from "./LineNumbers.types";
+```
+
+### 2.6 컴포넌트 배럴 추가 — `src/components/index.ts`
+
+```ts
+// 기존 export 위에 추가
+export * from "./LineNumbers";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/LineNumbers/
+├── LineNumbers.tsx          ← Column 모드 컴포넌트
+├── LineNumbersCell.tsx       ← Cell 모드 컴포넌트
+├── LineNumbers.types.ts      ← 타입
+├── utils.ts                  ← resolveGutterWidth + themeColors
+└── index.ts                  ← 배럴
+```
+
+**왜 Cell이 별도 파일인가**: CodeView가 Cell만 import하는 케이스 명확화. 또한 두 컴포넌트가 같은 파일이면 LineNumbers.Cell static assignment 시점에 순환 의존이 미묘해짐.
+
+---
+
+## 4. 동작 명세
+
+### 4.1 Column 모드
+
+**입력:**
+- `count = 5`, `start = 10`, `step = 2`
+
+**출력 (라벨):**
+```
+10
+12
+14
+16
+18
+```
+
+**자동 너비:**
+- `maxLine = 10 + 4*2 = 18` → 2 자리 → `2rem`
+
+### 4.2 Relative 모드
+
+**입력:**
+- `count = 7`, `start = 1`, `relative = true`, `activeLine = 4`
+
+**출력 (라벨):**
+```
+3
+2
+1
+0  ← activeLine
+1
+2
+3
+```
+
+**시퀀스:**
+- realLineNumber 1, 2, 3, 4, 5, 6, 7
+- displayLabel = `|realLineNumber - activeLine|` = 3, 2, 1, 0, 1, 2, 3
+
+### 4.3 강조
+
+```tsx
+<LineNumbers count={10} highlightLines={[3, 5, 7]} />
+```
+- 3, 5, 7번 라인 셀에 `data-highlighted=""` 속성 + `color: textHighlight` (amber).
+- 다른 셀과 동일한 너비·정렬·배경 유지.
+
+### 4.4 클릭 핸들러
+
+```tsx
+<LineNumbers count={10} onLineClick={(n) => alert(n)} />
+```
+- 각 셀이 `role="button"`, `tabIndex=0`, `cursor: pointer`.
+- 클릭 시 `onLineClick(lineNumber)`.
+- Enter/Space 키 시 동일 동작 (a11y).
+- onLineClick 미지정 시 `aria-hidden="true"` (장식).
+
+### 4.5 sticky 동작
+
+- `sticky=true` (기본): `position: sticky; left: 0; z-index: 1`. 부모가 가로 스크롤될 때 라인번호가 좌측 고정.
+- `sticky=false`: 일반 inline. CodeView 같이 부모가 자체 sticky 처리하는 경우 사용.
+
+### 4.6 컬럼 vs 셀 모드 sticky 충돌 방지
+
+Column 모드 내부에서 Cell들이 렌더될 때:
+- 컬럼 자체에 `position: sticky` 적용.
+- 자식 셀들의 sticky는 **강제로 false** (props에서 명시 무시) — 중첩 sticky는 컨텍스트에서 작동 안 하므로.
+
+코드:
+```tsx
+<LineNumbersCell ... sticky={false} bg={resolvedBg} />
+```
+
+### 4.7 너비 계산 vs 명시
+
+| width prop | 결과 |
+|---|---|
+| `"auto"` (기본) | `maxLine` 자릿수 기반: 1자리=1.5rem, 2자리=2rem, 3자리=2.75rem, 4자리=3.5rem, 5자리+=4.5rem |
+| `string` (e.g., `"3rem"`) | 그대로 |
+| `number` (e.g., `48`) | `"48px"` |
+
+**Cell 모드는 `"auto"` 미지원** (단일 셀로는 자릿수 결정 불가). 부모(예: CodeView)가 미리 계산해 모든 셀에 동일 width 전달.
+
+### 4.8 데이터 속성
+
+모든 셀이 다음 속성 출력:
+- `data-gutter="true"` — copy 로직 skip 마커 (CodeView 호환).
+- `data-line-number={lineNumber}` — 디버깅·테스트·CSS 셀렉터용.
+- `data-highlighted=""` — 강조 라인 표시 (선택자: `[data-highlighted]`).
+
+컬럼 자체도 `data-gutter="true"`.
+
+---
+
+## 5. CodeView 리팩토링
+
+### 5.1 현재 구조 (추출 전)
+
+`CodeView.tsx` line 467-519 발췌:
+
+```tsx
+const gutterStyle: React.CSSProperties = {
+  flexShrink:    0,
+  minWidth:      resolvedGutterWidth,
+  paddingRight:  resolvedGutterGap,
+  boxSizing:     "content-box",
+  textAlign:     "right",
+  color:         lineNumberColor[theme],
+  fontSize:      "0.85em",
+  lineHeight:    "inherit",
+  userSelect:    "none",
+  pointerEvents: "none",
+  position:      "sticky",
+  left:          0,
+  zIndex:        1,
+  backgroundColor: themeBg,
+};
+
+// ... 행별 렌더링:
+{showLineNumbers && (
+  <span data-gutter="true" aria-hidden="true" style={gutterStyle}>
+    {li + 1}
+  </span>
+)}
+```
+
+### 5.2 목표 구조 (추출 후)
+
+```tsx
+import { LineNumbers } from "../LineNumbers";
+
+// ...
+
+const resolvedGutterWidth = showLineNumbers
+  ? (gutterWidthProp ?? undefined) // undefined면 LineNumbers.Cell이 받기 전에 계산
+  : "0";
+
+// 행별 렌더링:
+{showLineNumbers && (
+  <LineNumbers.Cell
+    lineNumber={li + 1}
+    width={resolvedGutterWidth}  // CodeView가 통일 너비 전달
+    gap={resolvedGutterGap}
+    theme={theme}
+    bg={themeBg}
+    sticky
+  />
+)}
+```
+
+### 5.3 변경 사항 상세
+
+**삭제:**
+- `lineNumberColor` 상수 (line 18-21) — `LineNumbers/utils.ts`로 이동되므로.
+- `getGutterWidth` 함수 (line 43-48) — 동일.
+- `gutterStyle` 객체 (line 467-482) — `LineNumbers.Cell`이 자체 생성.
+
+**유지:**
+- `walkEffectiveNodes`의 `data-gutter` skip 로직 (line 73) — `LineNumbers.Cell`도 `data-gutter="true"`를 출력하므로 그대로 동작.
+- `gutterWidthProp`, `gutterGapProp` 사용자 prop — CodeView가 받아서 LineNumbers.Cell로 전달.
+- textarea overlay의 `paddingLeft: gutterTotalWidth` 계산 (line 521-524, 624) — gutterTotalWidth 계산 방식은 유지.
+
+**대체:**
+- `lineNumberColor[theme]` 직접 참조 → `themeColors[theme].text` (LineNumbers utils에서 import).
+- `getGutterWidth(tokens.length)` 직접 호출 → `resolveGutterWidth(tokens.length)` (LineNumbers utils에서 import).
+
+### 5.4 너비 결정 흐름 (CodeView 내부)
+
+리팩토링 후:
+```tsx
+import { resolveGutterWidth } from "../LineNumbers/utils";
+
+const resolvedGutterWidth = showLineNumbers
+  ? (gutterWidthProp ?? resolveGutterWidth(tokens.length))
+  : "0";
+const resolvedGutterGap = gutterGapProp ?? "1rem";
+```
+
+`gutterWidthProp` (사용자 명시 너비)가 있으면 그것 우선, 없으면 자동 계산.
+
+### 5.5 테마 색상 — bg 전달 주의
+
+CodeView의 `themeBg`은 `style.backgroundColor ?? (theme === "dark" ? "#1e1e1e" : "#fff")` (prism 테마 배경 또는 fallback). LineNumbers.Cell의 `bg` prop으로 그대로 전달:
+
+```tsx
+<LineNumbers.Cell
+  ...
+  bg={themeBg}  // sticky일 때 행 배경 가리는 용도
+/>
+```
+
+LineNumbers의 자체 `themeColors[theme].bg`는 standalone 사용 시의 기본값일 뿐 — CodeView 내부 사용 시는 `themeBg` (prism 배경)으로 명시 override해야 행과 자연스럽게 연결됨.
+
+### 5.6 walkEffectiveNodes 호환성
+
+기존 코드 (line 73):
+```ts
+if (el.hasAttribute("data-gutter")) return; // skip line numbers when copying
+```
+
+리팩토링 후 `LineNumbers.Cell`도 `data-gutter="true"` 출력하므로 기존 로직 그대로 동작. **테스트 항목**: CodeView 데모 페이지에서 텍스트 선택 + Cmd+C 시 복사 결과에 라인번호가 포함되지 않는지 확인.
+
+### 5.7 회귀 검증 체크리스트
+
+CodeView 데모 페이지(`demo/src/pages/CodeViewPage.tsx`)에서 모든 항목 시각·동작 확인:
+- [ ] showLineNumbers=true 기본 표시
+- [ ] showLineNumbers=false 라인번호 숨김
+- [ ] gutterWidth, gutterGap 명시 시 너비 반영
+- [ ] highlightLines 강조
+- [ ] 가로 스크롤 시 라인번호 sticky
+- [ ] 다크 테마 색상
+- [ ] alternating row 배경과 라인번호 정렬
+- [ ] copy 시 라인번호 제외 (선택 후 Cmd+C)
+- [ ] editable 모드에서 textarea overlay와 라인번호 정렬
+- [ ] 한글 IME 입력 시 라인번호 위치 변동 없음
+
+---
+
+## 6. 데모 페이지 — `demo/src/pages/LineNumbersPage.tsx`
+
+```tsx
+import { Card, LineNumbers } from "@pihitpihit/plastic";
+
+const SAMPLE_LINES = Array.from({ length: 12 }, (_, i) => `console.log("line ${i + 1}");`);
+
+export function LineNumbersPage() {
+  return (
+    <div>
+      <h1>LineNumbers</h1>
+
+      {/* 섹션 1: 기본 */}
+      <Card.Root>
+        <Card.Header>Basic — count={12}</Card.Header>
+        <Card.Body>
+          <div style={{ display: "flex", border: "1px solid #ddd", fontFamily: "monospace" }}>
+            <LineNumbers count={SAMPLE_LINES.length} />
+            <pre style={{ margin: 0, padding: "0 0 0 0", flex: 1 }}>
+              {SAMPLE_LINES.join("\n")}
+            </pre>
+          </div>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 2: start / step */}
+      <Card.Root>
+        <Card.Header>start={101} step={2}</Card.Header>
+        <Card.Body>
+          <div style={{ display: "flex", border: "1px solid #ddd", fontFamily: "monospace" }}>
+            <LineNumbers count={6} start={101} step={2} />
+            <pre style={{ margin: 0, flex: 1 }}>{"a\nb\nc\nd\ne\nf"}</pre>
+          </div>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 3: 강조 */}
+      <Card.Root>
+        <Card.Header>highlightLines={[3, 5, 7]}</Card.Header>
+        <Card.Body>
+          <div style={{ display: "flex", border: "1px solid #ddd", fontFamily: "monospace" }}>
+            <LineNumbers count={10} highlightLines={[3, 5, 7]} />
+            <pre style={{ margin: 0, flex: 1 }}>
+              {Array.from({ length: 10 }, (_, i) => `Line ${i + 1}`).join("\n")}
+            </pre>
+          </div>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 4: relative 모드 */}
+      <Card.Root>
+        <Card.Header>relative activeLine={5}</Card.Header>
+        <Card.Body>
+          <div style={{ display: "flex", border: "1px solid #ddd", fontFamily: "monospace" }}>
+            <LineNumbers count={9} relative activeLine={5} highlightLines={[5]} />
+            <pre style={{ margin: 0, flex: 1 }}>
+              {Array.from({ length: 9 }, (_, i) => `Line ${i + 1}`).join("\n")}
+            </pre>
+          </div>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 5: 클릭 핸들러 */}
+      <Card.Root>
+        <Card.Header>onLineClick (클릭/Enter로 alert)</Card.Header>
+        <Card.Body>
+          <div style={{ display: "flex", border: "1px solid #ddd", fontFamily: "monospace" }}>
+            <LineNumbers count={5} onLineClick={(n) => alert(`Clicked line ${n}`)} />
+            <pre style={{ margin: 0, flex: 1 }}>{"a\nb\nc\nd\ne"}</pre>
+          </div>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 6: 다크 테마 */}
+      <Card.Root>
+        <Card.Header>theme="dark"</Card.Header>
+        <Card.Body>
+          <div style={{ display: "flex", background: "#1e1e1e", color: "#e5e7eb", fontFamily: "monospace" }}>
+            <LineNumbers count={6} theme="dark" />
+            <pre style={{ margin: 0, flex: 1 }}>{"a\nb\nc\nd\ne\nf"}</pre>
+          </div>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 7: 큰 라인 수 (자동 너비) */}
+      <Card.Root>
+        <Card.Header>1000+ lines (자동 너비 확장)</Card.Header>
+        <Card.Body>
+          <div style={{ display: "flex", border: "1px solid #ddd", maxHeight: 200, overflow: "auto" }}>
+            <LineNumbers count={1500} />
+            <pre style={{ margin: 0, flex: 1 }}>
+              {Array.from({ length: 1500 }, (_, i) => `Line ${i + 1}`).join("\n")}
+            </pre>
+          </div>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 섹션 8: cell 모드 (per-row 임베드 예시) */}
+      <Card.Root>
+        <Card.Header>Cell 모드 — 사용자 정의 행 레이아웃</Card.Header>
+        <Card.Body>
+          <div style={{ fontFamily: "monospace" }}>
+            {SAMPLE_LINES.map((line, i) => (
+              <div key={i} style={{ display: "flex" }}>
+                <LineNumbers.Cell lineNumber={i + 1} width="2rem" highlighted={i === 4} />
+                <span style={{ flex: 1 }}>{line}</span>
+              </div>
+            ))}
+          </div>
+        </Card.Body>
+      </Card.Root>
+    </div>
+  );
+}
+```
+
+데모 라우팅 등록 — `demo/src/App.tsx`의 NAV에 `LineNumbers` 추가.
+
+---
+
+## 7. 접근성 (a11y)
+
+### 7.1 라인번호는 메타데이터 (장식)
+기본적으로 라인번호는 콘텐츠가 아니라 위치 메타데이터. 스크린리더가 매번 "1, 2, 3, ..." 을 읽으면 노이즈가 큼.
+
+→ 기본 `aria-hidden="true"` (column 자체 + 모든 셀).
+
+### 7.2 클릭 가능 라인번호는 의미 있음
+`onLineClick` prop이 있으면 라인번호가 인터랙티브 요소가 됨 (영구 링크, 라인 점프 등).
+
+→ `role="button"` + `tabIndex=0` + `aria-label="Line {N}"`.
+
+### 7.3 키보드 작동
+- Tab: 클릭 가능 셀들로 포커스 이동.
+- Enter/Space: 활성 셀 클릭 (`onLineClick(lineNumber)`).
+- Esc / 그 외 키: 무시.
+
+### 7.4 강조 라인의 시각 표시
+`data-highlighted=""` 속성 + 색상 변경으로 표현. 스크린리더 알림은 부모 컴포넌트(예: 검색 결과 표시)의 책임.
+
+---
+
+## 8. 설계 결정 사항 (rationale)
+
+### 8.1 Column 모드와 Cell 모드 둘 다 제공
+**이유**:
+- Column 모드: 단순 사용처(LogView, 정적 코드)에서 부모가 한 줄로 끝낼 수 있음. flex/grid 합성 비용 낮음.
+- Cell 모드: CodeView처럼 행마다 라인번호 + 컨텐츠를 한 행에 같이 배치하는 복잡 레이아웃이 필수. Column 모드만으로는 행 정렬·hover·selection 처리 불가.
+
+각각이 다른 사용 패턴을 지원해야 라이브러리가 LogView·Terminal·DiffView 같은 미래 컴포넌트를 모두 흡수 가능.
+
+### 8.2 `data-gutter="true"` 강제 출력
+**이유**: CodeView의 copy 로직(`walkEffectiveNodes`)이 이 속성에 의존. 추출 후에도 동일 동작 보장 위해 필수. 향후 다른 컴포넌트도 같은 패턴(라인번호 skip)을 쓸 수 있음.
+
+### 8.3 너비 자동 계산 — 자릿수 기반
+**이유**: 행 수가 증가해도 라인번호가 잘리거나 정렬 깨지지 않게. CodeView 기존 방식 그대로 보존(시각 회귀 0).
+
+### 8.4 sticky 기본 true
+**이유**: 가로 스크롤 시 라인번호가 화면 밖으로 사라지면 "현재 어디 보는지" 인지 곤란. 코드 표시의 표준. CodeView 기본값과 일치.
+
+### 8.5 `onLineClick` 옵셔널 + a11y 분기
+**이유**: 클릭 가능 여부에 따라 a11y 시맨틱이 완전히 달라짐 (장식 vs 버튼). prop 유무로 자동 분기하는 게 사용자 인지 부담 가장 작음.
+
+### 8.6 themeColors는 별도 utils 파일
+**이유**: CodeView도 사용해야 함 (특히 textarea overlay 색상 매칭). 두 컴포넌트가 같은 토큰 import하면 시각 drift 방지.
+
+### 8.7 Cell 모드에서 width="auto" 미지원
+**이유**: 단일 셀로는 totalLineCount 알 수 없음. 부모가 미리 계산해 모든 셀에 통일 너비 전달하는 게 명확.
+
+### 8.8 relative 모드 vim 스타일
+**이유**: 키보드 모달 에디터(Vim, Helix) 사용자에게 친숙. 단순 옵션이라 비용 낮음. 기본 false라 일반 사용자에 영향 0.
+
+---
+
+## 9. Edge cases
+
+### 9.1 count = 0
+```tsx
+<LineNumbers count={0} />
+```
+- 빈 컬럼 렌더 (자식 0개).
+- 컬럼 자체는 paddingRight + minWidth 유지 → 부모 레이아웃에서 의도 안 한 너비 차지 가능.
+- 권장 사용 패턴: `count > 0` 일 때만 렌더 (`{count > 0 && <LineNumbers count={count} />}`).
+
+### 9.2 count가 매우 큼 (10만+)
+- 가상화 없이 모든 셀을 렌더 → DOM 노드 10만개.
+- 성능 저하 — 부모가 가상 스크롤(react-window 등) 사용 권장.
+- v1은 가상화 미포함. 문서에 명시.
+
+### 9.3 step = 0
+- 모든 라인이 같은 번호 (`start, start, start, ...`).
+- 의도된 사용은 아니나 막지 않음. 부모 책임.
+
+### 9.4 step 음수
+```tsx
+<LineNumbers count={5} start={10} step={-1} />
+// → 10, 9, 8, 7, 6
+```
+- 정상 동작. 너비 계산은 `Math.abs(maxLine)` 기반이라 안전.
+
+### 9.5 highlightLines가 표시 범위 밖
+```tsx
+<LineNumbers count={10} highlightLines={[15, -3]} />
+```
+- 매치 안 되는 번호는 무시. 표시 범위(1~10) 안의 매치만 강조.
+
+### 9.6 lineHeight = 숫자(px) vs string(em/rem)
+- 숫자 → `"{n}px"`.
+- string → 그대로.
+- `"inherit"` → 부모 line-height 따라감 (CodeView 시나리오).
+
+### 9.7 sticky=true인데 부모에 `overflow` 설정 없음
+- sticky가 작동하지 않음 (브라우저 한계).
+- 시각 회귀 없음 (그냥 일반 inline처럼 보임).
+- 부모가 `overflow-x: auto` 같은 컨테이닝 블록 만들어야 sticky 활성.
+
+### 9.8 다크 테마 + 사용자 bg override
+```tsx
+<LineNumbers theme="dark" bg="black" />
+```
+- bg가 명시 우선. theme의 기본 bg 무시.
+- text 색상은 여전히 themeColors.dark.text 사용 → 사용자가 `style.color`로 override 가능.
+
+### 9.9 onLineClick + sticky 동시
+- sticky 셀이 클릭되어야 함.
+- pointer-events: auto 명시 필요 (코드에 이미 반영).
+
+### 9.10 CodeView 리팩토링 후 textarea 정렬 깨짐
+가장 위험한 회귀 케이스. 원인 가능성:
+- LineNumbers.Cell의 box-sizing/padding이 미세하게 다름.
+- bg color가 prism 테마와 미세하게 다름.
+
+**예방**: 리팩토링 후 모든 CodeView 데모 항목에서 textarea 클릭 → 캐럿 위치가 라인번호 직후 정확한 컬럼에 떨어지는지 확인. 한글 IME 조합 모드도 확인.
+
+---
+
+## 10. 구현 단계 (Phase)
+
+### Phase 1: LineNumbers 신설
+1. `src/components/LineNumbers/LineNumbers.types.ts` 작성
+2. `src/components/LineNumbers/utils.ts` 작성 (`resolveGutterWidth` + `themeColors`)
+3. `src/components/LineNumbers/LineNumbersCell.tsx` 작성
+4. `src/components/LineNumbers/LineNumbers.tsx` 작성
+5. `src/components/LineNumbers/index.ts` 배럴
+6. `src/components/index.ts`에 `export * from "./LineNumbers"` 추가
+7. `npm run typecheck` 통과
+8. `npm run build` 통과
+
+### Phase 2: 데모 페이지
+1. `demo/src/pages/LineNumbersPage.tsx` 작성 (§6 템플릿)
+2. `demo/src/App.tsx` NAV 등록
+3. 모든 8개 섹션 시각 확인 (light/dark)
+
+### Phase 3: CodeView 리팩토링
+1. `CodeView.tsx`에 `import { LineNumbers } from "../LineNumbers"` 추가.
+2. `lineNumberColor`, `getGutterWidth` 삭제 (utils로 이동됨).
+3. `import { resolveGutterWidth, themeColors } from "../LineNumbers/utils"` 추가.
+4. `gutterStyle` 인라인 객체 삭제.
+5. 행 렌더링 부에서 `<span data-gutter ...>{li + 1}</span>`을 `<LineNumbers.Cell ... />`로 교체.
+6. `themeBg` → `LineNumbers.Cell`의 `bg` prop으로 전달.
+7. `npm run typecheck` 통과.
+
+### Phase 4: CodeView 회귀 검증
+- [ ] 모든 CodeViewPage 섹션 시각 회귀 없음 (light/dark).
+- [ ] 가로 스크롤 sticky 정상.
+- [ ] highlightLines 강조 정상.
+- [ ] alternating row 정렬 정상.
+- [ ] editable 모드 textarea overlay 정렬 정상.
+- [ ] 한글 IME 입력 시 정렬 유지.
+- [ ] 텍스트 선택 + 복사 시 라인번호 미포함.
+- [ ] gutterWidth/gutterGap props 정상 동작.
+
+### Phase 5: 정리
+- [ ] `docs/candidates.md`에서 12번 LineNumbers 항목 제거 + 본 plan 링크.
+- [ ] README.md에 LineNumbers 섹션 추가.
+
+---
+
+## 11. 향후 확장 (v1.1+)
+
+| 항목 | 설명 |
+|---|---|
+| Gutter marker 시스템 | breakpoint/changes/folding marker — `<LineNumbers.Marker line={5} type="error" />` |
+| Blame annotation | 셀 옆 작성자/날짜 표시 — `<LineNumbers ... blame={blameMap} />` |
+| Hover anchor | 호버 시 `#L5` 링크 아이콘 표시 |
+| 다중 컬럼 | DiffView용 old/new 두 컬럼 — `<LineNumbers columns={[oldNums, newNums]} />` |
+| Virtual scroll 통합 | react-window 등과 자동 호환 |
+| 라인 색상별 분류 | type 기반 (`error`/`warning`/`added`/`removed` 등) |
+
+---
+
+## 12. 체크리스트 (작업 완료 기준)
+
+- [ ] `src/components/LineNumbers/` 5개 파일 작성 완료
+- [ ] Column 모드와 Cell 모드 모두 데모에서 정상
+- [ ] `npm run typecheck` 통과
+- [ ] `npm run build` 통과
+- [ ] `demo/src/pages/LineNumbersPage.tsx` 작성 + NAV 등록
+- [ ] CodeView 리팩토링 완료 (`lineNumberColor`/`getGutterWidth`/`gutterStyle` 삭제 + LineNumbers.Cell 사용)
+- [ ] CodeView 데모 모든 섹션 시각 회귀 없음 (light/dark)
+- [ ] copy 로직(`walkEffectiveNodes`) 정상 (선택+복사 시 라인번호 미포함)
+- [ ] textarea overlay 정렬 정상 (editable 모드)
+- [ ] 한글 IME 입력 정상
+- [ ] README.md 업데이트
+- [ ] `docs/candidates.md`에서 12번 항목 제거 + plan 링크 교체
+- [ ] PR 디스크립션에 변경 요약 (신규 LineNumbers + CodeView 내부 리팩토링)

--- a/docs/plans/025-calendar-component.md
+++ b/docs/plans/025-calendar-component.md
@@ -1,0 +1,1639 @@
+# Calendar 컴포넌트 설계문서 (DatePicker에서 분리)
+
+## Context
+
+현재 진행 중인 `DatePicker`(plan 015, `feat/datepicker-component` 브랜치)의 표현 부분 중 **달력 그리드(월 뷰 + 요일 헤더 + 네비게이션 + 날짜 셀)**를 단독 컴포넌트 `Calendar`로 분리한다. 분리 후 DatePicker는 자기 popover 안에서 `<Calendar />`를 사용하는 구조로 리팩토링된다.
+
+**왜 지금이 분리 적기인가**: DatePicker가 현재 타입·유틸·테마·Context+상태+데모까지 진행되었고, **다음 단계가 정확히 달력 그리드 표현 컴포넌트(`DatePicker.Grid`, `DatePicker.Day`, `DatePicker.Header`, `DatePicker.Nav` 등)**다. 이 표현 부분을 처음부터 별도 `Calendar` 컴포넌트로 만들고 DatePicker가 import하는 구조로 가면 향후 리팩토링 비용 0 + 단독 활용 자산 확보. 만약 그리드 로직이 DatePicker 안에 먼저 작성되어버리면 분리 비용이 100배 커진다.
+
+**Calendar 단독 활용 사례**:
+- 일정 보드/이벤트 마킹 캘린더 (input 없이 month grid만 필요)
+- DateRangePicker (Calendar 두 개 또는 single Calendar에 range mode)
+- ScheduleView, AgendaView 같은 향후 컴포넌트의 기반
+- 달력 디스플레이가 필요한 임의 기능 (출석 그리드, 통계 캘린더)
+
+**범위 결정의 핵심**: Calendar는 "월 그리드 + 날짜 선택 표면". 입력값 표시 (`<input>` + format/parse), popover 트리거, footer, ranges 빠른 선택 칩 등은 DatePicker가 담당. **표시 vs 입력의 명확한 분리**가 본 작업의 가장 중요한 설계 결정.
+
+참고 (prior art — calendar / date selection):
+- **react-day-picker** — 완성도 높은 표준 레퍼런스. `mode="single" | "range" | "multiple"`, `selected`, `onSelect`, `disabled`, `modifiers`, `locale`. Calendar 단독 컴포넌트.
+- **Radix UI** — DatePicker/Calendar primitive 부재 (커뮤니티 의존).
+- **react-aria** — `useCalendar` hook 기반 headless. `useCalendarGrid`, `useCalendarCell`, `useRangeCalendar`. CalendarDate 객체 기반 timezone-safe.
+- **MUI X DatePicker** — `DateCalendar` 단독 export. mode/views(`day | month | year`).
+- **Mantine `Calendar`, `MonthPickerInput`, `DatePickerInput`** — 셋이 분리됨. Calendar가 가장 기본 primitive.
+- **Ant Design `Calendar`** — 큰 풀-페이지 캘린더 (full-screen). 일반 input picker와 별개.
+- **vue-cal**, **FullCalendar** — 이벤트 캘린더 (v1 범위 외, ScheduleView 후보).
+
+본 레포 내부 참조 (읽어야 할 파일 — 모두 현재 DatePicker 구현 중인 것):
+- `src/components/DatePicker/DatePicker.types.ts` (141줄) — `CalendarDate`, `SingleValue`, `RangeValue`, `WeekStart`, `DatePickerDayInfo` 등. **본 작업으로 일부 타입이 Calendar로 이동**.
+- `src/components/DatePicker/DatePicker.dateMath.ts` (106줄) — date 산수 유틸. **전부 Calendar로 이동**.
+- `src/components/DatePicker/DatePicker.intl.ts` (29줄) — locale 정보. **Calendar로 이동**.
+- `src/components/DatePicker/DatePicker.theme.ts` (116줄) — 테마. Calendar 관련 부분만 분리.
+- `src/components/DatePicker/DatePicker.format.ts` (183줄) — format/parse. **DatePicker에 유지** (input 표시용).
+- `src/components/DatePicker/useDatePickerState.ts` (446줄) — 상태. Calendar 관련 부분(focused day, selection 적용) 일부 분리, 나머지(input value, parse error, popover open) DatePicker 유지.
+- `src/components/DatePicker/DatePickerRoot.tsx` (173줄) — 본 작업 후 Calendar import + 합성.
+- `src/components/DatePicker/DatePicker.parts.tsx` (39줄) — sub-component 합성. 본 작업 후 일부가 Calendar의 sub-component로 이동.
+- `src/components/DatePicker/index.ts` — export. Calendar 신설 후 DatePicker는 Calendar 일부 타입을 re-export.
+- `src/components/index.ts` — Calendar 추가.
+- `src/components/_shared/useFloating.ts` — DatePicker가 popover로 사용 (Calendar는 floating 무관).
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+// 1. 단독 사용 — 단일 날짜 선택 캘린더
+<Calendar.Root mode="single" onSelect={(d) => console.log(d)}>
+  <Calendar.Header>
+    <Calendar.Nav direction="prev-month" />
+    <Calendar.MonthLabel />
+    <Calendar.Nav direction="next-month" />
+  </Calendar.Header>
+  <Calendar.Grid />  {/* 자동으로 7x6 그리드 + 요일 헤더 */}
+</Calendar.Root>
+
+// 2. range 모드
+<Calendar.Root mode="range" onSelect={({start, end}) => ...}>
+  <Calendar.Header>...</Calendar.Header>
+  <Calendar.Grid />
+</Calendar.Root>
+
+// 3. 다중 선택
+<Calendar.Root mode="multiple" onSelect={(dates) => ...}>...
+
+// 4. controlled
+<Calendar.Root
+  mode="single"
+  value={selectedDate}
+  onValueChange={setSelectedDate}
+  month={visibleMonth}
+  onMonthChange={setVisibleMonth}
+>...
+
+// 5. 비활성 날짜
+<Calendar.Root
+  minDate={{year:2026, month:1, day:1}}
+  maxDate={{year:2026, month:12, day:31}}
+  isDisabled={(d) => weekdayOf(d) === 0}  // 일요일 비활성
+>
+
+// 6. 커스텀 day 렌더 (이벤트 마킹 등)
+<Calendar.Grid>
+  {(day) => (
+    <Calendar.Day day={day}>
+      {day.date.day}
+      {hasEvent(day.date) && <span style={{color:'red'}}>•</span>}
+    </Calendar.Day>
+  )}
+</Calendar.Grid>
+
+// 7. DatePicker 내부 사용 (DatePicker가 Calendar를 합성)
+<DatePicker.Root mode="single" value={...} onValueChange={...}>
+  <DatePicker.Input />
+  <DatePicker.Trigger />
+  <DatePicker.Popover>
+    <Calendar.Root mode="single" /* DatePicker context에서 props 자동 inherit */>
+      <Calendar.Header>...</Calendar.Header>
+      <Calendar.Grid />
+    </Calendar.Root>
+  </DatePicker.Popover>
+</DatePicker.Root>
+```
+
+핵심 설계 원칙:
+- **compound 컴포넌트 패턴** — `Calendar.Root` (Context provider) + `Header` + `Nav` + `MonthLabel` + `WeekdayHeader` + `Grid` + `Day`. 사용자가 자유 합성.
+- **mode 기반 다형성** — `single` / `range` / `multiple`. 같은 컴포넌트 트리, value 타입만 다름.
+- **DatePicker와의 관계**: Calendar는 자체 Context를 가지며 단독으로 완전히 작동. DatePicker는 Calendar 외부에서 popover 컨테이너 + input 표시 + format/parse 담당. **상태 동기화는 DatePicker 측에서 책임**.
+- **headless / 오버라이드 가능** — 모든 sub-component가 className/style 받음. 색상은 `CalendarTheme` 토큰으로 관리.
+- **a11y**: `role="application"` (표준 캘린더 패턴) + Arrow 키 네비 + Home/End/PgUp/PgDn + Enter 선택 + `aria-label` 동적.
+- **42칸 고정 grid** — 6주 × 7일 = 42 셀. 항상 lead/trail 일자 포함 (이전·다음 달 날짜).
+- **timezone-safe `CalendarDate`** — `{ year, month(1-indexed), day }`. JS Date 객체 회피해 timezone 버그 원천 차단.
+- **i18n**: `locale` prop + Intl API. `weekStartsOn` 별도 prop.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. `Calendar.Root` — Context provider, mode/value/month/locale/disabled 처리.
+2. `Calendar.Header` — 네비게이션 + 월/년 라벨 컨테이너.
+3. `Calendar.Nav` — `direction: "prev-year" | "prev-month" | "next-month" | "next-year"` 버튼.
+4. `Calendar.MonthLabel` — 현재 보이는 월/년 텍스트 (locale 인식).
+5. `Calendar.WeekdayHeader` — 요일 머리글 행 (Mon-Sun, locale + weekStartsOn 인식).
+6. `Calendar.Grid` — 42칸 날짜 그리드. children render prop 옵셔널 (커스텀 day 렌더).
+7. `Calendar.Day` — 단일 날짜 셀. `day: CalendarDayInfo` prop.
+8. **3가지 mode**: `single` (CalendarDate | null), `range` ({start, end}), `multiple` (CalendarDate[]).
+9. **controlled / uncontrolled** 모두 지원 — `value`/`defaultValue`/`onValueChange`, `month`/`defaultMonth`/`onMonthChange`.
+10. **min/max + isDisabled predicate** — 날짜 비활성.
+11. **range preview** — range 모드에서 hover 시 preview 표시 (start만 있을 때 hover 위치까지 회색 음영).
+12. **키보드 네비게이션**:
+    - Arrow: 좌(=−1일), 우(=+1일), 위(=−7일), 아래(=+7일).
+    - Home: 주 시작일, End: 주 마지막 일.
+    - PgUp: 이전 달 같은 일자, PgDn: 다음 달.
+    - Shift+PgUp/PgDn: 이전/다음 년.
+    - Enter/Space: 선택.
+    - Esc: focus 해제 (popover에서는 닫힘 — DatePicker 책임).
+13. **포커스 관리** — focused day (visual cursor) 자동 유지. Tab으로 진입 시 selected 또는 today에 포커스.
+14. **i18n** — `locale` (Intl 사용), `weekStartsOn`.
+15. **테마** — `light` / `dark` + 사용자 색상 override.
+16. **DatePicker와의 통합** — Calendar는 외부 ref/Context로 DatePicker와 통신 가능 (선택 시 popover 닫기 등).
+17. **타입 export** — `CalendarDate`, `CalendarDayInfo`, `CalendarMode`, `CalendarTheme`, `WeekStart` 등.
+18. 배럴 — `export * from "./Calendar"`.
+
+### Non-goals (v1 제외)
+- **time 선택** — TimePicker는 별도 후보 (검토 대상). Calendar는 날짜만.
+- **datetime 합성** — 위 동일.
+- **이벤트 마킹 baked-in** — 사용자가 `<Calendar.Day>{children}</Calendar.Day>`로 직접 주입.
+- **week-view / agenda-view / multi-month** — `WeekView`, `AgendaView`는 향후 후보.
+- **연도 picker / month picker view** — 다른 view (Mantine은 `views: "day" | "month" | "year"` 지원). v1은 day view만.
+- **드래그 선택 range** — range는 클릭 1, 클릭 2 패턴만.
+- **휠 스크롤 month 네비** — 키보드 + 버튼만.
+- **input 처리** — DatePicker 책임.
+- **popover 통합** — DatePicker 책임.
+- **timezone awareness** — CalendarDate가 timezone-naive. 사용자가 timezone 처리 책임.
+- **lunar/Hijri/이슬람력** 등 비-그레고리력 — Intl API 의존이지만 v1은 그레고리력만 검증.
+- **persian-style numerals 자동 변환** — locale="fa-IR" 등에서 숫자 시각만 변환 (Intl이 알아서 처리).
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Calendar/Calendar.types.ts`
+
+```ts
+import type { CSSProperties, ReactNode } from "react";
+
+export type CalendarTheme = "light" | "dark";
+export type CalendarMode = "single" | "range" | "multiple";
+
+/** Year 절대값, month 1-12 (1-indexed), day 1-31. JS Date 회피. */
+export interface CalendarDate {
+  year: number;
+  month: number; // 1 = January
+  day: number;
+}
+
+export type CalendarSingleValue = CalendarDate | null;
+export interface CalendarRangeValue {
+  start: CalendarDate | null;
+  end: CalendarDate | null;
+}
+export type CalendarMultipleValue = CalendarDate[];
+
+/** 0 = Sunday, 1 = Monday, ..., 6 = Saturday. */
+export type WeekStart = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+/** 한 셀에 전달되는 날짜 메타. */
+export interface CalendarDayInfo {
+  date: CalendarDate;
+  inCurrentMonth: boolean;
+  isToday: boolean;
+  isSelected: boolean;
+  isRangeStart: boolean;
+  isRangeEnd: boolean;
+  isInRange: boolean;
+  isRangePreview: boolean;
+  isDisabled: boolean;
+  isFocused: boolean;
+}
+
+/** Root props 공통. */
+interface CalendarRootBase {
+  /** Calendar 표시 월. controlled. */
+  month?: CalendarDate;
+  defaultMonth?: CalendarDate;
+  onMonthChange?: (month: CalendarDate) => void;
+
+  /** 비활성 날짜 처리. */
+  minDate?: CalendarDate | Date;
+  maxDate?: CalendarDate | Date;
+  isDisabled?: (day: CalendarDate) => boolean;
+
+  /** locale, weekStartsOn. 기본: locale=navigator.language, weekStartsOn=0. */
+  locale?: string;
+  weekStartsOn?: WeekStart;
+
+  /** 테마. 기본 "light". */
+  theme?: CalendarTheme;
+
+  /** Calendar 전체 비활성 (포커스/선택 모두 차단). */
+  disabled?: boolean;
+
+  /** 자동 포커스 (mount 시 today 또는 selected에 포커스). 기본 false. */
+  autoFocus?: boolean;
+
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+export interface CalendarRootSingleProps extends CalendarRootBase {
+  mode?: "single";
+  value?: CalendarSingleValue;
+  defaultValue?: CalendarSingleValue;
+  onValueChange?: (value: CalendarSingleValue) => void;
+  /** 선택 시 트리거 (pop close 등 외부 액션 알림용). */
+  onSelect?: (date: CalendarDate) => void;
+}
+
+export interface CalendarRootRangeProps extends CalendarRootBase {
+  mode: "range";
+  value?: CalendarRangeValue;
+  defaultValue?: CalendarRangeValue;
+  onValueChange?: (value: CalendarRangeValue) => void;
+  onSelect?: (range: CalendarRangeValue) => void;
+}
+
+export interface CalendarRootMultipleProps extends CalendarRootBase {
+  mode: "multiple";
+  value?: CalendarMultipleValue;
+  defaultValue?: CalendarMultipleValue;
+  onValueChange?: (value: CalendarMultipleValue) => void;
+  onSelect?: (dates: CalendarMultipleValue) => void;
+}
+
+export type CalendarRootProps =
+  | CalendarRootSingleProps
+  | CalendarRootRangeProps
+  | CalendarRootMultipleProps;
+
+export interface CalendarHeaderProps {
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+export interface CalendarNavProps {
+  direction: "prev-year" | "prev-month" | "next-month" | "next-year";
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+  "aria-label"?: string;
+}
+
+export interface CalendarMonthLabelProps {
+  /**
+   * 라벨 포맷.
+   * - "long" (기본): "January 2026"
+   * - "short": "Jan 2026"
+   * - 사용자 정의: (month, locale) => string
+   */
+  format?: "long" | "short" | ((month: CalendarDate, locale: string) => string);
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface CalendarWeekdayHeaderProps {
+  /**
+   * 요일 표시 형식.
+   * - "narrow" (기본): "M" "T" "W" ...
+   * - "short": "Mon" "Tue" ...
+   * - "long": "Monday" "Tuesday" ...
+   */
+  format?: "narrow" | "short" | "long";
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface CalendarGridProps {
+  /**
+   * 커스텀 day 렌더. 미지정 시 기본 `<Calendar.Day>` 사용.
+   * 지정 시 사용자가 자유로운 셀 컨텐츠 합성 가능.
+   */
+  children?: (day: CalendarDayInfo) => ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface CalendarDayProps {
+  /** 셀이 표현하는 날짜 메타. */
+  day: CalendarDayInfo;
+  /** 셀 클릭 핸들러 override (기본 Calendar Context의 select 호출). */
+  onClick?: (date: CalendarDate) => void;
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+```
+
+### 2.2 utils — `src/components/Calendar/Calendar.dateMath.ts`
+
+`DatePicker.dateMath.ts`의 모든 함수를 그대로 이동:
+
+```ts
+// (DatePicker.dateMath.ts에서 100% 이동)
+export function isValidCalendarDate(c: CalendarDate): boolean { ... }
+export function compareCalendarDate(a, b): number { ... }
+export function isSameDay(a, b): boolean { ... }
+export function getDaysInMonth(year, month): number { ... }
+export function startOfMonthWeekday(year, month): number { ... }
+export function addMonths(c, delta): CalendarDate { ... }
+export function addDays(c, delta): CalendarDate { ... }
+export function addYears(c, delta): CalendarDate { ... }
+export function todayCalendarDate(): CalendarDate { ... }
+export function orderedWeekdays(weekStartsOn): number[] { ... }
+export function toCalendarDate(d): CalendarDate { ... }
+export function toDate(c): Date { ... }
+export function normalizeDateInput(input): CalendarDate | null { ... }
+export function weekdayOf(c): number { ... }
+export function buildMonthGrid(currentMonth, weekStartsOn): CalendarDate[] { ... }
+export function clampToRange(c, minDate, maxDate): CalendarDate { ... }
+```
+
+### 2.3 intl — `src/components/Calendar/Calendar.intl.ts`
+
+`DatePicker.intl.ts`의 locale 관련 함수 이동.
+
+```ts
+export function getMonthLabel(
+  month: CalendarDate,
+  locale: string,
+  format: "long" | "short" = "long",
+): string {
+  const date = new Date(month.year, month.month - 1, 1);
+  return new Intl.DateTimeFormat(locale, { month: format, year: "numeric" }).format(date);
+}
+
+export function getWeekdayLabel(
+  weekday: number, // 0-6
+  locale: string,
+  format: "narrow" | "short" | "long" = "narrow",
+): string {
+  // 임의 기준 일자에서 해당 요일 가져오기 (1970-01-04는 일요일)
+  const date = new Date(1970, 0, 4 + weekday);
+  return new Intl.DateTimeFormat(locale, { weekday: format }).format(date);
+}
+
+export function defaultLocale(): string {
+  if (typeof navigator !== "undefined" && navigator.language) {
+    return navigator.language;
+  }
+  return "en-US";
+}
+```
+
+### 2.4 theme — `src/components/Calendar/Calendar.theme.ts`
+
+DatePicker.theme.ts에서 Calendar 관련 부분 추출:
+
+```ts
+export interface CalendarThemeTokens {
+  // Container
+  bg: string;
+  border: string;
+
+  // Header / Nav
+  navBtn: string;
+  navBtnHover: string;
+  monthLabel: string;
+
+  // Weekday header
+  weekdayFg: string;
+
+  // Day cell
+  dayFg: string;
+  dayBg: string;
+  dayBgHover: string;
+  dayFgMuted: string;       // 다른 달 날짜
+  dayFgToday: string;
+  dayBorderToday: string;
+  dayBgSelected: string;
+  dayFgSelected: string;
+  dayBgRange: string;       // range 사이 음영
+  dayBgRangePreview: string;
+  dayFgDisabled: string;
+  dayBgDisabled: string;
+  dayBgFocused: string;     // 포커스 ring (또는 outline)
+
+  // Disabled state
+  disabledOpacity: number;
+}
+
+export const calendarThemes: Record<CalendarTheme, CalendarThemeTokens> = {
+  light: {
+    bg: "#ffffff",
+    border: "rgba(0,0,0,0.08)",
+    navBtn: "#6b7280",
+    navBtnHover: "#111827",
+    monthLabel: "#111827",
+    weekdayFg: "#9ca3af",
+    dayFg: "#111827",
+    dayBg: "transparent",
+    dayBgHover: "#f3f4f6",
+    dayFgMuted: "#cbd5e1",
+    dayFgToday: "#2563eb",
+    dayBorderToday: "#2563eb",
+    dayBgSelected: "#2563eb",
+    dayFgSelected: "#ffffff",
+    dayBgRange: "rgba(37,99,235,0.10)",
+    dayBgRangePreview: "rgba(37,99,235,0.05)",
+    dayFgDisabled: "#cbd5e1",
+    dayBgDisabled: "transparent",
+    dayBgFocused: "rgba(37,99,235,0.18)",
+    disabledOpacity: 0.5,
+  },
+  dark: {
+    bg: "#1f2937",
+    border: "rgba(255,255,255,0.08)",
+    navBtn: "#9ca3af",
+    navBtnHover: "#e5e7eb",
+    monthLabel: "#e5e7eb",
+    weekdayFg: "#6b7280",
+    dayFg: "#e5e7eb",
+    dayBg: "transparent",
+    dayBgHover: "#374151",
+    dayFgMuted: "#4b5563",
+    dayFgToday: "#60a5fa",
+    dayBorderToday: "#60a5fa",
+    dayBgSelected: "#60a5fa",
+    dayFgSelected: "#0f172a",
+    dayBgRange: "rgba(96,165,250,0.18)",
+    dayBgRangePreview: "rgba(96,165,250,0.10)",
+    dayFgDisabled: "#4b5563",
+    dayBgDisabled: "transparent",
+    dayBgFocused: "rgba(96,165,250,0.28)",
+    disabledOpacity: 0.5,
+  },
+};
+```
+
+### 2.5 Context — `src/components/Calendar/CalendarContext.ts`
+
+```ts
+import { createContext, useContext } from "react";
+import type {
+  CalendarDate,
+  CalendarMode,
+  CalendarSingleValue,
+  CalendarRangeValue,
+  CalendarMultipleValue,
+  CalendarTheme,
+  WeekStart,
+} from "./Calendar.types";
+
+export interface CalendarContextValue {
+  mode: CalendarMode;
+
+  // value (mode에 따라 union)
+  value: CalendarSingleValue | CalendarRangeValue | CalendarMultipleValue;
+  setValue: (next: any) => void;
+
+  // 보이는 월 (uncontrolled은 내부 state, controlled은 prop)
+  month: CalendarDate;
+  setMonth: (next: CalendarDate) => void;
+
+  // 비활성 판정
+  isDisabledDay: (day: CalendarDate) => boolean;
+
+  // 포커스
+  focusedDay: CalendarDate | null;
+  setFocusedDay: (d: CalendarDate | null) => void;
+
+  // range preview (range 모드 전용)
+  rangePreviewEnd: CalendarDate | null;
+  setRangePreviewEnd: (d: CalendarDate | null) => void;
+
+  // 클릭/선택 (mode에 따라 동작 다름)
+  selectDay: (day: CalendarDate) => void;
+
+  // 설정
+  locale: string;
+  weekStartsOn: WeekStart;
+  theme: CalendarTheme;
+  disabled: boolean;
+
+  // 외부 알림
+  onSelect?: (value: any) => void;
+}
+
+export const CalendarContext = createContext<CalendarContextValue | null>(null);
+
+export function useCalendarContext(): CalendarContextValue {
+  const ctx = useContext(CalendarContext);
+  if (!ctx) {
+    throw new Error("Calendar.* components must be used within Calendar.Root");
+  }
+  return ctx;
+}
+```
+
+### 2.6 메인 컴포넌트 합성 — `src/components/Calendar/Calendar.tsx`
+
+```tsx
+import { CalendarRoot } from "./CalendarRoot";
+import { CalendarHeader } from "./CalendarHeader";
+import { CalendarNav } from "./CalendarNav";
+import { CalendarMonthLabel } from "./CalendarMonthLabel";
+import { CalendarWeekdayHeader } from "./CalendarWeekdayHeader";
+import { CalendarGrid } from "./CalendarGrid";
+import { CalendarDay } from "./CalendarDay";
+
+export const Calendar = {
+  Root: CalendarRoot,
+  Header: CalendarHeader,
+  Nav: CalendarNav,
+  MonthLabel: CalendarMonthLabel,
+  WeekdayHeader: CalendarWeekdayHeader,
+  Grid: CalendarGrid,
+  Day: CalendarDay,
+};
+```
+
+### 2.7 배럴 — `src/components/Calendar/index.ts`
+
+```ts
+export { Calendar } from "./Calendar";
+export type {
+  CalendarRootProps,
+  CalendarRootSingleProps,
+  CalendarRootRangeProps,
+  CalendarRootMultipleProps,
+  CalendarHeaderProps,
+  CalendarNavProps,
+  CalendarMonthLabelProps,
+  CalendarWeekdayHeaderProps,
+  CalendarGridProps,
+  CalendarDayProps,
+  CalendarDate,
+  CalendarDayInfo,
+  CalendarMode,
+  CalendarSingleValue,
+  CalendarRangeValue,
+  CalendarMultipleValue,
+  CalendarTheme,
+  CalendarThemeTokens,
+  WeekStart,
+} from "./Calendar.types";
+export {
+  isSameDay,
+  isValidCalendarDate,
+  compareCalendarDate,
+  todayCalendarDate,
+  toCalendarDate,
+  toDate,
+  weekdayOf,
+} from "./Calendar.dateMath";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/Calendar/
+├── Calendar.types.ts             ← 타입
+├── Calendar.dateMath.ts          ← date 산수 (DatePicker.dateMath.ts에서 이동)
+├── Calendar.intl.ts              ← locale (DatePicker.intl.ts에서 이동)
+├── Calendar.theme.ts             ← 테마 토큰
+├── CalendarContext.ts            ← Context 정의 + use hook
+├── CalendarRoot.tsx              ← state 관리, Context provider
+├── CalendarHeader.tsx            ← 헤더 컨테이너
+├── CalendarNav.tsx               ← prev/next 버튼
+├── CalendarMonthLabel.tsx        ← 월/년 라벨
+├── CalendarWeekdayHeader.tsx     ← 요일 행
+├── CalendarGrid.tsx              ← 42칸 grid + render prop
+├── CalendarDay.tsx               ← 단일 셀
+├── Calendar.tsx                  ← compound assembly
+└── index.ts                      ← 배럴
+```
+
+---
+
+## 4. 동작 명세
+
+### 4.1 Mode별 selectDay 동작
+
+| mode | 클릭 시 |
+|---|---|
+| `single` | value = clickedDate. onSelect(date). |
+| `range` | value.start === null → start = clickedDate. value.start !== null && value.end === null → end = clickedDate (단, start보다 작으면 swap). 둘 다 있으면 새 클릭 = start만 다시 시작. |
+| `multiple` | value.includes(clickedDate) → 제거 (toggle). 아니면 추가 (정렬 유지). |
+
+### 4.2 Range preview
+
+- `mode === "range"` AND `value.start !== null` AND `value.end === null` 일 때만 활성.
+- Day cell의 onMouseEnter → `setRangePreviewEnd(date)`.
+- Grid의 onMouseLeave → `setRangePreviewEnd(null)`.
+- preview 영역: `start ~ rangePreviewEnd` (작은 값부터 큰 값) 사이 모든 날짜에 `isRangePreview: true`.
+
+### 4.3 isInRange / isRangeStart / isRangeEnd
+
+- `mode === "range"`, value.start AND value.end 모두 있으면:
+  - `isRangeStart`: date === start
+  - `isRangeEnd`: date === end
+  - `isInRange`: start < date < end
+- preview 단계는 `isRangePreview` (별도 시각).
+
+### 4.4 buildMonthGrid (이미 구현됨)
+
+```ts
+buildMonthGrid({year:2026, month:4}, weekStartsOn=0)
+// → 42 CalendarDate. lead: 4월 1일이 수요일이면 일/월/화 (3칸) lead.
+//   trail: 4월 30일이 목요일이면 금/토 (2칸) trail. 마지막 주 보충.
+```
+
+각 셀의 `inCurrentMonth = (date.month === currentMonth.month && date.year === currentMonth.year)`.
+
+### 4.5 키보드 네비게이션
+
+`Calendar.Root` 또는 활성 day cell에 keydown listener:
+
+| 키 | 동작 |
+|---|---|
+| `ArrowLeft` | focusedDay = addDays(focusedDay, -1) |
+| `ArrowRight` | focusedDay = addDays(focusedDay, +1) |
+| `ArrowUp` | focusedDay = addDays(focusedDay, -7) |
+| `ArrowDown` | focusedDay = addDays(focusedDay, +7) |
+| `Home` | focusedDay = 주 시작일 |
+| `End` | focusedDay = 주 마지막일 |
+| `PageUp` | focusedDay = addMonths(focusedDay, -1) |
+| `PageDown` | focusedDay = addMonths(focusedDay, +1) |
+| `Shift+PageUp` | focusedDay = addYears(focusedDay, -1) |
+| `Shift+PageDown` | focusedDay = addYears(focusedDay, +1) |
+| `Enter` / `Space` | selectDay(focusedDay) |
+| `Esc` | (no-op, popover 컨테이너 책임) |
+
+focusedDay 이동 시 month가 다르면 `setMonth(focusedDay)` 자동 호출 (월 자동 전환).
+
+### 4.6 자동 포커스 (autoFocus prop)
+
+- mount 시 focused day 초기화:
+  - `value`가 있으면 그것 (single: value, range: start, multiple: 첫 항목).
+  - 없으면 today.
+  - today가 minDate/maxDate 밖이면 minDate.
+- `autoFocus={true}`이면 mount 시 첫 day cell 또는 grid에 실제 focus().
+- 기본 false (DatePicker는 popover 열릴 때 별도 트리거).
+
+### 4.7 disabled 상태
+
+- `disabled: true` Root prop: 모든 셀 비활성, 키보드 차단.
+- 개별 day의 `isDisabled`:
+  - `minDate <= day <= maxDate` 범위 밖.
+  - `isDisabled?.(day) === true`.
+- 비활성 셀은 클릭 시 select 안 됨, hover preview 무시.
+
+### 4.8 month 변경 — controlled / uncontrolled
+
+- `month` prop 명시: controlled. `setMonth` 호출 시 `onMonthChange(next)` 만 호출 (내부 state 변경 안 함).
+- `defaultMonth` 명시 또는 미지정: uncontrolled. 내부 state 사용.
+
+initial month 결정:
+1. controlled: `month` prop.
+2. `defaultMonth`.
+3. value가 있으면 그 값의 월.
+4. today.
+
+---
+
+## 5. DatePicker와의 통합
+
+### 5.1 DatePicker가 Calendar를 어떻게 사용하나
+
+DatePicker.parts.tsx에 다음 패턴:
+
+```tsx
+<DatePicker.Root
+  mode={mode}
+  value={value}
+  onValueChange={onValueChange}
+  open={open}
+  onOpenChange={onOpenChange}
+  ...
+>
+  <DatePicker.Input />
+  <DatePicker.Trigger />
+  <DatePicker.Popover>
+    {/* DatePickerRoot가 Calendar.Root에 props 자동 전달 */}
+    <DatePicker.Calendar>
+      {/* DatePicker.Calendar = 내부적으로 <Calendar.Root> 렌더 */}
+      <Calendar.Header>
+        <Calendar.Nav direction="prev-month" />
+        <Calendar.MonthLabel />
+        <Calendar.Nav direction="next-month" />
+      </Calendar.Header>
+      <Calendar.WeekdayHeader />
+      <Calendar.Grid />
+    </DatePicker.Calendar>
+  </DatePicker.Popover>
+</DatePicker.Root>
+```
+
+### 5.2 DatePicker.Calendar wrapper
+
+DatePicker는 `DatePicker.Calendar`라는 wrapper component를 가지며, 이것이 DatePicker Context에서 prop을 추출해 `<Calendar.Root>`에 전달:
+
+```tsx
+// DatePicker/DatePickerCalendar.tsx
+export function DatePickerCalendar({ children }: { children: ReactNode }) {
+  const dpCtx = useDatePickerContext();
+
+  return (
+    <Calendar.Root
+      mode={dpCtx.mode}
+      value={dpCtx.value}
+      onValueChange={dpCtx.setValue}
+      month={dpCtx.month}
+      onMonthChange={dpCtx.setMonth}
+      minDate={dpCtx.minDate}
+      maxDate={dpCtx.maxDate}
+      isDisabled={dpCtx.isDisabled}
+      locale={dpCtx.locale}
+      weekStartsOn={dpCtx.weekStartsOn}
+      theme={dpCtx.theme}
+      disabled={dpCtx.disabled}
+      autoFocus={dpCtx.open} // popover 열릴 때 자동 포커스
+      onSelect={() => {
+        if (dpCtx.closeOnSelect) dpCtx.setOpen(false);
+      }}
+    >
+      {children}
+    </Calendar.Root>
+  );
+}
+```
+
+### 5.3 상태 동기화 흐름
+
+```
+사용자 input 타이핑
+  → DatePicker.Input onChange
+  → DatePicker.format.parse → CalendarDate
+  → DatePickerContext.setValue(date)
+  → Calendar.Root가 value prop 변화 감지
+  → Calendar 내부 selected day 표시 갱신
+
+사용자 Calendar Day 클릭
+  → CalendarContext.selectDay(date)
+  → Calendar의 onValueChange 호출 (DatePickerCalendar가 wiring)
+  → DatePickerContext.setValue(date)
+  → DatePicker.Input format.format → 표시
+  → onSelect → closeOnSelect=true면 popover 닫음
+```
+
+### 5.4 어떤 코드가 어디로 가는가
+
+| 현재 위치 | 이동 후 |
+|---|---|
+| `DatePicker.dateMath.ts` 100% | `Calendar.dateMath.ts` (Calendar export, DatePicker import) |
+| `DatePicker.intl.ts` 100% | `Calendar.intl.ts` |
+| `DatePicker.theme.ts`의 day/grid/header 토큰 | `Calendar.theme.ts` |
+| `DatePicker.theme.ts`의 input/trigger/popover 토큰 | `DatePicker.theme.ts` 유지 |
+| `DatePicker.types.ts`의 `CalendarDate`, `WeekStart`, `DatePickerDayInfo` (이름 `CalendarDayInfo`로 변경) | `Calendar.types.ts` (DatePicker가 re-export) |
+| `DatePicker.types.ts`의 input/trigger/popover/footer types | `DatePicker.types.ts` 유지 |
+| `useDatePickerState.ts`의 month/value/focus/preview state | Calendar Context로 이동 (CalendarRoot 내부) |
+| `useDatePickerState.ts`의 input value/parse error/popover open state | DatePicker에 유지 |
+
+### 5.5 type re-export
+
+DatePicker가 기존에 export하던 `CalendarDate`, `DatePickerDayInfo` 등은 사용자 입장에서 깨지지 않게 re-export:
+
+```ts
+// DatePicker/index.ts
+export type {
+  CalendarDate,
+  WeekStart,
+  CalendarDayInfo as DatePickerDayInfo, // alias 유지
+  CalendarSingleValue as SingleValue,
+  CalendarRangeValue as RangeValue,
+} from "../Calendar";
+```
+
+기존 `DatePicker.parts.tsx`에서 `<DatePicker.Calendar>`, `<DatePicker.Header>`, `<DatePicker.Grid>` 같은 이름으로 export하던 것은 다음 두 옵션:
+- (a) **deprecate** — DatePicker.X를 유지하되 내부적으로 Calendar.X로 forwarding. 하위 호환.
+- (b) **rename** — Calendar.X로 통일. Breaking change. DatePicker는 Wrapper만 (`DatePicker.Calendar` = wrapper, sub-component는 Calendar.X 직접).
+
+권장: **(b)**. DatePicker가 아직 사용자에게 export 전(진행 중 브랜치)이므로 breaking 위험 적음. 코드 명료성 우선.
+
+---
+
+## 6. 컴포넌트 구현 상세
+
+### 6.1 CalendarRoot.tsx
+
+```tsx
+export function CalendarRoot(props: CalendarRootProps) {
+  const {
+    mode = "single",
+    value: controlledValue,
+    defaultValue,
+    onValueChange,
+    onSelect,
+    month: controlledMonth,
+    defaultMonth,
+    onMonthChange,
+    minDate,
+    maxDate,
+    isDisabled,
+    locale = defaultLocale(),
+    weekStartsOn = 0,
+    theme = "light",
+    disabled = false,
+    autoFocus = false,
+    className,
+    style,
+    children,
+  } = props;
+
+  // value (controlled / uncontrolled)
+  const [internalValue, setInternalValue] = useState(() =>
+    defaultValue ?? (mode === "range" ? { start: null, end: null } : mode === "multiple" ? [] : null)
+  );
+  const value = controlledValue !== undefined ? controlledValue : internalValue;
+
+  const setValue = useCallback((next) => {
+    if (controlledValue === undefined) setInternalValue(next);
+    onValueChange?.(next);
+  }, [controlledValue, onValueChange]);
+
+  // month
+  const initialMonth = useMemo(() => {
+    if (controlledMonth) return controlledMonth;
+    if (defaultMonth) return defaultMonth;
+    // value 우선
+    if (mode === "single" && value) return value as CalendarDate;
+    if (mode === "range" && (value as CalendarRangeValue).start) return (value as CalendarRangeValue).start!;
+    if (mode === "multiple" && (value as CalendarMultipleValue).length) return (value as CalendarMultipleValue)[0];
+    return todayCalendarDate();
+  }, []);
+  const [internalMonth, setInternalMonth] = useState(initialMonth);
+  const month = controlledMonth ?? internalMonth;
+  const setMonth = useCallback((next) => {
+    if (controlledMonth === undefined) setInternalMonth(next);
+    onMonthChange?.(next);
+  }, [controlledMonth, onMonthChange]);
+
+  // focus
+  const [focusedDay, setFocusedDay] = useState<CalendarDate | null>(null);
+
+  // range preview
+  const [rangePreviewEnd, setRangePreviewEnd] = useState<CalendarDate | null>(null);
+
+  // isDisabledDay 종합
+  const minDateNorm = useMemo(() => normalizeDateInput(minDate), [minDate]);
+  const maxDateNorm = useMemo(() => normalizeDateInput(maxDate), [maxDate]);
+  const isDisabledDay = useCallback((d: CalendarDate) => {
+    if (minDateNorm && compareCalendarDate(d, minDateNorm) < 0) return true;
+    if (maxDateNorm && compareCalendarDate(d, maxDateNorm) > 0) return true;
+    if (isDisabled?.(d)) return true;
+    return false;
+  }, [minDateNorm, maxDateNorm, isDisabled]);
+
+  // selectDay (mode별)
+  const selectDay = useCallback((day: CalendarDate) => {
+    if (disabled || isDisabledDay(day)) return;
+
+    if (mode === "single") {
+      setValue(day);
+      onSelect?.(day);
+    } else if (mode === "range") {
+      const cur = value as CalendarRangeValue;
+      let next: CalendarRangeValue;
+      if (cur.start === null || (cur.start !== null && cur.end !== null)) {
+        // 새 range 시작
+        next = { start: day, end: null };
+      } else {
+        // start만 있음 → end 결정 (작으면 swap)
+        if (compareCalendarDate(day, cur.start) < 0) {
+          next = { start: day, end: cur.start };
+        } else {
+          next = { start: cur.start, end: day };
+        }
+      }
+      setValue(next);
+      if (next.start && next.end) onSelect?.(next);
+    } else if (mode === "multiple") {
+      const cur = value as CalendarMultipleValue;
+      const idx = cur.findIndex((d) => isSameDay(d, day));
+      let next: CalendarMultipleValue;
+      if (idx >= 0) {
+        next = [...cur.slice(0, idx), ...cur.slice(idx + 1)];
+      } else {
+        next = [...cur, day].sort(compareCalendarDate);
+      }
+      setValue(next);
+      onSelect?.(next);
+    }
+  }, [mode, value, disabled, isDisabledDay, setValue, onSelect]);
+
+  // 키보드 핸들러는 Day cell에 부착 (포커스된 cell이 받음).
+
+  // autoFocus
+  const rootRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (autoFocus && rootRef.current) {
+      const initialFocus = (() => {
+        if (mode === "single" && value) return value as CalendarDate;
+        if (mode === "range" && (value as CalendarRangeValue).start) return (value as CalendarRangeValue).start!;
+        return todayCalendarDate();
+      })();
+      setFocusedDay(initialFocus);
+      // DOM에서 focused cell 찾아서 focus()
+      requestAnimationFrame(() => {
+        const cell = rootRef.current?.querySelector<HTMLElement>(`[data-day-focused="true"]`);
+        cell?.focus();
+      });
+    }
+  }, [autoFocus]);
+
+  // theme tokens
+  const tokens = calendarThemes[theme];
+
+  const ctx: CalendarContextValue = {
+    mode,
+    value,
+    setValue,
+    month,
+    setMonth,
+    isDisabledDay,
+    focusedDay,
+    setFocusedDay,
+    rangePreviewEnd,
+    setRangePreviewEnd,
+    selectDay,
+    locale,
+    weekStartsOn,
+    theme,
+    disabled,
+    onSelect,
+  };
+
+  return (
+    <CalendarContext.Provider value={ctx}>
+      <div
+        ref={rootRef}
+        role="application"
+        aria-label="Calendar"
+        className={className}
+        style={{
+          display: "inline-block",
+          background: tokens.bg,
+          border: `1px solid ${tokens.border}`,
+          borderRadius: 8,
+          padding: 8,
+          fontFamily: "inherit",
+          ...style,
+        }}
+      >
+        {children}
+      </div>
+    </CalendarContext.Provider>
+  );
+}
+```
+
+### 6.2 CalendarHeader / Nav / MonthLabel
+
+```tsx
+export function CalendarHeader(props: CalendarHeaderProps) {
+  const { className, style, children } = props;
+  return (
+    <div
+      className={className}
+      style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "4px 0", ...style }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function CalendarNav(props: CalendarNavProps) {
+  const { direction, className, style, children, "aria-label": ariaLabel } = props;
+  const ctx = useCalendarContext();
+  const tokens = calendarThemes[ctx.theme];
+
+  const handleClick = () => {
+    const delta = {
+      "prev-year": -12,
+      "prev-month": -1,
+      "next-month": 1,
+      "next-year": 12,
+    }[direction];
+    ctx.setMonth(addMonths(ctx.month, delta));
+  };
+
+  const labelMap = {
+    "prev-year": "Previous year",
+    "prev-month": "Previous month",
+    "next-month": "Next month",
+    "next-year": "Next year",
+  };
+
+  // 기본 children: chevron 또는 double chevron 아이콘 (Icon 시스템 활용)
+  const defaultChildren = direction.startsWith("prev")
+    ? direction.endsWith("year") ? "«" : "‹"
+    : direction.endsWith("year") ? "»" : "›";
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={ariaLabel ?? labelMap[direction]}
+      disabled={ctx.disabled}
+      className={className}
+      style={{
+        background: "transparent",
+        border: "none",
+        color: tokens.navBtn,
+        cursor: ctx.disabled ? "not-allowed" : "pointer",
+        padding: "4px 8px",
+        borderRadius: 4,
+        fontSize: 14,
+        ...style,
+      }}
+    >
+      {children ?? defaultChildren}
+    </button>
+  );
+}
+
+export function CalendarMonthLabel(props: CalendarMonthLabelProps) {
+  const { format = "long", className, style } = props;
+  const ctx = useCalendarContext();
+  const tokens = calendarThemes[ctx.theme];
+
+  const label = typeof format === "function"
+    ? format(ctx.month, ctx.locale)
+    : getMonthLabel(ctx.month, ctx.locale, format);
+
+  return (
+    <span
+      aria-live="polite"
+      className={className}
+      style={{ fontWeight: 600, color: tokens.monthLabel, ...style }}
+    >
+      {label}
+    </span>
+  );
+}
+```
+
+### 6.3 CalendarWeekdayHeader
+
+```tsx
+export function CalendarWeekdayHeader(props: CalendarWeekdayHeaderProps) {
+  const { format = "narrow", className, style } = props;
+  const ctx = useCalendarContext();
+  const tokens = calendarThemes[ctx.theme];
+  const weekdays = orderedWeekdays(ctx.weekStartsOn);
+
+  return (
+    <div
+      className={className}
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(7, 1fr)",
+        textAlign: "center",
+        fontSize: 11,
+        color: tokens.weekdayFg,
+        textTransform: "uppercase",
+        letterSpacing: 0.5,
+        padding: "4px 0",
+        ...style,
+      }}
+    >
+      {weekdays.map((wd) => (
+        <span key={wd} aria-hidden="true">
+          {getWeekdayLabel(wd, ctx.locale, format)}
+        </span>
+      ))}
+    </div>
+  );
+}
+```
+
+### 6.4 CalendarGrid
+
+```tsx
+export function CalendarGrid(props: CalendarGridProps) {
+  const { children, className, style } = props;
+  const ctx = useCalendarContext();
+  const days = useMemo(() => buildMonthGrid(ctx.month, ctx.weekStartsOn), [ctx.month, ctx.weekStartsOn]);
+
+  const handleMouseLeave = () => {
+    if (ctx.mode === "range") ctx.setRangePreviewEnd(null);
+  };
+
+  return (
+    <div
+      role="grid"
+      className={className}
+      onMouseLeave={handleMouseLeave}
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(7, 1fr)",
+        gap: 0,
+        ...style,
+      }}
+    >
+      {days.map((date, i) => {
+        const info = computeDayInfo(date, ctx);
+        return children
+          ? <Fragment key={i}>{children(info)}</Fragment>
+          : <CalendarDay key={i} day={info} />;
+      })}
+    </div>
+  );
+}
+
+function computeDayInfo(date: CalendarDate, ctx: CalendarContextValue): CalendarDayInfo {
+  const today = todayCalendarDate();
+  const inCurrentMonth = date.month === ctx.month.month && date.year === ctx.month.year;
+  const isToday = isSameDay(date, today);
+
+  let isSelected = false;
+  let isRangeStart = false;
+  let isRangeEnd = false;
+  let isInRange = false;
+  let isRangePreview = false;
+
+  if (ctx.mode === "single") {
+    const v = ctx.value as CalendarSingleValue;
+    isSelected = isSameDay(date, v);
+  } else if (ctx.mode === "range") {
+    const v = ctx.value as CalendarRangeValue;
+    isRangeStart = isSameDay(date, v.start);
+    isRangeEnd = isSameDay(date, v.end);
+    if (v.start && v.end) {
+      isInRange = compareCalendarDate(date, v.start) > 0 && compareCalendarDate(date, v.end) < 0;
+    }
+    isSelected = isRangeStart || isRangeEnd;
+
+    if (v.start && !v.end && ctx.rangePreviewEnd) {
+      const lo = compareCalendarDate(v.start, ctx.rangePreviewEnd) <= 0 ? v.start : ctx.rangePreviewEnd;
+      const hi = compareCalendarDate(v.start, ctx.rangePreviewEnd) <= 0 ? ctx.rangePreviewEnd : v.start;
+      isRangePreview =
+        compareCalendarDate(date, lo) >= 0 && compareCalendarDate(date, hi) <= 0;
+    }
+  } else if (ctx.mode === "multiple") {
+    const v = ctx.value as CalendarMultipleValue;
+    isSelected = v.some((d) => isSameDay(d, date));
+  }
+
+  return {
+    date,
+    inCurrentMonth,
+    isToday,
+    isSelected,
+    isRangeStart,
+    isRangeEnd,
+    isInRange,
+    isRangePreview,
+    isDisabled: ctx.isDisabledDay(date),
+    isFocused: isSameDay(date, ctx.focusedDay),
+  };
+}
+```
+
+### 6.5 CalendarDay
+
+```tsx
+export function CalendarDay(props: CalendarDayProps) {
+  const { day, onClick, className, style, children } = props;
+  const ctx = useCalendarContext();
+  const tokens = calendarThemes[ctx.theme];
+
+  const handleClick = () => {
+    if (day.isDisabled) return;
+    if (onClick) onClick(day.date);
+    else ctx.selectDay(day.date);
+  };
+
+  const handleMouseEnter = () => {
+    if (ctx.mode === "range") ctx.setRangePreviewEnd(day.date);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (ctx.disabled) return;
+    let next: CalendarDate | null = null;
+    switch (e.key) {
+      case "ArrowLeft":  next = addDays(day.date, -1); break;
+      case "ArrowRight": next = addDays(day.date, +1); break;
+      case "ArrowUp":    next = addDays(day.date, -7); break;
+      case "ArrowDown":  next = addDays(day.date, +7); break;
+      case "Home":       next = addDays(day.date, -weekdayIndex(day.date, ctx.weekStartsOn)); break;
+      case "End":        next = addDays(day.date, 6 - weekdayIndex(day.date, ctx.weekStartsOn)); break;
+      case "PageUp":     next = e.shiftKey ? addYears(day.date, -1) : addMonths(day.date, -1); break;
+      case "PageDown":   next = e.shiftKey ? addYears(day.date, +1) : addMonths(day.date, +1); break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        handleClick();
+        return;
+      default:
+        return;
+    }
+    e.preventDefault();
+    if (next) {
+      ctx.setFocusedDay(next);
+      // 다른 달이면 month 자동 전환
+      if (next.month !== ctx.month.month || next.year !== ctx.month.year) {
+        ctx.setMonth({ year: next.year, month: next.month, day: 1 });
+      }
+      // 다음 렌더 후 새 cell에 focus
+      requestAnimationFrame(() => {
+        const cell = document.querySelector<HTMLElement>(`[data-day="${next.year}-${next.month}-${next.day}"]`);
+        cell?.focus();
+      });
+    }
+  };
+
+  const cellStyle: CSSProperties = {
+    width: 36,
+    height: 36,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: 13,
+    cursor: day.isDisabled ? "not-allowed" : "pointer",
+    color: day.isDisabled
+      ? tokens.dayFgDisabled
+      : !day.inCurrentMonth
+        ? tokens.dayFgMuted
+        : day.isSelected
+          ? tokens.dayFgSelected
+          : day.isToday
+            ? tokens.dayFgToday
+            : tokens.dayFg,
+    background: day.isDisabled
+      ? tokens.dayBgDisabled
+      : day.isSelected || day.isRangeStart || day.isRangeEnd
+        ? tokens.dayBgSelected
+        : day.isInRange
+          ? tokens.dayBgRange
+          : day.isRangePreview
+            ? tokens.dayBgRangePreview
+            : day.isFocused
+              ? tokens.dayBgFocused
+              : tokens.dayBg,
+    border: day.isToday && !day.isSelected ? `1px solid ${tokens.dayBorderToday}` : "1px solid transparent",
+    borderRadius: 4,
+    boxSizing: "border-box",
+    opacity: day.isDisabled ? tokens.disabledOpacity : 1,
+    outline: "none",
+    ...style,
+  };
+
+  return (
+    <button
+      type="button"
+      role="gridcell"
+      tabIndex={day.isFocused ? 0 : -1}
+      aria-selected={day.isSelected}
+      aria-disabled={day.isDisabled}
+      aria-label={`${day.date.year}-${day.date.month}-${day.date.day}`}
+      data-day={`${day.date.year}-${day.date.month}-${day.date.day}`}
+      data-day-focused={day.isFocused ? "true" : undefined}
+      data-day-selected={day.isSelected ? "true" : undefined}
+      data-day-today={day.isToday ? "true" : undefined}
+      onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onKeyDown={handleKeyDown}
+      disabled={day.isDisabled || ctx.disabled}
+      className={className}
+      style={cellStyle}
+    >
+      {children ?? day.date.day}
+    </button>
+  );
+}
+
+function weekdayIndex(date: CalendarDate, weekStartsOn: WeekStart): number {
+  const wd = weekdayOf(date);
+  return (wd - weekStartsOn + 7) % 7;
+}
+```
+
+---
+
+## 7. 데모 페이지 — `demo/src/pages/CalendarPage.tsx`
+
+```tsx
+export function CalendarPage() {
+  const [single, setSingle] = useState<CalendarSingleValue>(null);
+  const [range, setRange] = useState<CalendarRangeValue>({ start: null, end: null });
+  const [multi, setMulti] = useState<CalendarMultipleValue>([]);
+
+  return (
+    <div>
+      <h1>Calendar</h1>
+
+      {/* 1. single */}
+      <Card.Root>
+        <Card.Header>Single mode</Card.Header>
+        <Card.Body>
+          <Calendar.Root mode="single" value={single} onValueChange={setSingle}>
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-year" />
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+              <Calendar.Nav direction="next-year" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader />
+            <Calendar.Grid />
+          </Calendar.Root>
+          <p>Selected: {single ? `${single.year}-${single.month}-${single.day}` : "(none)"}</p>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 2. range */}
+      <Card.Root>
+        <Card.Header>Range mode</Card.Header>
+        <Card.Body>
+          <Calendar.Root mode="range" value={range} onValueChange={setRange}>
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader />
+            <Calendar.Grid />
+          </Calendar.Root>
+          <p>Range: {range.start ? `${formatDate(range.start)} ~ ${range.end ? formatDate(range.end) : "..."}` : "(none)"}</p>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 3. multiple */}
+      <Card.Root>
+        <Card.Header>Multiple mode</Card.Header>
+        <Card.Body>
+          <Calendar.Root mode="multiple" value={multi} onValueChange={setMulti}>
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader />
+            <Calendar.Grid />
+          </Calendar.Root>
+          <p>Selected: {multi.length} dates</p>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 4. min/max + isDisabled */}
+      <Card.Root>
+        <Card.Header>Constrained (min, max, isDisabled=Sun)</Card.Header>
+        <Card.Body>
+          <Calendar.Root
+            mode="single"
+            minDate={{year:2026, month:4, day:10}}
+            maxDate={{year:2026, month:5, day:20}}
+            isDisabled={(d) => weekdayOf(d) === 0}
+          >
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader />
+            <Calendar.Grid />
+          </Calendar.Root>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 5. 커스텀 day 렌더 */}
+      <Card.Root>
+        <Card.Header>Custom day render (이벤트 마킹)</Card.Header>
+        <Card.Body>
+          <Calendar.Root mode="single">
+            <Calendar.Header>...</Calendar.Header>
+            <Calendar.WeekdayHeader />
+            <Calendar.Grid>
+              {(day) => (
+                <Calendar.Day day={day}>
+                  {day.date.day}
+                  {hasEvent(day.date) && <span style={{position:"absolute",bottom:2,right:4,color:"red"}}>•</span>}
+                </Calendar.Day>
+              )}
+            </Calendar.Grid>
+          </Calendar.Root>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 6. locale */}
+      <Card.Root>
+        <Card.Header>Locale (ko-KR)</Card.Header>
+        <Card.Body>
+          <Calendar.Root mode="single" locale="ko-KR" weekStartsOn={1}>
+            <Calendar.Header>
+              <Calendar.Nav direction="prev-month" />
+              <Calendar.MonthLabel />
+              <Calendar.Nav direction="next-month" />
+            </Calendar.Header>
+            <Calendar.WeekdayHeader format="narrow" />
+            <Calendar.Grid />
+          </Calendar.Root>
+        </Card.Body>
+      </Card.Root>
+
+      {/* 7. dark theme */}
+      <Card.Root>
+        <Card.Header>Dark theme</Card.Header>
+        <Card.Body>
+          <div style={{background:"#1f2937", padding:16}}>
+            <Calendar.Root mode="single" theme="dark">
+              <Calendar.Header>
+                <Calendar.Nav direction="prev-month" />
+                <Calendar.MonthLabel />
+                <Calendar.Nav direction="next-month" />
+              </Calendar.Header>
+              <Calendar.WeekdayHeader />
+              <Calendar.Grid />
+            </Calendar.Root>
+          </div>
+        </Card.Body>
+      </Card.Root>
+    </div>
+  );
+}
+```
+
+---
+
+## 8. 접근성 (a11y)
+
+### 8.1 ARIA 구조
+- `Calendar.Root` → `role="application"`, `aria-label="Calendar"`.
+- `Calendar.Grid` → `role="grid"`.
+- `Calendar.Day` → `role="gridcell"`, `aria-selected`, `aria-disabled`, `aria-label="{YYYY}-{MM}-{DD}"`.
+- `Calendar.MonthLabel` → `aria-live="polite"` (월 변경 시 알림).
+- `Calendar.Nav` 버튼 → `aria-label="Previous month"` 등.
+
+### 8.2 포커스 관리
+- focused day cell만 `tabIndex=0`. 나머지 `tabIndex=-1`.
+- Tab → focused cell로 진입. 다시 Tab → grid 밖으로 (다음 인접 요소).
+- Arrow 키 이동 시 focusedDay 갱신 + DOM focus 이동.
+
+### 8.3 키보드 단축키
+모든 Arrow/Home/End/PgUp/PgDn 처리 (§4.5).
+
+### 8.4 스크린리더 검증
+- VoiceOver: 셀에 포커스 → "April 15, 2026, selected" 식 안내.
+- NVDA: grid role 인식, gridcell에서 화살표 이동 안내.
+- 월 변경 시 MonthLabel이 polite로 알려야 (반복 알림 노이즈 주의 — debounce 검토).
+
+---
+
+## 9. 설계 결정 사항 (rationale)
+
+### 9.1 CalendarDate 객체 (year/month/day) vs Date
+**이유**: JS `Date`는 timezone에 의존 → "2026-04-26"이 사용자 timezone에 따라 다른 날로 해석되는 클래식 버그. Calendar/DatePicker는 "로컬 시간 기준 캘린더 일자"라는 의미를 명확히 분리. timezone-naive 객체로 통일.
+
+### 9.2 month 0-indexed 회피 (1-12)
+**이유**: 사용자가 콘솔에 찍을 때 `{year:2026, month:4}` → 4월. Date 객체의 0-11 vs 캘린더 통상 표기 1-12 미스매치 버그 흔함.
+
+### 9.3 42칸 고정 grid
+**이유**: 6주 × 7일은 모든 월을 담을 수 있는 최소 공통 크기. 셀 개수 가변이면 그리드 높이가 매월 변동 → popover 점프. 고정 42칸 + lead/trail 회색 처리가 표준.
+
+### 9.4 mode 기반 다형성 vs 별도 컴포넌트
+**이유**: `Calendar.Single`, `Calendar.Range`, `Calendar.Multiple` 별도 컴포넌트로 갈 수도 있으나, 코드 중복이 크고 사용자가 mode 변경 시 import 바꿔야 함. mode prop + value union이 react-day-picker, react-aria 표준 패턴.
+
+### 9.5 Compound 컴포넌트 (Header/Nav/Grid 분리)
+**이유**: 사용자가 Header에 prev-only 또는 prev-year 추가 등 자유 구성. 또한 footer 영역(예: "Today" 버튼)을 사용자가 원하는 대로 추가 가능. monolithic `<Calendar />` 한 컴포넌트보다 합성성 우수.
+
+### 9.6 Calendar Context — DatePicker Context와 중첩
+**이유**: Calendar는 자기 Context로 완전히 자립. DatePicker가 Calendar를 wrap할 때, DatePicker.Calendar wrapper가 props bridging만 담당. 두 Context는 nested되지만 독립 — Calendar는 DatePicker를 모름. 이 방향이 단독 사용을 가능하게 함.
+
+### 9.7 range preview hover만 + 클릭 패턴
+**이유**: 드래그 선택은 모바일 터치 친화도 낮고 키보드 a11y 어려움. 클릭 1, 클릭 2 + hover preview 가 react-day-picker, mantine 등 표준.
+
+### 9.8 자동 month 전환 (focused day가 다른 달)
+**이유**: 사용자가 ArrowUp을 다음 달 첫 주에서 누르면 이전 달로 자연스럽게 넘어가야. 자동 전환 없으면 포커스가 보이지 않게 됨.
+
+### 9.9 onSelect vs onValueChange
+**이유**: onValueChange는 value가 바뀔 때마다 (controlled 패턴), onSelect는 "사용자가 선택을 완료한 시점" 트리거 (range는 end 결정 시, single은 매 클릭). DatePicker가 popover 닫기 같은 외부 액션을 onSelect에 wiring.
+
+---
+
+## 10. Edge cases
+
+### 10.1 month가 minDate~maxDate 범위 밖
+- 사용자가 prev/next 클릭으로 범위 밖으로 이동 가능.
+- 모든 셀이 disabled로 표시 → 선택 불가.
+- `<Calendar.Nav>` 버튼 자체를 disable하는 옵션은 v1.1.
+
+### 10.2 weekStartsOn=6 (토요일)
+- 정상 동작. weekday 헤더, grid 모두 토요일이 첫 컬럼.
+
+### 10.3 윤년 2월
+- `getDaysInMonth(2024, 2) === 29`. JS Date 정확하게 처리.
+
+### 10.4 1900년 이전 / 9999년 이후
+- v1 검증 범위 밖. 동작은 할 수 있으나 보장 안 함.
+
+### 10.5 RTL locale (Arabic 등)
+- Intl이 자동 처리. 단 grid 자체는 LTR 가정 — 명시적 RTL 지원은 v1.1.
+
+### 10.6 multiple 모드 100+ 개 선택
+- 성능: array.findIndex / sort O(n log n). 100개 정도는 문제 없음. 1000+이면 Set 기반으로 변경 필요 (v1.1).
+
+### 10.7 controlled value가 invalid CalendarDate
+- 예: `{year:2026, month:13, day:1}` → JS Date가 자동 normalize (2027-1-1).
+- v1은 검증 안 함. 사용자가 `isValidCalendarDate` 미리 체크 권장. 문서에 명시.
+
+### 10.8 mode 변경 (single → range 등)
+- 권장하지 않음 (value 타입 호환 안 됨). React가 컴포넌트 재마운트 강제할 가능성.
+- 사용자가 mode를 prop으로 변경하면 internal state mismatch 가능성 → key prop으로 재마운트 강제 권장.
+
+### 10.9 IME (한국어 등) 입력
+- Calendar는 텍스트 입력 없음 (DatePicker.Input 책임). 영향 없음.
+
+### 10.10 SSR
+- `todayCalendarDate()` 호출이 서버/클라이언트에서 다른 값 반환 가능.
+- 권장: month/value를 controlled로 명시. uncontrolled는 hydration 직후 잠시 mismatch 가능.
+
+---
+
+## 11. 구현 단계 (Phase)
+
+### Phase 1: Calendar 신설
+1. `src/components/Calendar/` 디렉터리 생성, 14개 파일 작성:
+   - Calendar.types.ts
+   - Calendar.dateMath.ts (DatePicker.dateMath.ts 복사 + import path 수정)
+   - Calendar.intl.ts (DatePicker.intl.ts 복사)
+   - Calendar.theme.ts (DatePicker.theme.ts에서 calendar 토큰 추출)
+   - CalendarContext.ts
+   - CalendarRoot.tsx
+   - CalendarHeader.tsx, CalendarNav.tsx, CalendarMonthLabel.tsx
+   - CalendarWeekdayHeader.tsx, CalendarGrid.tsx, CalendarDay.tsx
+   - Calendar.tsx (compound assembly), index.ts
+2. `src/components/index.ts` 추가.
+3. `npm run typecheck` 통과.
+4. `npm run build` 통과.
+
+### Phase 2: Calendar 데모 페이지
+1. `demo/src/pages/CalendarPage.tsx` 작성 (§7).
+2. NAV 등록, 모든 7개 섹션 시각 확인.
+3. 키보드 네비 (Arrow, Home/End, PgUp/PgDn, Enter) 모두 작동 확인.
+4. light/dark 테마 확인.
+
+### Phase 3: DatePicker 리팩토링
+1. `DatePicker.dateMath.ts` 삭제 (Calendar.dateMath.ts로 이동됨).
+2. `DatePicker.intl.ts` 삭제.
+3. `DatePicker.theme.ts`에서 calendar 토큰 제거 (input/trigger/popover만 남김).
+4. `DatePicker.types.ts`에서 `CalendarDate`, `WeekStart`, `DatePickerDayInfo`, `SingleValue`, `RangeValue` 제거 → Calendar에서 re-export.
+5. `useDatePickerState.ts`에서 month/value/focus/preview 상태 제거 → Calendar Context 활용.
+6. `DatePickerContext`에서 calendar 관련 필드 제거.
+7. `DatePickerRoot.tsx` 단순화 — 더 이상 calendar 상태 관리 안 함.
+8. `DatePicker.parts.tsx`에서 `DatePicker.Calendar`, `DatePicker.Header`, `DatePicker.Grid`, `DatePicker.Day`, `DatePicker.Nav`, `DatePicker.MonthLabel` 제거.
+9. 새로운 `DatePicker/DatePickerCalendar.tsx` 작성 — Calendar.Root wrapper.
+10. `DatePicker.tsx` namespace에 `Calendar: DatePickerCalendar` 추가.
+11. `DatePicker/index.ts`에서 type re-export 정리.
+
+### Phase 4: DatePicker 데모 페이지 업데이트
+1. `demo/src/pages/DatePickerPage.tsx`가 새 합성 패턴 사용:
+   ```tsx
+   <DatePicker.Root>
+     <DatePicker.Input />
+     <DatePicker.Trigger />
+     <DatePicker.Popover>
+       <DatePicker.Calendar>
+         <Calendar.Header>
+           <Calendar.Nav direction="prev-month" />
+           <Calendar.MonthLabel />
+           <Calendar.Nav direction="next-month" />
+         </Calendar.Header>
+         <Calendar.WeekdayHeader />
+         <Calendar.Grid />
+       </DatePicker.Calendar>
+     </DatePicker.Popover>
+   </DatePicker.Root>
+   ```
+2. 시각 회귀 확인.
+
+### Phase 5: 정리
+- [ ] `docs/candidates.md`에서 6번 Calendar 항목 제거 + 본 plan 링크.
+- [ ] README.md에 Calendar 섹션 추가.
+
+---
+
+## 12. 향후 확장 (v1.1+)
+
+| 항목 | 설명 |
+|---|---|
+| `views: "day"\|"month"\|"year"` | 월 picker, 년 picker view 전환 |
+| `numberOfMonths` | 다중 월 동시 표시 (DateRangePicker용) |
+| `rtl` | RTL 명시 지원 |
+| Set 기반 multiple value | 1000+ 선택 성능 최적화 |
+| `Nav` 자동 disable | minDate/maxDate 도달 시 prev/next 비활성 |
+| `<Calendar.Today>` | "오늘" 빠른 이동 버튼 |
+| `<Calendar.WeekNumber>` | ISO 주차 번호 컬럼 |
+| Modifiers 시스템 | react-day-picker처럼 임의 modifier 정의 |
+| Animation | 월 전환 슬라이드 애니메이션 |
+
+---
+
+## 13. 체크리스트 (작업 완료 기준)
+
+- [ ] `src/components/Calendar/` 14개 파일 작성 완료
+- [ ] `npm run typecheck` 통과
+- [ ] `npm run build` 통과
+- [ ] CalendarPage 7개 섹션 모두 시각 정상 (light/dark)
+- [ ] 키보드 네비 모두 작동 (Arrow/Home/End/PgUp/PgDn/Enter/Space)
+- [ ] 3가지 mode 모두 정상 (single/range/multiple)
+- [ ] range preview 정상
+- [ ] min/max/isDisabled 정상
+- [ ] locale 변경 시 라벨 정상 (ko-KR 등)
+- [ ] DatePicker 리팩토링 완료, DatePickerPage 시각 정상
+- [ ] DatePicker 기존 type re-export로 사용자 코드 깨지지 않음
+- [ ] `docs/candidates.md`에서 6번 항목 제거 + plan 링크
+- [ ] README.md 업데이트

--- a/docs/plans/026-copybutton-component.md
+++ b/docs/plans/026-copybutton-component.md
@@ -1,0 +1,1093 @@
+# CopyButton + useCopyToClipboard 설계문서
+
+## Context
+
+라이브러리에 **클립보드 복사 + idle/copied 피드백 상태**를 표준화한 두 자산을 도입한다:
+
+1. **`useCopyToClipboard`** (`src/components/_shared/useCopyToClipboard.ts`) — 클립보드 쓰기 + idle/copied 상태 관리 + 자동 리셋 타이머를 캡슐화한 React 훅. 단독으로 export하여 사용자가 자체 UI를 만들 수 있게 함.
+2. **`CopyButton`** (`src/components/CopyButton/`) — 위 훅을 사용하는 일반 UI 버튼 컴포넌트. 기본 텍스트("Copy" → "Copied!"), 아이콘, 사이즈, 테마 등 표준화.
+
+본 작업은 **신규 자산 추가 + 기존 컴포넌트 마이그레이션**의 두 측면을 가진다.
+
+**현재 상태**:
+- `HexView`에 자체 copy 구현이 존재 (`src/components/HexView/HexView.tsx` line 312-325, `doCopy` 함수). 동일 패턴(navigator.clipboard.writeText + 1500ms idle 복귀)이지만 컴포넌트 내부에 잠겨 있음.
+- `CodeView`에는 copy 버튼 자체는 있으나(line 426-450), 같은 idle/copied 상태 패턴을 자체 구현하고 있음(`copyState` state).
+- `PathInput`, `KeyValueList`(향후 후보), `Field`(향후 후보) 등 다른 컴포넌트는 copy 패턴이 아직 없으나 추가될 가능성 높음.
+
+**B방향 마이그레이션 (사용자 결정)**: 신규 사용처는 `<CopyButton />`을 직접 사용하고, 기존 컴포넌트(HexView, CodeView)도 자체 `doCopy`/`copyState` 로직을 `useCopyToClipboard` 훅으로 교체한다. 외부 UI는 유지(HexView의 포맷 토글, CodeView의 우상단 버튼)하되 클립보드 쓰기·상태 관리만 공유 훅에 위임. 이로써 향후 클립보드 정책 변경(권한 실패 fallback, secure context 처리, 알림 톤 등)을 한 곳에서 관리.
+
+참고 (prior art):
+- **react-copy-to-clipboard** — 가장 잘 알려진 라이브러리. `<CopyToClipboard text={...} onCopy={...}><button>...</button></CopyToClipboard>` 패턴. 단점: render prop 아닌 wrapper, 자식 클릭 가로채기.
+- **@uiw/react-copy-to-clipboard** — 동일 패턴 + ref 지원.
+- **copy-to-clipboard** (npm) — 함수형, IE 11+ 호환을 위해 `document.execCommand("copy")` 폴백 포함.
+- **navigator.clipboard.writeText** — 모던 표준. HTTPS / localhost / file:// 같은 secure context 필요. 권한 실패 시 reject Promise.
+- **shadcn/ui** — `useCopyToClipboard` 훅 + `<Button>` 합성. 훅이 `[copied, copy]` 반환.
+- **Mantine `useClipboard`** — `{copied, copy(value), reset, error}` 객체 반환. timeout default 2000ms.
+- **VSCode** — copy 버튼 클릭 시 inline `Copied!` 토스트 (1.5s 정도).
+
+본 레포 내부 참조 (읽어야 할 파일):
+- `src/components/HexView/HexView.tsx` (1000+줄) — line 185 (`copyState` state), 312-325 (`doCopy`), 327-335 (`onCopyEvent`, native clipboard event 처리), 350-353 (Cmd+C 핸들러), 753-790 (포맷 토글 UI). **마이그레이션 대상**.
+- `src/components/HexView/HexView.utils.ts` — `formatBytes(slice, fmt)` 헬퍼 (유지, copy 로직만 훅으로 이동).
+- `src/components/HexView/HexView.types.ts` — `HexViewCopyFormat`, `showCopyButton`, `defaultCopyFormat` props.
+- `src/components/CodeView/CodeView.tsx` — line 127 (`copyState` state), line 426-450 (copy 버튼 렌더), copy 핸들러 (`handleCopyAll` 등). **마이그레이션 대상**.
+- `src/components/_shared/` — 공유 hooks 위치. `useCopyToClipboard.ts`가 추가될 곳.
+- `src/components/Icon/` (plan 023) — CopyButton의 기본 아이콘 슬롯에 `<Icon name="copy" />` 사용.
+- `src/components/index.ts` — CopyButton 추가.
+- `src/index.ts` — useCopyToClipboard 훅도 export.
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+// 1. 가장 단순한 사용 — CopyButton에 텍스트만 전달
+<CopyButton value="Hello, world!" />
+// → 클릭 시 클립보드 복사, 1.5초간 "Copied!" 표시 후 원상태
+
+// 2. 텍스트 동적 결정
+<CopyButton value={() => generateLink()} />
+
+// 3. 다양한 사이즈 / variant
+<CopyButton value={text} size="sm" variant="ghost" />
+<CopyButton value={text} size="md" variant="primary" />
+
+// 4. 라벨 / 아이콘 커스터마이징
+<CopyButton value={text} idleLabel="복사" copiedLabel="복사됨!" />
+<CopyButton value={text}>
+  {({ copied }) => (copied ? "✓" : <Icon name="copy" />)}
+</CopyButton>
+
+// 5. 콜백
+<CopyButton value={text} onCopy={() => analytics.track("copy")} onError={(err) => ...} />
+
+// 6. 훅 단독 사용 (자체 UI 만들기)
+function MyCustomCopy() {
+  const { copied, copy, reset, error } = useCopyToClipboard({ resetMs: 2000 });
+  return (
+    <button onClick={() => copy("hello")}>
+      {copied ? "✓ Copied" : "Copy"}
+    </button>
+  );
+}
+
+// 7. 동기적이지 않을 때 (서버에서 받아온 값 등)
+const { copy } = useCopyToClipboard();
+const handleClick = async () => {
+  const text = await fetchSecret();
+  await copy(text);
+};
+```
+
+핵심 설계 원칙:
+- **2-layer**: `useCopyToClipboard` 훅 (로직) + `CopyButton` 컴포넌트 (UI). 사용자는 둘 중 원하는 것 사용.
+- **idle/copied 상태 + 자동 리셋**: 기본 1500ms. 사용자가 `resetMs`로 조정 가능.
+- **권한·secure context 실패 처리**: `navigator.clipboard` 미지원/거부 시 `error` 상태 노출. fallback으로 `document.execCommand("copy")` 시도.
+- **headless / 합성 가능**: `CopyButton`은 children render prop으로 완전 커스터마이징 가능.
+- **마이그레이션**: HexView·CodeView가 자체 `copyState` 제거하고 `useCopyToClipboard` 사용. 동작·시각 100% 동일.
+- **a11y**: copied 상태 변화 시 `aria-live` 알림. 버튼 자체는 표준 button.
+- **theme**: light/dark + variant(`ghost`, `primary`, `subtle`).
+- **Icon 의존**: 기본 아이콘은 `<Icon name="copy" />` (plan 023이 선행되어야 깔끔).
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+
+#### `useCopyToClipboard` 훅
+1. `copy(text: string): Promise<boolean>` — 복사 시도, 성공 여부 반환.
+2. 상태: `copied: boolean`, `error: Error | null`.
+3. 자동 리셋: `resetMs` 옵션 (기본 1500). 0 이면 자동 리셋 없음 (수동 `reset()`).
+4. `reset(): void` — 수동 idle 복귀.
+5. `navigator.clipboard.writeText` 우선, 실패 시 `document.execCommand("copy")` 폴백.
+6. cleanup — 컴포넌트 unmount 시 진행 중 timeout 취소.
+7. SSR-safe — Node 환경에서 import 가능, `copy()` 호출 시만 navigator 접근.
+8. TypeScript strict — 모든 옵션·반환 타입 명시.
+
+#### `CopyButton` 컴포넌트
+1. `value: string | (() => string)` — 복사할 텍스트. 함수형은 클릭 시점 호출.
+2. `idleLabel?: string` — 기본 "Copy".
+3. `copiedLabel?: string` — 기본 "Copied!".
+4. `size?: "sm" | "md" | "lg"` — 기본 "md".
+5. `variant?: "primary" | "ghost" | "subtle"` — 기본 "ghost".
+6. `theme?: "light" | "dark"` — 기본 "light".
+7. `showIcon?: boolean` — 기본 true. `<Icon name="copy" />` 또는 `<Icon name="check" />` 표시.
+8. `iconPlacement?: "left" | "right"` — 기본 "left".
+9. `onCopy?: (text: string) => void`, `onError?: (error: Error) => void` 콜백.
+10. `resetMs?: number` — 훅에 전달 (기본 1500).
+11. `disabled?: boolean`.
+12. children render prop — `({ copied, error, copy }) => ReactNode` 형태로 완전 커스텀 UI 가능.
+13. 표준 `ButtonHTMLAttributes` props pass-through (`aria-label`, `data-*` 등).
+14. `aria-live="polite"` 알림 영역 (visually-hidden) — copied 상태 알림.
+15. **마이그레이션 — HexView**: `doCopy` 로직을 `useCopyToClipboard`로 교체. 외부 UI(포맷 토글)는 유지.
+16. **마이그레이션 — CodeView**: `copyState` state + `handleCopyAll` 로직을 훅으로 교체. 외부 우상단 버튼 UI는 유지 (`<CopyButton>` 직접 교체는 v1.1 검토).
+
+### Non-goals (v1 제외)
+- **rich content 복사** (HTML/이미지/파일) — 텍스트만. clipboard API의 다중 형식은 v1.1.
+- **클립보드 읽기** (`navigator.clipboard.readText`) — 본 작업은 쓰기만.
+- **모바일 share API 통합** (`navigator.share`) — 별도 컴포넌트 후보.
+- **다중 텍스트 자동 포맷** (HexView처럼 hex/ascii/c-array 같은 변환) — `value`에 사용자가 미리 포맷한 문자열 전달.
+- **드래그 앤 드롭으로 복사** — 별도 패턴.
+- **자동 모달/토스트** — copied 피드백은 버튼 자체에. 외부 토스트는 사용자가 `onCopy`에 wiring.
+- **secure context 자동 redirect** — fallback만. https 미충족 시 사용자 책임.
+
+---
+
+## 2. 공개 API
+
+### 2.1 useCopyToClipboard 타입 — `src/components/_shared/useCopyToClipboard.ts`
+
+```ts
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface UseCopyToClipboardOptions {
+  /**
+   * copied → idle 자동 복귀 시간 (ms).
+   * 기본 1500. 0이면 자동 리셋 없음 (수동 reset() 호출 필요).
+   */
+  resetMs?: number;
+}
+
+export interface UseCopyToClipboardReturn {
+  /** 현재 copied 상태. 복사 직후 true, resetMs 후 자동 false. */
+  copied: boolean;
+
+  /** 마지막 복사 시도에서 발생한 에러. 없으면 null. */
+  error: Error | null;
+
+  /**
+   * 복사 시도.
+   * @returns Promise<boolean> — 성공 여부.
+   */
+  copy: (text: string) => Promise<boolean>;
+
+  /** 수동 idle 복귀. error도 함께 초기화. */
+  reset: () => void;
+}
+
+export function useCopyToClipboard(
+  options: UseCopyToClipboardOptions = {},
+): UseCopyToClipboardReturn {
+  const { resetMs = 1500 } = options;
+
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // unmount 시 timer 정리
+  useEffect(() => {
+    return () => clearTimer();
+  }, [clearTimer]);
+
+  const reset = useCallback(() => {
+    clearTimer();
+    setCopied(false);
+    setError(null);
+  }, [clearTimer]);
+
+  const copy = useCallback(
+    async (text: string): Promise<boolean> => {
+      clearTimer();
+      try {
+        // 모던 path: navigator.clipboard
+        if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(text);
+          setCopied(true);
+          setError(null);
+          if (resetMs > 0) {
+            timerRef.current = window.setTimeout(() => {
+              setCopied(false);
+              timerRef.current = null;
+            }, resetMs);
+          }
+          return true;
+        }
+
+        // Fallback: execCommand
+        const fallbackOk = legacyCopy(text);
+        if (fallbackOk) {
+          setCopied(true);
+          setError(null);
+          if (resetMs > 0) {
+            timerRef.current = window.setTimeout(() => {
+              setCopied(false);
+              timerRef.current = null;
+            }, resetMs);
+          }
+          return true;
+        }
+
+        throw new Error("Clipboard API unavailable");
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        setError(err);
+        setCopied(false);
+        return false;
+      }
+    },
+    [clearTimer, resetMs],
+  );
+
+  return { copied, error, copy, reset };
+}
+
+/**
+ * Legacy fallback — execCommand("copy") via temporary textarea.
+ * Insecure context (HTTP, file://)에서 navigator.clipboard 미지원 시 사용.
+ */
+function legacyCopy(text: string): boolean {
+  if (typeof document === "undefined") return false;
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    // 화면에서 안 보이게 + 포커스 영향 최소화
+    textarea.style.position = "fixed";
+    textarea.style.top = "-1000px";
+    textarea.style.left = "-1000px";
+    textarea.style.opacity = "0";
+    textarea.setAttribute("readonly", "");
+    document.body.appendChild(textarea);
+
+    // 현재 selection 보존
+    const prevSelection = document.getSelection();
+    const prevRange = prevSelection && prevSelection.rangeCount > 0 ? prevSelection.getRangeAt(0) : null;
+
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    const ok = document.execCommand("copy");
+
+    document.body.removeChild(textarea);
+
+    // selection 복원
+    if (prevRange && prevSelection) {
+      prevSelection.removeAllRanges();
+      prevSelection.addRange(prevRange);
+    }
+
+    return ok;
+  } catch {
+    return false;
+  }
+}
+```
+
+### 2.2 CopyButton 타입 — `src/components/CopyButton/CopyButton.types.ts`
+
+```ts
+import type { ButtonHTMLAttributes, CSSProperties, ReactNode } from "react";
+
+export type CopyButtonSize = "sm" | "md" | "lg";
+export type CopyButtonVariant = "primary" | "ghost" | "subtle";
+export type CopyButtonTheme = "light" | "dark";
+
+export interface CopyButtonRenderArgs {
+  copied: boolean;
+  error: Error | null;
+  copy: () => Promise<boolean>;
+}
+
+export interface CopyButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "value" | "children"> {
+  /** 복사할 텍스트. 함수형은 클릭 시점에 호출되어 최신 값 보장. */
+  value: string | (() => string | Promise<string>);
+
+  /** idle 라벨. 기본 "Copy". */
+  idleLabel?: string;
+
+  /** copied 라벨. 기본 "Copied!". */
+  copiedLabel?: string;
+
+  /** error 라벨. 기본 "Failed". */
+  errorLabel?: string;
+
+  /** 사이즈. 기본 "md". */
+  size?: CopyButtonSize;
+
+  /** variant. 기본 "ghost". */
+  variant?: CopyButtonVariant;
+
+  /** 테마. 기본 "light". */
+  theme?: CopyButtonTheme;
+
+  /** 아이콘 표시 여부. 기본 true. */
+  showIcon?: boolean;
+
+  /** 아이콘 위치. 기본 "left". */
+  iconPlacement?: "left" | "right";
+
+  /** copied → idle 자동 복귀 시간 (ms). 기본 1500. */
+  resetMs?: number;
+
+  /** 복사 성공 콜백. */
+  onCopy?: (text: string) => void;
+
+  /** 복사 실패 콜백. */
+  onError?: (error: Error) => void;
+
+  /**
+   * children render prop — 완전 커스텀 UI.
+   * 지정 시 idleLabel/copiedLabel/showIcon/iconPlacement 모두 무시.
+   */
+  children?: ReactNode | ((args: CopyButtonRenderArgs) => ReactNode);
+
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.3 CopyButton 컴포넌트 — `src/components/CopyButton/CopyButton.tsx`
+
+```tsx
+import { useCallback, type CSSProperties } from "react";
+import { useCopyToClipboard } from "../_shared/useCopyToClipboard";
+import { Icon } from "../Icon";
+import type { CopyButtonProps } from "./CopyButton.types";
+import { copyButtonStyles } from "./CopyButton.styles";
+
+export function CopyButton(props: CopyButtonProps) {
+  const {
+    value,
+    idleLabel = "Copy",
+    copiedLabel = "Copied!",
+    errorLabel = "Failed",
+    size = "md",
+    variant = "ghost",
+    theme = "light",
+    showIcon = true,
+    iconPlacement = "left",
+    resetMs = 1500,
+    onCopy,
+    onError,
+    children,
+    className,
+    style,
+    disabled,
+    ...rest
+  } = props;
+
+  const { copied, error, copy } = useCopyToClipboard({ resetMs });
+
+  const handleClick = useCallback(async () => {
+    const text = typeof value === "function" ? await value() : value;
+    const ok = await copy(text);
+    if (ok) onCopy?.(text);
+    else if (error) onError?.(error);
+  }, [value, copy, onCopy, onError, error]);
+
+  // 스타일 조회
+  const styles = copyButtonStyles[theme][variant][size];
+
+  // children render prop 우선
+  if (typeof children === "function") {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled}
+        className={className}
+        style={{ ...styles.base, ...style }}
+        {...rest}
+      >
+        {children({ copied, error, copy: () => handleClick().then(() => true).catch(() => false) })}
+      </button>
+    );
+  }
+
+  // children이 ReactNode (string 등)이면 그대로
+  const customContent = children !== undefined && typeof children !== "function";
+
+  // 라벨 / 아이콘 결정
+  const currentLabel = error ? errorLabel : copied ? copiedLabel : idleLabel;
+  const iconName = error ? "error" : copied ? "check" : "copy";
+
+  const iconNode = showIcon ? (
+    <Icon name={iconName} size={size === "sm" ? "sm" : "md"} aria-hidden="true" />
+  ) : null;
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled}
+      aria-live="polite"
+      data-state={error ? "error" : copied ? "copied" : "idle"}
+      className={className}
+      style={{ ...styles.base, ...style }}
+      {...rest}
+    >
+      {customContent ? (
+        children
+      ) : (
+        <>
+          {iconPlacement === "left" && iconNode}
+          <span>{currentLabel}</span>
+          {iconPlacement === "right" && iconNode}
+        </>
+      )}
+    </button>
+  );
+}
+
+CopyButton.displayName = "CopyButton";
+```
+
+### 2.4 스타일 — `src/components/CopyButton/CopyButton.styles.ts`
+
+```ts
+import type { CSSProperties } from "react";
+import type { CopyButtonSize, CopyButtonTheme, CopyButtonVariant } from "./CopyButton.types";
+
+interface ButtonStyleSet {
+  base: CSSProperties;
+}
+
+const sizeMap: Record<CopyButtonSize, { padding: string; fontSize: number; gap: number }> = {
+  sm: { padding: "4px 8px", fontSize: 12, gap: 4 },
+  md: { padding: "6px 12px", fontSize: 13, gap: 6 },
+  lg: { padding: "8px 16px", fontSize: 14, gap: 8 },
+};
+
+function makeBase(size: CopyButtonSize, variant: CopyButtonVariant, theme: CopyButtonTheme): CSSProperties {
+  const s = sizeMap[size];
+  const palette = palettes[theme][variant];
+
+  return {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: s.gap,
+    padding: s.padding,
+    fontSize: s.fontSize,
+    fontFamily: "inherit",
+    fontWeight: 500,
+    lineHeight: 1,
+    borderRadius: 6,
+    border: `1px solid ${palette.border}`,
+    background: palette.bg,
+    color: palette.fg,
+    cursor: "pointer",
+    transition: "background 120ms ease, border-color 120ms ease, color 120ms ease",
+    userSelect: "none",
+  };
+}
+
+const palettes: Record<CopyButtonTheme, Record<CopyButtonVariant, { bg: string; fg: string; border: string }>> = {
+  light: {
+    primary: { bg: "#2563eb", fg: "#ffffff", border: "#2563eb" },
+    ghost: { bg: "transparent", fg: "#374151", border: "transparent" },
+    subtle: { bg: "rgba(0,0,0,0.05)", fg: "#374151", border: "rgba(0,0,0,0.08)" },
+  },
+  dark: {
+    primary: { bg: "#60a5fa", fg: "#0f172a", border: "#60a5fa" },
+    ghost: { bg: "transparent", fg: "#e5e7eb", border: "transparent" },
+    subtle: { bg: "rgba(255,255,255,0.08)", fg: "#e5e7eb", border: "rgba(255,255,255,0.12)" },
+  },
+};
+
+export const copyButtonStyles: Record<
+  CopyButtonTheme,
+  Record<CopyButtonVariant, Record<CopyButtonSize, ButtonStyleSet>>
+> = {
+  light: {
+    primary: { sm: { base: makeBase("sm", "primary", "light") }, md: { base: makeBase("md", "primary", "light") }, lg: { base: makeBase("lg", "primary", "light") } },
+    ghost: { sm: { base: makeBase("sm", "ghost", "light") }, md: { base: makeBase("md", "ghost", "light") }, lg: { base: makeBase("lg", "ghost", "light") } },
+    subtle: { sm: { base: makeBase("sm", "subtle", "light") }, md: { base: makeBase("md", "subtle", "light") }, lg: { base: makeBase("lg", "subtle", "light") } },
+  },
+  dark: {
+    primary: { sm: { base: makeBase("sm", "primary", "dark") }, md: { base: makeBase("md", "primary", "dark") }, lg: { base: makeBase("lg", "primary", "dark") } },
+    ghost: { sm: { base: makeBase("sm", "ghost", "dark") }, md: { base: makeBase("md", "ghost", "dark") }, lg: { base: makeBase("lg", "ghost", "dark") } },
+    subtle: { sm: { base: makeBase("sm", "subtle", "dark") }, md: { base: makeBase("md", "subtle", "dark") }, lg: { base: makeBase("lg", "subtle", "dark") } },
+  },
+};
+```
+
+### 2.5 배럴 — `src/components/CopyButton/index.ts`
+
+```ts
+export { CopyButton } from "./CopyButton";
+export type {
+  CopyButtonProps,
+  CopyButtonSize,
+  CopyButtonVariant,
+  CopyButtonTheme,
+  CopyButtonRenderArgs,
+} from "./CopyButton.types";
+```
+
+### 2.6 components 배럴 — `src/components/index.ts`
+
+```ts
+export * from "./CopyButton";
+```
+
+### 2.7 useCopyToClipboard public export — `src/components/_shared/index.ts`
+
+`_shared` 디렉터리는 현재 컴포넌트 외부에서 접근 불가능 (의도). 하지만 `useCopyToClipboard`는 사용자가 자체 UI 만들 때 유용하므로 public으로 export:
+
+```ts
+// src/components/_shared/index.ts (신설)
+export { useCopyToClipboard } from "./useCopyToClipboard";
+export type {
+  UseCopyToClipboardOptions,
+  UseCopyToClipboardReturn,
+} from "./useCopyToClipboard";
+
+// src/components/index.ts에 추가
+export * from "./_shared";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/
+├── _shared/
+│   ├── useCopyToClipboard.ts       ← 신설 (훅)
+│   └── index.ts                     ← 신설 (public 부분 export)
+└── CopyButton/
+    ├── CopyButton.tsx
+    ├── CopyButton.types.ts
+    ├── CopyButton.styles.ts
+    └── index.ts
+```
+
+---
+
+## 4. 동작 명세
+
+### 4.1 copy 함수 흐름
+
+```
+copy(text)
+  ├─ navigator.clipboard.writeText(text) 시도
+  │   ├─ 성공 → setCopied(true), setError(null), timer 시작
+  │   └─ 실패 → catch
+  │       └─ legacyCopy(text) 시도
+  │           ├─ 성공 → setCopied(true), setError(null), timer 시작
+  │           └─ 실패 → throw
+  └─ 모든 시도 실패 → setError(err), setCopied(false)
+```
+
+### 4.2 timer 동작
+
+- copy 성공 시 `setTimeout(setCopied(false), resetMs)`.
+- 또 다른 copy 호출 시 기존 timer 취소 + 새 timer 시작.
+- `reset()` 호출 시 timer 취소.
+- unmount 시 timer 취소.
+
+### 4.3 resetMs=0 동작
+
+- copy 성공 후 `copied=true` 영구 (수동 `reset()` 호출까지).
+- 매우 긴 피드백 원할 때 사용.
+
+### 4.4 동시 다발 copy
+
+```ts
+copy("a"); // copied=true, timer 시작 (1500ms)
+copy("b"); // 첫 timer 취소, 새 timer 시작 (1500ms)
+// → 첫 호출의 "a" 클립보드 덮어쓰기 (b가 마지막)
+```
+
+### 4.5 secure context 미충족
+
+`navigator.clipboard`는 HTTPS / localhost / file://에서만 지원. HTTP는 unsafe context.
+- `navigator.clipboard?.writeText` 체크에서 `?.`로 안전 분기.
+- 미지원이면 즉시 `legacyCopy` 시도.
+- legacyCopy도 실패 (예: iframe + sandbox)면 error throw.
+
+### 4.6 권한 거부
+
+- `navigator.permissions.query({name: "clipboard-write"})` 사전 체크는 v1 미지원.
+- copy 호출 시 권한 prompt → 거부 시 `writeText`가 reject → catch에서 fallback → fallback도 실패 시 error.
+
+### 4.7 CopyButton 클릭 흐름
+
+```
+사용자 클릭
+  → handleClick
+  → value가 함수면 호출 (await)
+  → copy(text)
+  → 성공: onCopy(text), copied=true 표시
+  → 실패: onError(error), error 표시
+  → resetMs 후 자동 idle 복귀
+```
+
+### 4.8 children render prop
+
+```tsx
+<CopyButton value={text}>
+  {({ copied, error, copy }) => (
+    <span>{copied ? "✓" : error ? "✗" : "📋"}</span>
+  )}
+</CopyButton>
+```
+
+children이 함수면 render prop 모드 — idleLabel/copiedLabel/showIcon 모두 무시.
+
+---
+
+## 5. 마이그레이션 — HexView
+
+### 5.1 변경 전 (`src/components/HexView/HexView.tsx`)
+
+```tsx
+const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+
+const doCopy = useCallback(
+  (fmt: HexViewCopyFormat) => {
+    const slice = selection ? bytes.slice(selection.start, selection.end) : bytes;
+    if (slice.length === 0) return;
+    const text = formatBytes(slice, fmt);
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopyState("copied");
+      setTimeout(() => setCopyState("idle"), 1500);
+    });
+  },
+  [bytes, selection],
+);
+```
+
+### 5.2 변경 후
+
+```tsx
+import { useCopyToClipboard } from "../_shared/useCopyToClipboard";
+
+// state 제거
+// const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+
+const { copied, copy } = useCopyToClipboard({ resetMs: 1500 });
+
+const doCopy = useCallback(
+  (fmt: HexViewCopyFormat) => {
+    const slice = selection ? bytes.slice(selection.start, selection.end) : bytes;
+    if (slice.length === 0) return;
+    const text = formatBytes(slice, fmt);
+    void copy(text);
+  },
+  [bytes, selection, copy],
+);
+
+// 기존 copyState 참조처 모두 copied로 교체
+// 예: copyState === "copied" → copied
+```
+
+### 5.3 변경 항목 정리
+
+**삭제:**
+- `useState<"idle" | "copied">("idle")`.
+- `setTimeout(...)` 인라인 호출.
+- `setCopyState("copied")`, `setCopyState("idle")` 호출들.
+
+**유지:**
+- `formatBytes` 헬퍼 (포맷 변환은 사용자 코드).
+- `onCopyEvent` 핸들러 (native clipboard event는 별개 — `e.clipboardData.setData`로 처리, 훅 무관).
+- 포맷 토글 UI (hex/ascii/c-array 버튼).
+- Cmd+C 키 핸들러.
+
+**수정:**
+- `copyState === "copied"` 조건 → `copied`.
+- 표시 라벨 (예: 버튼 텍스트 "복사" ↔ "✓ 복사됨")은 그대로.
+
+### 5.4 onCopyEvent (native clipboard event) 별개 처리
+
+`onCopyEvent`는 사용자가 텍스트를 선택하고 Cmd+C를 누를 때 발생하는 `paste`/`copy` event 핸들러. `useCopyToClipboard`와 무관 — 이 경우 clipboard API가 아니라 `e.clipboardData.setData`로 직접 데이터 주입. 그대로 유지.
+
+```tsx
+const onCopyEvent = useCallback(
+  (e: ReactClipboardEvent<HTMLDivElement>) => {
+    if (!selection) return;
+    e.preventDefault();
+    const slice = bytes.slice(selection.start, selection.end);
+    e.clipboardData.setData("text/plain", formatBytes(slice, copyFmt));
+    // 추가: copied 상태 알림
+    // 옵션: copy 훅의 상태도 갱신할지 결정 (UX 일관성)
+    // → copy("") 빈 문자열 호출은 의미 없음. 별도 상태 동기화 미필요.
+  },
+  [bytes, copyFmt, selection],
+);
+```
+
+**주의**: `onCopyEvent`로 복사 시 `copyState`는 idle 그대로 (button을 클릭한 게 아니므로). 사용자 시각으로는 OS의 자체 복사 피드백(Mac의 경우 visual cue)에 의존. 원하면 별도 상태 알림 추가 가능 — v1은 기존 동작 유지.
+
+### 5.5 회귀 검증
+
+- [ ] HexView 데모 페이지에서 텍스트 선택 + 우상단 "복사" 버튼 클릭 → 클립보드에 hex/ascii/c-array 형식대로 들어가는지 확인.
+- [ ] "복사" 버튼 클릭 후 "✓ 복사됨" 1.5초 후 다시 "복사"로 복귀.
+- [ ] 빈 selection (선택 없음) + 클릭 → 전체 데이터 복사.
+- [ ] Cmd+C (선택 후) → 클립보드 들어감 (onCopyEvent 경로).
+- [ ] 포맷 토글 (hex/ascii/c-array) 변경 → 다음 복사 시 새 포맷 적용.
+
+---
+
+## 6. 마이그레이션 — CodeView
+
+### 6.1 현재 CodeView copy 구현
+
+```tsx
+const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+
+// ... 어딘가의 handleCopyAll
+const handleCopyAll = () => {
+  navigator.clipboard.writeText(displayCode).then(() => {
+    setCopyState("copied");
+    setTimeout(() => setCopyState("idle"), 1500);
+  });
+};
+
+// 렌더 (line 426-450)
+const copyBtn = showCopyButton ? (
+  <button onClick={handleCopyAll} ...>
+    {copyState === "copied" ? "✓ 복사됨" : "복사"}
+  </button>
+) : null;
+```
+
+### 6.2 변경 후
+
+```tsx
+import { useCopyToClipboard } from "../_shared/useCopyToClipboard";
+
+const { copied, copy } = useCopyToClipboard({ resetMs: 1500 });
+
+const handleCopyAll = useCallback(() => {
+  void copy(displayCode);
+}, [copy, displayCode]);
+
+const copyBtn = showCopyButton ? (
+  <button onClick={handleCopyAll} ...>
+    {copied ? "✓ 복사됨" : "복사"}
+  </button>
+) : null;
+```
+
+**옵션 — 더 적극적 마이그레이션 (v1.1 검토)**: 자체 button → `<CopyButton variant="subtle" size="sm" value={displayCode} idleLabel="복사" copiedLabel="✓ 복사됨" />` 직접 교체. 다만 CodeView가 button 위치(absolute top right)를 직접 제어하므로 v1은 button 자체는 유지하고 내부 로직만 훅 교체. 시각·DOM 구조 변경 0.
+
+### 6.3 회귀 검증
+
+- [ ] CodeViewPage에서 "복사" 버튼 클릭 → 코드 클립보드 복사.
+- [ ] "✓ 복사됨" 1.5초 후 "복사"로 복귀.
+- [ ] dark 테마에서도 정상.
+
+---
+
+## 7. 데모 페이지 — `demo/src/pages/CopyButtonPage.tsx`
+
+```tsx
+export function CopyButtonPage() {
+  const longText = "function hello() {\n  console.log('world');\n}";
+
+  return (
+    <div>
+      <h1>CopyButton</h1>
+
+      <Card.Root>
+        <Card.Header>Basic</Card.Header>
+        <Card.Body>
+          <CopyButton value="Hello, world!" />
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Sizes</Card.Header>
+        <Card.Body style={{ display: "flex", gap: 12, alignItems: "center" }}>
+          <CopyButton value="text" size="sm" />
+          <CopyButton value="text" size="md" />
+          <CopyButton value="text" size="lg" />
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Variants</Card.Header>
+        <Card.Body style={{ display: "flex", gap: 12 }}>
+          <CopyButton value="text" variant="primary" />
+          <CopyButton value="text" variant="ghost" />
+          <CopyButton value="text" variant="subtle" />
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>커스텀 라벨</Card.Header>
+        <Card.Body>
+          <CopyButton value={longText} idleLabel="코드 복사" copiedLabel="✓ 복사됨" />
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>아이콘 위치 / 숨김</Card.Header>
+        <Card.Body style={{ display: "flex", gap: 12 }}>
+          <CopyButton value="text" iconPlacement="left" />
+          <CopyButton value="text" iconPlacement="right" />
+          <CopyButton value="text" showIcon={false} />
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Render prop (완전 커스텀)</Card.Header>
+        <Card.Body>
+          <CopyButton value="text">
+            {({ copied }) => (
+              <span style={{ fontSize: 24 }}>{copied ? "🎉" : "📋"}</span>
+            )}
+          </CopyButton>
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>동적 value (함수형)</Card.Header>
+        <Card.Body>
+          <CopyButton value={() => `Time: ${new Date().toISOString()}`} idleLabel="타임스탬프 복사" />
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>onCopy / onError 콜백</Card.Header>
+        <Card.Body>
+          <CopyButton
+            value="logged"
+            onCopy={(t) => console.log("Copied:", t)}
+            onError={(e) => console.error("Error:", e)}
+          />
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>resetMs 변경</Card.Header>
+        <Card.Body style={{ display: "flex", gap: 12 }}>
+          <CopyButton value="t" resetMs={500} idleLabel="500ms" />
+          <CopyButton value="t" resetMs={3000} idleLabel="3000ms" />
+          <CopyButton value="t" resetMs={0} idleLabel="수동 reset 필요" />
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Dark theme</Card.Header>
+        <Card.Body style={{ background: "#1f2937", padding: 16 }}>
+          <CopyButton value="text" theme="dark" variant="primary" />
+          <CopyButton value="text" theme="dark" variant="ghost" />
+          <CopyButton value="text" theme="dark" variant="subtle" />
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Disabled</Card.Header>
+        <Card.Body>
+          <CopyButton value="text" disabled />
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>훅 단독 사용 예시</Card.Header>
+        <Card.Body>
+          <HookOnlyExample />
+        </Card.Body>
+      </Card.Root>
+    </div>
+  );
+}
+
+function HookOnlyExample() {
+  const { copied, copy, error, reset } = useCopyToClipboard({ resetMs: 2000 });
+
+  return (
+    <div>
+      <button onClick={() => copy("custom UI value")}>
+        {copied ? "Copied via hook!" : "Copy with hook"}
+      </button>
+      {error && <span style={{ color: "red", marginLeft: 8 }}>Error: {error.message}</span>}
+      <button onClick={reset} style={{ marginLeft: 8 }}>Reset</button>
+    </div>
+  );
+}
+```
+
+데모 라우팅 등록 — `demo/src/App.tsx`의 NAV에 `CopyButton` 항목 추가.
+
+---
+
+## 8. 접근성 (a11y)
+
+### 8.1 button 시맨틱
+- `<button type="button">` — 표준. Enter/Space 모두 click 트리거.
+- `disabled` 속성 자동 처리.
+
+### 8.2 copied 상태 알림
+- `aria-live="polite"` 영역으로 "Copied!" 변화 알림.
+- 단, 매번 클릭마다 알림 → 노이즈일 수 있음. 권장: visually-hidden span을 별도로 두고 거기에만 aria-live 적용, 시각 라벨은 일반 span. v1은 button 자체에 `aria-live="polite"`로 단순화.
+
+### 8.3 키보드 작동
+- Tab: 포커스 이동.
+- Enter / Space: 클릭 트리거.
+
+### 8.4 데이터 속성
+- `data-state="idle" | "copied" | "error"` — CSS 셀렉터·테스트용.
+
+### 8.5 에러 시
+- 시각: `errorLabel` ("Failed") 표시.
+- 알림: `aria-live="polite"`로 자동 알림.
+- 권장: 사용자가 `onError`로 추가 알림(Toast 등) 트리거.
+
+---
+
+## 9. 설계 결정 사항 (rationale)
+
+### 9.1 훅 + 컴포넌트 2-layer
+**이유**: 사용자가 자체 UI를 만들고 싶을 때(예: tooltip 안에 작은 copy 아이콘)도 같은 로직 재사용. 또한 라이브러리 내부(HexView, CodeView)도 자체 UI를 유지한 채 로직만 공유. layer 분리가 마이그레이션 비용을 가장 낮춤.
+
+### 9.2 default resetMs=1500
+**이유**: 기존 HexView·CodeView가 1500ms 사용 — 동일 값으로 시각 회귀 0. UX 측면에서 1.5~2초는 사용자가 "복사됨" 인지하고도 빨리 다음 액션 가능한 균형점.
+
+### 9.3 navigator.clipboard 우선 + execCommand 폴백
+**이유**: navigator.clipboard는 모던 표준이지만 HTTPS/secure context 필요. file:// 프로토콜로 데모를 여는 경우 등 개발 환경에서 작동 안 함. polyfill로 execCommand 유지.
+
+### 9.4 value를 함수형으로도 받음
+**이유**: 클릭 시점의 최신 값 필요한 케이스 (예: 동적 생성된 링크, 시간 기반 값). 함수형은 await 가능 — 비동기 fetch도 가능.
+
+### 9.5 children render prop
+**이유**: 라벨/아이콘만으로는 표현 못 하는 커스텀 UI (이모지, custom svg, 합성 영상) 지원. shadcn 패턴.
+
+### 9.6 errorLabel 명시적
+**이유**: 권한 거부·secure context 미충족 등 실패가 가능. 무음 실패는 사용자 혼란. 시각 + 콜백 둘 다.
+
+### 9.7 useCopyToClipboard를 _shared에 배치
+**이유**: CopyButton 외에도 HexView·CodeView가 사용. 컴포넌트 디렉터리에 종속되지 않은 utility hook으로 분리. 동시에 _shared/index.ts로 public export하여 사용자도 활용.
+
+### 9.8 마이그레이션 — UI 유지, 로직 교체
+**이유**: HexView와 CodeView의 자체 button UI는 위치·시각·인터랙션이 컴포넌트 맥락에 맞춰져 있음. 이를 `<CopyButton>`로 교체하면 시각 회귀 위험. 로직(상태 + 클립보드 호출)만 훅으로 교체하는 게 가장 안전. v1.1+에서 시각 통일 필요 시 추가 마이그레이션 검토.
+
+---
+
+## 10. Edge cases
+
+### 10.1 빈 문자열 복사
+```ts
+copy("")
+```
+- navigator.clipboard.writeText("")는 정상 작동 (빈 클립보드).
+- copied=true 됨. v1 의도된 동작 (사용자가 명시 호출).
+
+### 10.2 매우 긴 텍스트 (수 MB)
+- navigator.clipboard.writeText는 string 입력 받음. 브라우저 한계까지 가능.
+- 메모리/성능은 사용자 책임.
+
+### 10.3 Promise 미반환 시 (non-async 코드 흐름)
+```tsx
+<CopyButton value={() => fetchSecret()} />
+```
+- value 함수가 Promise 반환하면 await로 처리. 자동 동기/비동기 호환.
+
+### 10.4 disabled 중 copy 호출 시도
+- 외부에서 ref로 button.click() 시 `disabled` 속성이 차단.
+- 훅 단독 사용 시는 disabled 상태 별도 관리 필요 (사용자 책임).
+
+### 10.5 useEffect cleanup 도중 copy
+- unmount 직후 호출은 setState 경고 발생 가능.
+- v1은 timer만 cleanup. setState mid-async는 React 18에서 자동 무시 (mounted ref 추가는 v1.1).
+
+### 10.6 동일 컴포넌트에 CopyButton 다중
+```tsx
+<CopyButton value="A" />
+<CopyButton value="B" />
+```
+- 각자 독립 훅 인스턴스 → 독립 copied 상태. 정상.
+
+### 10.7 SSR
+- import는 안전 (훅은 use 시점에만 navigator 접근).
+- 첫 렌더에서 `copied=false`, `error=null` 으로 일관 시작. hydration 안전.
+
+### 10.8 권한 prompt 중 사용자가 페이지 이탈
+- copy Promise pending 중 unmount → useEffect cleanup으로 timer 정리. setState는 stale (React가 무시).
+
+### 10.9 비-secure context (HTTP)
+- navigator.clipboard 미지원.
+- legacyCopy 시도 → execCommand가 deprecated되었지만 여전히 대부분의 브라우저 지원.
+- 둘 다 실패 시 error.
+
+### 10.10 iframe sandbox
+- `<iframe sandbox="allow-scripts">` (allow-clipboard 없음) → navigator.clipboard.writeText reject + execCommand 실패.
+- error 표시. 사용자에게 "이 환경은 클립보드 접근 불가" 안내 책임.
+
+---
+
+## 11. 구현 단계 (Phase)
+
+### Phase 1: useCopyToClipboard 훅 신설
+1. `src/components/_shared/useCopyToClipboard.ts` 작성.
+2. `src/components/_shared/index.ts` 작성 (public export).
+3. `src/components/index.ts`에 `export * from "./_shared"` 추가.
+4. `npm run typecheck` 통과.
+
+### Phase 2: CopyButton 신설
+1. `src/components/CopyButton/CopyButton.types.ts`
+2. `src/components/CopyButton/CopyButton.styles.ts`
+3. `src/components/CopyButton/CopyButton.tsx`
+4. `src/components/CopyButton/index.ts`
+5. `src/components/index.ts`에 추가.
+6. `npm run typecheck` + `npm run build` 통과.
+
+### Phase 3: 데모 페이지
+1. `demo/src/pages/CopyButtonPage.tsx` 작성 (§7).
+2. NAV 등록.
+3. 모든 섹션 동작 확인:
+   - 클립보드에 실제 들어가는지 (텍스트 에디터에 붙여넣기).
+   - copied 1.5초 후 idle 복귀.
+   - HookOnlyExample 작동.
+   - light/dark 모두.
+
+### Phase 4: HexView 마이그레이션
+1. `useCopyToClipboard` import.
+2. `copyState` state 제거.
+3. `doCopy` 내부의 `navigator.clipboard.writeText` + `setCopyState` + `setTimeout` 삭제, `copy(text)` 한 줄로 교체.
+4. `copyState === "copied"` 참조처를 `copied`로 교체.
+5. HexView 데모 회귀 확인 (§5.5).
+
+### Phase 5: CodeView 마이그레이션
+1. `useCopyToClipboard` import.
+2. `copyState` state 제거.
+3. `handleCopyAll` 내부 교체.
+4. `copyState === "copied"` 참조처 `copied`로 교체.
+5. CodeView 데모 회귀 확인.
+
+### Phase 6: 정리
+- [ ] `docs/candidates.md`에서 7번 항목 제거 + plan 링크.
+- [ ] README.md에 CopyButton 섹션 추가.
+- [ ] PR 디스크립션에 변경 요약.
+
+---
+
+## 12. 향후 확장 (v1.1+)
+
+| 항목 | 설명 |
+|---|---|
+| 다중 형식 클립보드 | text/html, image/png 등 동시 복사 |
+| `navigator.permissions` 사전 체크 | UI에 "권한 필요" 사전 안내 |
+| Tooltip 통합 | 자동 "Copied!" tooltip 띄우기 (Tooltip 컴포넌트 사용) |
+| copy events bubble 통합 | HexView의 `onCopyEvent`도 훅을 통해 상태 sync |
+| readClipboard | `useReadFromClipboard` 훅 |
+| share API | `navigator.share` 통합 |
+| Hex/CodeView UI도 CopyButton로 통일 | 시각 표준화 (현 v1은 로직만) |
+
+---
+
+## 13. 체크리스트 (작업 완료 기준)
+
+- [ ] `src/components/_shared/useCopyToClipboard.ts` 작성, public export
+- [ ] `src/components/CopyButton/` 4개 파일 작성
+- [ ] `npm run typecheck` 통과
+- [ ] `npm run build` 통과
+- [ ] CopyButtonPage 모든 섹션 정상 (light/dark)
+- [ ] 클립보드에 실제 데이터 들어감 (텍스트 에디터 검증)
+- [ ] HexView 마이그레이션 완료 (`copyState` 제거, `doCopy`가 훅 호출)
+- [ ] HexView 데모 회귀 없음 (포맷 토글, Cmd+C, 버튼 클릭 모두)
+- [ ] CodeView 마이그레이션 완료 (`copyState` 제거, `handleCopyAll`이 훅 호출)
+- [ ] CodeView 데모 회귀 없음 (복사 버튼 동작·다크 테마)
+- [ ] secure context 미충족 시 fallback 작동 (file:// 프로토콜로 데모 여는 등 검증)
+- [ ] `docs/candidates.md` 7번 제거 + 링크
+- [ ] README.md 업데이트

--- a/docs/plans/027-tag-component.md
+++ b/docs/plans/027-tag-component.md
@@ -1,0 +1,1023 @@
+# Tag / Chip 컴포넌트 설계문서
+
+## Context
+
+**라벨·필터 칩·상태 표시**용 작은 컴포넌트 `Tag`(또는 alias `Chip`)를 추가한다. 다른 라이브러리에서 `Tag`, `Chip`, `Badge`, `Label`, `Pill` 등으로 다양하게 불리는 어휘 — 본 라이브러리는 **`Tag`를 정식 명칭**으로 채택하되 `Chip`을 alias로 동시 export하여 사용자 친숙성 보장.
+
+본 컴포넌트는 다음 시나리오 모두를 흡수:
+- DataTable의 status 컬럼 ("active", "pending", "blocked")
+- CommandPalette 검색 결과의 카테고리 라벨
+- Form 다중 입력 시 추가된 항목 표시 (이메일 리스트 등)
+- 필터 상태 표시 ("× Author: alice")
+- 일반 카테고리 라벨 (블로그 태그 등)
+
+라이브러리에 현재 비슷한 컴포넌트 없음. `Toast`나 `Button`은 시각·시맨틱 다름.
+
+참고 (prior art):
+- **Material UI `Chip`** — 가장 영향력 있는 표준. `variant: filled | outlined`, `color` 시스템(primary/secondary/success/etc), `size: small | medium`, `onDelete` (제거 가능), avatar/icon 슬롯.
+- **Ant Design `Tag`** — 색상 시스템 풍부 (preset colors: red, blue, green / hex 직접). `closable`, `bordered`, `icon`.
+- **Mantine `Badge`** — gradient·dot indicator·multiple sizes.
+- **Chakra `Tag`** — `Tag.Root`, `Tag.Label`, `Tag.CloseTrigger` compound 패턴.
+- **Radix UI** — Tag/Chip 미제공 (사용자 직접).
+- **shadcn/ui `Badge`** — `variant: default | secondary | destructive | outline`. Tailwind 기반.
+- **GitHub** — issue label 칩 (다양한 색상 + dot indicator).
+- **Apple HIG** — 시스템 status pill (sf rounded, semibold).
+
+본 레포 내부 참조:
+- `src/components/Icon/` (plan 023) — `removable` 모드의 X 아이콘에 사용. `<Icon name="x" size="xs" />`.
+- `src/components/Toast/colors.ts` — severity 토큰 (plan 037에서 _shared/severity.ts로 추출 예정). Tag의 색상 prop과 별개 (Tag는 카테고리 색상, severity는 의미 색상).
+- `src/components/index.ts` — Tag 추가 위치.
+- `tsconfig.json` — strict 옵션 (특히 `exactOptionalPropertyTypes`).
+
+---
+
+## 0. TL;DR (한 페이지 요약)
+
+```tsx
+// 1. 가장 단순한 사용
+<Tag>Beta</Tag>
+<Tag>JavaScript</Tag>
+
+// 2. 색상 (preset color)
+<Tag color="blue">Info</Tag>
+<Tag color="green">Active</Tag>
+<Tag color="red">Error</Tag>
+<Tag color="purple">Custom</Tag>
+
+// 3. 임의 색상 (hex / rgb)
+<Tag color="#ff6b35">Custom</Tag>
+
+// 4. 사이즈
+<Tag size="sm">Small</Tag>
+<Tag size="md">Medium</Tag>
+<Tag size="lg">Large</Tag>
+
+// 5. variant (스타일 종류)
+<Tag variant="solid" color="blue">Solid</Tag>
+<Tag variant="subtle" color="blue">Subtle (default)</Tag>
+<Tag variant="outline" color="blue">Outline</Tag>
+<Tag variant="dot" color="blue">Dot</Tag>      // 좌측 점 + 텍스트
+
+// 6. 제거 가능 (× 버튼)
+<Tag removable onRemove={() => removeTag(id)}>Filter</Tag>
+
+// 7. 클릭 가능 (필터 토글 등)
+<Tag clickable onClick={() => toggleFilter()}>+ Add filter</Tag>
+
+// 8. 아이콘 슬롯
+<Tag icon={<Icon name="check" size="xs" />} color="green">Verified</Tag>
+
+// 9. 그룹 — 여러 칩 wrap (단순 flex/gap)
+<Tag.Group>
+  <Tag color="blue">react</Tag>
+  <Tag color="purple">typescript</Tag>
+  <Tag color="green">ui</Tag>
+</Tag.Group>
+
+// 10. Chip alias (동일 컴포넌트, 다른 이름)
+<Chip>Same as Tag</Chip>
+```
+
+핵심 설계 원칙:
+- **단순함 우선** — 단일 컴포넌트 + 옵션. compound 분리는 `Tag.Group`만 (다중 칩 레이아웃 도우미).
+- **색상**: preset 색상 토큰 9종 (blue/green/red/yellow/purple/pink/gray/teal/orange) + 임의 hex 모두.
+- **variant 4종**: `solid`(진한 배경), `subtle`(연한 배경, 기본), `outline`(테두리만), `dot`(좌측 점 + 텍스트).
+- **사이즈 3종**: `sm` / `md` (기본) / `lg`.
+- **제거 가능**: `removable` + `onRemove` — 우측 X 버튼.
+- **클릭 가능**: `clickable` 시 `cursor: pointer` + 호버 효과 + `role="button"`.
+- **아이콘 슬롯**: 좌측 임의 React 노드 (보통 `<Icon />`).
+- **theme**: light/dark — 색상 팔레트 자동 분기.
+- **a11y**: removable 시 X 버튼은 별도 button (aria-label="Remove {label}").
+- **headless 정신**: className/style로 모든 시각 override 가능.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. `<Tag>` 단일 컴포넌트 + `Tag.Group` (간단 wrap container).
+2. `<Chip>` alias export — 이름만 다르고 완전 동일 컴포넌트.
+3. **9가지 preset color**: `blue` / `green` / `red` / `yellow` / `purple` / `pink` / `gray` / `teal` / `orange`. 기본 `gray`.
+4. **임의 hex/rgb 색상**: `color="#ff6b35"` 또는 `color="rgb(255,107,53)"` — 자동 light/dark 변형 계산.
+5. **4가지 variant**: `solid` / `subtle`(기본) / `outline` / `dot`.
+6. **3가지 size**: `sm` (height 18) / `md` (height 22) / `lg` (height 26).
+7. **테마**: `light` / `dark` 명시 prop + 색상 자동 매핑.
+8. **`removable` prop + `onRemove` callback**: 우측 X 버튼 표시. X 클릭 시 `onRemove()` 호출 + 본 Tag 클릭 이벤트는 차단.
+9. **`clickable` prop + `onClick`**: 호버 효과, role="button", tabIndex=0, Enter/Space 키 작동.
+10. **`disabled` prop**: cursor not-allowed, opacity 0.5, 클릭/제거 차단.
+11. **`icon` prop**: 좌측 아이콘 슬롯 (ReactNode, 보통 Icon 컴포넌트).
+12. **TypeScript strict**: 모든 옵션 타입 명시.
+13. 배럴 — `export { Tag, Chip } from "./Tag"` + 타입.
+
+### Non-goals (v1 제외)
+- **animated dismiss** — onRemove 시 Tag가 자체 페이드아웃 애니메이션. v1은 즉시 제거 (사용자 책임). v1.1+.
+- **Avatar 슬롯 baked-in** — Material UI Chip의 `<Avatar>` 슬롯. v1은 일반 `icon` 슬롯으로 흡수 (사용자가 직접 Avatar 넣음).
+- **Tag input 통합** — `TagInput` / `ChipInput` (다중 값 입력)은 별도 후보 컴포넌트.
+- **drag & drop reorder** — Sortable 컴포넌트가 별도 후보.
+- **gradient color** — Mantine처럼 그라디언트 배경. v1은 단색.
+- **선택 상태 (selected)** — toggle 칩. v1은 clickable로 충분.
+- **counter badge** — "+3 more" — v1은 사용자가 직접 합성 (`<Tag>+3 more</Tag>`).
+- **status dot 단독** — Status indicator는 별도 후보 (`Status` / `Pulse`).
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Tag/Tag.types.ts`
+
+```ts
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+
+export type TagTheme = "light" | "dark";
+export type TagSize = "sm" | "md" | "lg";
+export type TagVariant = "solid" | "subtle" | "outline" | "dot";
+
+/** Preset color 이름. 9종. */
+export type TagPresetColor =
+  | "blue"
+  | "green"
+  | "red"
+  | "yellow"
+  | "purple"
+  | "pink"
+  | "gray"
+  | "teal"
+  | "orange";
+
+/**
+ * Tag 색상.
+ * - Preset 이름 (TagPresetColor) → 내부 팔레트 매핑.
+ * - 임의 string (hex `"#ff0000"` / rgb `"rgb(255,0,0)"`) → 자동 light/dark 변형 계산.
+ */
+export type TagColor = TagPresetColor | (string & {});
+
+export interface TagProps extends Omit<HTMLAttributes<HTMLSpanElement>, "color"> {
+  /** 색상. 기본 "gray". */
+  color?: TagColor;
+
+  /** 사이즈. 기본 "md". */
+  size?: TagSize;
+
+  /** variant. 기본 "subtle". */
+  variant?: TagVariant;
+
+  /** 테마. 기본 "light". */
+  theme?: TagTheme;
+
+  /** 좌측 아이콘 슬롯. */
+  icon?: ReactNode;
+
+  /** X 버튼 표시 + 제거 가능. */
+  removable?: boolean;
+
+  /** removable일 때 X 클릭 시 호출. */
+  onRemove?: () => void;
+
+  /** 클릭 가능. cursor pointer + role=button + 키보드 활성. */
+  clickable?: boolean;
+
+  /** 비활성. */
+  disabled?: boolean;
+
+  /** 라벨 컨텐츠. */
+  children?: ReactNode;
+
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface TagGroupProps extends HTMLAttributes<HTMLDivElement> {
+  /** 자식 사이 간격. 기본 6. */
+  gap?: number | string;
+
+  /** wrap 여부. 기본 true. */
+  wrap?: boolean;
+
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.2 Color resolver — `src/components/Tag/Tag.colors.ts`
+
+```ts
+import type { TagPresetColor, TagTheme, TagVariant, TagColor } from "./Tag.types";
+
+interface ColorTokens {
+  bg: string;     // solid bg
+  fg: string;     // solid fg
+  subtleBg: string;   // subtle bg (연한 배경)
+  subtleFg: string;   // subtle fg
+  outlineBorder: string;
+  outlineFg: string;
+  dotColor: string;
+  hoverBg: string;    // clickable hover overlay
+}
+
+/**
+ * Preset 9색 × light/dark.
+ * 색상 디자인 — Tailwind 500 (solid bg) / 100 (subtle light bg) / 700 (dark fg) / 900 (dark subtle bg) 등 차용.
+ */
+export const tagColors: Record<TagPresetColor, Record<TagTheme, ColorTokens>> = {
+  blue: {
+    light: { bg: "#3b82f6", fg: "#ffffff", subtleBg: "#dbeafe", subtleFg: "#1e40af", outlineBorder: "#3b82f6", outlineFg: "#1e40af", dotColor: "#3b82f6", hoverBg: "rgba(59,130,246,0.08)" },
+    dark:  { bg: "#3b82f6", fg: "#0f172a", subtleBg: "rgba(59,130,246,0.18)", subtleFg: "#93c5fd", outlineBorder: "#60a5fa", outlineFg: "#93c5fd", dotColor: "#60a5fa", hoverBg: "rgba(96,165,250,0.18)" },
+  },
+  green: {
+    light: { bg: "#10b981", fg: "#ffffff", subtleBg: "#d1fae5", subtleFg: "#065f46", outlineBorder: "#10b981", outlineFg: "#065f46", dotColor: "#10b981", hoverBg: "rgba(16,185,129,0.08)" },
+    dark:  { bg: "#10b981", fg: "#0f172a", subtleBg: "rgba(16,185,129,0.18)", subtleFg: "#6ee7b7", outlineBorder: "#34d399", outlineFg: "#6ee7b7", dotColor: "#34d399", hoverBg: "rgba(52,211,153,0.18)" },
+  },
+  red: {
+    light: { bg: "#ef4444", fg: "#ffffff", subtleBg: "#fee2e2", subtleFg: "#991b1b", outlineBorder: "#ef4444", outlineFg: "#991b1b", dotColor: "#ef4444", hoverBg: "rgba(239,68,68,0.08)" },
+    dark:  { bg: "#ef4444", fg: "#0f172a", subtleBg: "rgba(239,68,68,0.18)", subtleFg: "#fca5a5", outlineBorder: "#f87171", outlineFg: "#fca5a5", dotColor: "#f87171", hoverBg: "rgba(248,113,113,0.18)" },
+  },
+  yellow: {
+    light: { bg: "#eab308", fg: "#ffffff", subtleBg: "#fef3c7", subtleFg: "#854d0e", outlineBorder: "#eab308", outlineFg: "#854d0e", dotColor: "#eab308", hoverBg: "rgba(234,179,8,0.08)" },
+    dark:  { bg: "#eab308", fg: "#0f172a", subtleBg: "rgba(234,179,8,0.18)", subtleFg: "#fde047", outlineBorder: "#facc15", outlineFg: "#fde047", dotColor: "#facc15", hoverBg: "rgba(250,204,21,0.18)" },
+  },
+  purple: {
+    light: { bg: "#a855f7", fg: "#ffffff", subtleBg: "#f3e8ff", subtleFg: "#6b21a8", outlineBorder: "#a855f7", outlineFg: "#6b21a8", dotColor: "#a855f7", hoverBg: "rgba(168,85,247,0.08)" },
+    dark:  { bg: "#a855f7", fg: "#0f172a", subtleBg: "rgba(168,85,247,0.18)", subtleFg: "#d8b4fe", outlineBorder: "#c084fc", outlineFg: "#d8b4fe", dotColor: "#c084fc", hoverBg: "rgba(192,132,252,0.18)" },
+  },
+  pink: {
+    light: { bg: "#ec4899", fg: "#ffffff", subtleBg: "#fce7f3", subtleFg: "#9d174d", outlineBorder: "#ec4899", outlineFg: "#9d174d", dotColor: "#ec4899", hoverBg: "rgba(236,72,153,0.08)" },
+    dark:  { bg: "#ec4899", fg: "#0f172a", subtleBg: "rgba(236,72,153,0.18)", subtleFg: "#f9a8d4", outlineBorder: "#f472b6", outlineFg: "#f9a8d4", dotColor: "#f472b6", hoverBg: "rgba(244,114,182,0.18)" },
+  },
+  gray: {
+    light: { bg: "#6b7280", fg: "#ffffff", subtleBg: "#f3f4f6", subtleFg: "#374151", outlineBorder: "#d1d5db", outlineFg: "#374151", dotColor: "#6b7280", hoverBg: "rgba(107,114,128,0.08)" },
+    dark:  { bg: "#6b7280", fg: "#ffffff", subtleBg: "rgba(255,255,255,0.08)", subtleFg: "#e5e7eb", outlineBorder: "rgba(255,255,255,0.18)", outlineFg: "#e5e7eb", dotColor: "#9ca3af", hoverBg: "rgba(255,255,255,0.08)" },
+  },
+  teal: {
+    light: { bg: "#14b8a6", fg: "#ffffff", subtleBg: "#ccfbf1", subtleFg: "#115e59", outlineBorder: "#14b8a6", outlineFg: "#115e59", dotColor: "#14b8a6", hoverBg: "rgba(20,184,166,0.08)" },
+    dark:  { bg: "#14b8a6", fg: "#0f172a", subtleBg: "rgba(20,184,166,0.18)", subtleFg: "#5eead4", outlineBorder: "#2dd4bf", outlineFg: "#5eead4", dotColor: "#2dd4bf", hoverBg: "rgba(45,212,191,0.18)" },
+  },
+  orange: {
+    light: { bg: "#f97316", fg: "#ffffff", subtleBg: "#ffedd5", subtleFg: "#9a3412", outlineBorder: "#f97316", outlineFg: "#9a3412", dotColor: "#f97316", hoverBg: "rgba(249,115,22,0.08)" },
+    dark:  { bg: "#f97316", fg: "#0f172a", subtleBg: "rgba(249,115,22,0.18)", subtleFg: "#fdba74", outlineBorder: "#fb923c", outlineFg: "#fdba74", dotColor: "#fb923c", hoverBg: "rgba(251,146,60,0.18)" },
+  },
+};
+
+/** Preset 키인지 검사. */
+export function isPresetColor(c: TagColor): c is TagPresetColor {
+  return c in tagColors;
+}
+
+/**
+ * 임의 hex/rgb 색상에서 ColorTokens 자동 생성.
+ *
+ * 전략:
+ * - solid bg = c (사용자 지정), fg = readableFg(c)
+ * - subtle bg = c + alpha(0.15)
+ * - subtle fg = c (다크 테마는 lighten)
+ * - outline border = c, fg = c
+ * - dot color = c
+ * - hover bg = c + alpha(0.08)
+ *
+ * 한계: 사용자 색상이 너무 어두우면 dark 테마에서 안 보일 수 있음.
+ *       v1은 단순 alpha 변형만, perceptual lighten/darken은 v1.1+.
+ */
+export function arbitraryColorTokens(c: string, theme: TagTheme): ColorTokens {
+  const fg = readableFg(c);
+  const alphaSubtle = theme === "dark" ? 0.22 : 0.15;
+  const alphaHover = theme === "dark" ? 0.12 : 0.08;
+  return {
+    bg: c,
+    fg,
+    subtleBg: withAlpha(c, alphaSubtle),
+    subtleFg: c,
+    outlineBorder: c,
+    outlineFg: c,
+    dotColor: c,
+    hoverBg: withAlpha(c, alphaHover),
+  };
+}
+
+/**
+ * hex/rgb → readable foreground (white or near-black) 결정.
+ * WCAG luminance 기반 단순 분기.
+ */
+function readableFg(c: string): string {
+  const rgb = parseColor(c);
+  if (!rgb) return "#ffffff";
+  // relative luminance
+  const r = sRGBToLinear(rgb.r / 255);
+  const g = sRGBToLinear(rgb.g / 255);
+  const b = sRGBToLinear(rgb.b / 255);
+  const L = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return L > 0.5 ? "#0f172a" : "#ffffff";
+}
+
+function sRGBToLinear(v: number): number {
+  return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+}
+
+function withAlpha(c: string, alpha: number): string {
+  const rgb = parseColor(c);
+  if (!rgb) return c; // fallback: 그대로
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
+}
+
+function parseColor(c: string): { r: number; g: number; b: number } | null {
+  // hex (#rgb, #rrggbb)
+  const hex = c.match(/^#([0-9a-f]{3,8})$/i);
+  if (hex) {
+    let h = hex[1];
+    if (h.length === 3) h = h.split("").map((x) => x + x).join("");
+    if (h.length === 4) h = h.slice(0, 3).split("").map((x) => x + x).join("") + h.slice(3).split("").map((x) => x + x).join("");
+    if (h.length >= 6) {
+      return {
+        r: parseInt(h.slice(0, 2), 16),
+        g: parseInt(h.slice(2, 4), 16),
+        b: parseInt(h.slice(4, 6), 16),
+      };
+    }
+  }
+  // rgb / rgba
+  const rgb = c.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i);
+  if (rgb) {
+    return {
+      r: parseInt(rgb[1]!, 10),
+      g: parseInt(rgb[2]!, 10),
+      b: parseInt(rgb[3]!, 10),
+    };
+  }
+  return null;
+}
+
+export function resolveColorTokens(c: TagColor, theme: TagTheme): ColorTokens {
+  if (isPresetColor(c)) return tagColors[c][theme];
+  return arbitraryColorTokens(c, theme);
+}
+```
+
+### 2.3 Tag 컴포넌트 — `src/components/Tag/Tag.tsx`
+
+```tsx
+import { useCallback, type CSSProperties, type KeyboardEvent, type MouseEvent } from "react";
+import { Icon } from "../Icon";
+import { resolveColorTokens } from "./Tag.colors";
+import type { TagProps, TagSize, TagVariant } from "./Tag.types";
+
+const sizeMap: Record<TagSize, { height: number; padding: string; fontSize: number; gap: number; iconSize: number; dotSize: number }> = {
+  sm: { height: 18, padding: "0 6px", fontSize: 11, gap: 4, iconSize: 11, dotSize: 6 },
+  md: { height: 22, padding: "0 8px", fontSize: 12, gap: 5, iconSize: 12, dotSize: 7 },
+  lg: { height: 26, padding: "0 10px", fontSize: 13, gap: 6, iconSize: 14, dotSize: 8 },
+};
+
+export function Tag(props: TagProps) {
+  const {
+    color = "gray",
+    size = "md",
+    variant = "subtle",
+    theme = "light",
+    icon,
+    removable = false,
+    onRemove,
+    clickable = false,
+    disabled = false,
+    children,
+    onClick,
+    onKeyDown,
+    className,
+    style,
+    ...rest
+  } = props;
+
+  const tokens = resolveColorTokens(color, theme);
+  const s = sizeMap[size];
+
+  // variant별 스타일
+  let variantStyle: CSSProperties;
+  switch (variant) {
+    case "solid":
+      variantStyle = {
+        background: tokens.bg,
+        color: tokens.fg,
+        border: `1px solid ${tokens.bg}`,
+      };
+      break;
+    case "subtle":
+      variantStyle = {
+        background: tokens.subtleBg,
+        color: tokens.subtleFg,
+        border: `1px solid transparent`,
+      };
+      break;
+    case "outline":
+      variantStyle = {
+        background: "transparent",
+        color: tokens.outlineFg,
+        border: `1px solid ${tokens.outlineBorder}`,
+      };
+      break;
+    case "dot":
+      variantStyle = {
+        background: theme === "dark" ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.04)",
+        color: theme === "dark" ? "#e5e7eb" : "#374151",
+        border: `1px solid transparent`,
+      };
+      break;
+  }
+
+  const baseStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: s.gap,
+    height: s.height,
+    padding: s.padding,
+    fontSize: s.fontSize,
+    fontFamily: "inherit",
+    fontWeight: 500,
+    lineHeight: 1,
+    borderRadius: s.height / 2, // 알약형
+    boxSizing: "border-box",
+    cursor: disabled ? "not-allowed" : clickable ? "pointer" : "default",
+    opacity: disabled ? 0.5 : 1,
+    userSelect: "none",
+    transition: "background 120ms ease",
+    ...variantStyle,
+    ...style,
+  };
+
+  const handleClick = useCallback((e: MouseEvent<HTMLSpanElement>) => {
+    if (disabled) return;
+    onClick?.(e);
+  }, [disabled, onClick]);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLSpanElement>) => {
+    onKeyDown?.(e);
+    if (e.defaultPrevented) return;
+    if (clickable && (e.key === "Enter" || e.key === " ")) {
+      e.preventDefault();
+      onClick?.(e as unknown as MouseEvent<HTMLSpanElement>);
+    }
+  }, [clickable, onKeyDown, onClick]);
+
+  const handleRemoveClick = useCallback((e: MouseEvent) => {
+    e.stopPropagation(); // Tag 자체 클릭 방지
+    if (disabled) return;
+    onRemove?.();
+  }, [disabled, onRemove]);
+
+  const handleRemoveKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      if (disabled) return;
+      onRemove?.();
+    }
+  }, [disabled, onRemove]);
+
+  const a11yProps = clickable
+    ? { role: "button" as const, tabIndex: disabled ? -1 : 0, "aria-disabled": disabled || undefined }
+    : {};
+
+  const dotEl = variant === "dot" ? (
+    <span
+      aria-hidden="true"
+      style={{
+        width: s.dotSize,
+        height: s.dotSize,
+        borderRadius: "50%",
+        background: tokens.dotColor,
+        flexShrink: 0,
+      }}
+    />
+  ) : null;
+
+  const removeBtn = removable ? (
+    <button
+      type="button"
+      onClick={handleRemoveClick}
+      onKeyDown={handleRemoveKeyDown}
+      disabled={disabled}
+      aria-label="Remove"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: s.iconSize + 4,
+        height: s.iconSize + 4,
+        marginRight: -2,
+        marginLeft: 2,
+        padding: 0,
+        background: "transparent",
+        border: "none",
+        borderRadius: "50%",
+        color: "currentColor",
+        opacity: 0.6,
+        cursor: disabled ? "not-allowed" : "pointer",
+        transition: "opacity 120ms ease, background 120ms ease",
+      }}
+    >
+      <Icon name="x" size={s.iconSize} />
+    </button>
+  ) : null;
+
+  return (
+    <span
+      className={className}
+      style={baseStyle}
+      onClick={clickable ? handleClick : undefined}
+      onKeyDown={clickable ? handleKeyDown : undefined}
+      {...a11yProps}
+      data-variant={variant}
+      data-size={size}
+      data-disabled={disabled || undefined}
+      data-clickable={clickable || undefined}
+      {...rest}
+    >
+      {dotEl}
+      {icon}
+      {children !== undefined && children !== null && <span>{children}</span>}
+      {removeBtn}
+    </span>
+  );
+}
+
+Tag.displayName = "Tag";
+```
+
+### 2.4 Tag.Group — `src/components/Tag/TagGroup.tsx`
+
+```tsx
+import type { CSSProperties } from "react";
+import type { TagGroupProps } from "./Tag.types";
+
+export function TagGroup(props: TagGroupProps) {
+  const { gap = 6, wrap = true, children, className, style, ...rest } = props;
+
+  const baseStyle: CSSProperties = {
+    display: "flex",
+    flexWrap: wrap ? "wrap" : "nowrap",
+    alignItems: "center",
+    gap: typeof gap === "number" ? `${gap}px` : gap,
+    ...style,
+  };
+
+  return (
+    <div className={className} style={baseStyle} {...rest}>
+      {children}
+    </div>
+  );
+}
+
+TagGroup.displayName = "Tag.Group";
+```
+
+### 2.5 Compound assembly — `src/components/Tag/Tag.assembly.tsx`
+
+```tsx
+import { Tag as TagBase } from "./Tag";
+import { TagGroup } from "./TagGroup";
+
+type TagComponent = typeof TagBase & {
+  Group: typeof TagGroup;
+};
+
+export const Tag = TagBase as TagComponent;
+Tag.Group = TagGroup;
+
+// Chip은 동일 컴포넌트의 alias
+export const Chip = Tag;
+```
+
+### 2.6 배럴 — `src/components/Tag/index.ts`
+
+```ts
+export { Tag, Chip } from "./Tag.assembly";
+export type {
+  TagProps,
+  TagGroupProps,
+  TagPresetColor,
+  TagColor,
+  TagSize,
+  TagVariant,
+  TagTheme,
+} from "./Tag.types";
+```
+
+### 2.7 components 배럴 — `src/components/index.ts`
+
+```ts
+export * from "./Tag";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/Tag/
+├── Tag.tsx              ← 메인 컴포넌트
+├── TagGroup.tsx          ← 다중 칩 wrap helper
+├── Tag.assembly.tsx      ← Tag.Group 합성 + Chip alias
+├── Tag.types.ts          ← 타입
+├── Tag.colors.ts         ← 9 preset 팔레트 + 임의 색상 resolver
+└── index.ts              ← 배럴
+```
+
+---
+
+## 4. 동작 명세
+
+### 4.1 variant별 시각
+
+| variant | 배경 | 전경 | 테두리 |
+|---|---|---|---|
+| `solid` | preset bg (예: blue.500) | white | 같은 색 |
+| `subtle` (기본) | preset 배경 (light: 100, dark: alpha) | preset 진한 톤 | transparent |
+| `outline` | transparent | preset 진한 톤 | preset 색 |
+| `dot` | 매우 연한 회색 | 일반 텍스트 색 | transparent. 좌측 점만 preset 색 |
+
+### 4.2 size별 픽셀
+
+| size | height | padding | fontSize | iconSize |
+|---|---|---|---|---|
+| `sm` | 18 | 0 6 | 11 | 11 |
+| `md` | 22 | 0 8 | 12 | 12 |
+| `lg` | 26 | 0 10 | 13 | 14 |
+
+borderRadius = height / 2 → 알약형 (perfect pill).
+
+### 4.3 임의 색상 처리
+
+```tsx
+<Tag color="#3b82f6" />
+```
+- `arbitraryColorTokens("#3b82f6", "light")` 호출.
+- bg = `"#3b82f6"`, fg = readableFg(`"#3b82f6"`) → luminance 계산 결과 `"#ffffff"` (대비 충분).
+- subtleBg = `"rgba(59, 130, 246, 0.15)"`.
+- subtleFg = `"#3b82f6"` (다크에선 자동 lighten 안 함 — v1 한계).
+
+WCAG AA 자동 검증 안 함. 사용자가 contrast 책임.
+
+### 4.4 removable + clickable 동시
+
+```tsx
+<Tag removable onRemove={...} clickable onClick={...}>Filter: Author</Tag>
+```
+- 본체 클릭 → `onClick`.
+- X 버튼 클릭 → `onRemove`. `e.stopPropagation()`로 본체 onClick 차단.
+- 키보드: Tag 자체 포커스 + Enter → onClick. X 버튼은 별도 button (Tab 한 번 더로 포커스).
+
+### 4.5 disabled
+
+- cursor: not-allowed.
+- opacity 0.5.
+- onClick / onRemove 무시.
+- aria-disabled="true".
+
+### 4.6 dot variant
+
+좌측에 색상 점 + 텍스트. 배경/테두리는 중립 회색. status 표시 ("● Active") 패턴.
+
+```
+[● Active]
+```
+
+### 4.7 icon 슬롯
+
+```tsx
+<Tag icon={<Icon name="check" size="xs" />}>Verified</Tag>
+```
+- 좌측에 임의 ReactNode 렌더.
+- dot variant + icon 동시 사용은 금지하지 않음 (둘 다 표시).
+
+### 4.8 hover effect (clickable)
+
+clickable Tag에 hover 시 배경에 `tokens.hoverBg` overlay. CSS hover pseudo-class로:
+
+```css
+/* CSS-in-JS 한계로 onMouseEnter/Leave + state 사용 */
+```
+
+**구현 단순화**: v1은 hover 시 background 변경 안 함 (CSS-in-JS pseudo class 제한). 대안: `<style>` injection 또는 `:hover` className. v1은 단순 `data-clickable` attribute + `cursor: pointer`만, 호버 색상 변화는 v1.1.
+
+→ **결정**: v1은 hover overlay 미포함 (단순). cursor + outline 포커스 정도. clickable 시각 변화는 사용자가 className으로 추가.
+
+### 4.9 Tag.Group 동작
+
+- 단순 flex container with gap.
+- 자식 Tag들이 wrap 가능.
+- 별도 시맨틱 없음 (role 무).
+
+---
+
+## 5. 데모 페이지 — `demo/src/pages/TagPage.tsx`
+
+```tsx
+export function TagPage() {
+  const [filters, setFilters] = useState(["Author: alice", "Status: open", "Priority: high"]);
+
+  return (
+    <div>
+      <h1>Tag / Chip</h1>
+
+      <Card.Root>
+        <Card.Header>Basic — preset colors</Card.Header>
+        <Card.Body>
+          <Tag.Group>
+            <Tag color="blue">blue</Tag>
+            <Tag color="green">green</Tag>
+            <Tag color="red">red</Tag>
+            <Tag color="yellow">yellow</Tag>
+            <Tag color="purple">purple</Tag>
+            <Tag color="pink">pink</Tag>
+            <Tag color="gray">gray</Tag>
+            <Tag color="teal">teal</Tag>
+            <Tag color="orange">orange</Tag>
+          </Tag.Group>
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Variants</Card.Header>
+        <Card.Body>
+          <Tag.Group>
+            <Tag variant="solid" color="blue">Solid</Tag>
+            <Tag variant="subtle" color="blue">Subtle</Tag>
+            <Tag variant="outline" color="blue">Outline</Tag>
+            <Tag variant="dot" color="blue">Dot</Tag>
+          </Tag.Group>
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Sizes</Card.Header>
+        <Card.Body>
+          <Tag.Group>
+            <Tag size="sm" color="blue">Small</Tag>
+            <Tag size="md" color="blue">Medium</Tag>
+            <Tag size="lg" color="blue">Large</Tag>
+          </Tag.Group>
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Custom hex color</Card.Header>
+        <Card.Body>
+          <Tag.Group>
+            <Tag color="#ff6b35" variant="solid">#ff6b35</Tag>
+            <Tag color="#ff6b35" variant="subtle">#ff6b35</Tag>
+            <Tag color="#ff6b35" variant="outline">#ff6b35</Tag>
+            <Tag color="#ff6b35" variant="dot">#ff6b35</Tag>
+          </Tag.Group>
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>With icon</Card.Header>
+        <Card.Body>
+          <Tag.Group>
+            <Tag color="green" icon={<Icon name="check" size="xs" />}>Verified</Tag>
+            <Tag color="red" icon={<Icon name="x" size="xs" />}>Rejected</Tag>
+            <Tag color="yellow" icon={<Icon name="warning" size="xs" />}>Warning</Tag>
+          </Tag.Group>
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Removable (filter chips)</Card.Header>
+        <Card.Body>
+          <Tag.Group>
+            {filters.map((f) => (
+              <Tag key={f} removable onRemove={() => setFilters(filters.filter((x) => x !== f))} color="blue">
+                {f}
+              </Tag>
+            ))}
+            <Tag clickable variant="outline" color="gray" onClick={() => setFilters([...filters, `Filter ${filters.length + 1}`])}>
+              + Add filter
+            </Tag>
+          </Tag.Group>
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Clickable (toggle)</Card.Header>
+        <Card.Body>
+          <Tag clickable color="blue" onClick={() => alert("toggled")}>
+            Click me
+          </Tag>
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Disabled</Card.Header>
+        <Card.Body>
+          <Tag.Group>
+            <Tag color="blue" disabled>Disabled</Tag>
+            <Tag color="blue" removable disabled>Cannot remove</Tag>
+          </Tag.Group>
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Dark theme</Card.Header>
+        <Card.Body style={{ background: "#1f2937", padding: 16 }}>
+          <Tag.Group>
+            <Tag theme="dark" color="blue">blue</Tag>
+            <Tag theme="dark" color="green">green</Tag>
+            <Tag theme="dark" color="red">red</Tag>
+            <Tag theme="dark" variant="solid" color="purple">solid</Tag>
+            <Tag theme="dark" variant="outline" color="orange">outline</Tag>
+            <Tag theme="dark" variant="dot" color="teal">dot</Tag>
+          </Tag.Group>
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Chip alias (동일 동작)</Card.Header>
+        <Card.Body>
+          <Tag.Group>
+            <Chip color="purple">Same as Tag</Chip>
+          </Tag.Group>
+        </Card.Body>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>Tag.Group — 다양한 gap</Card.Header>
+        <Card.Body>
+          <p>gap=2 (densest)</p>
+          <Tag.Group gap={2}>
+            <Tag>a</Tag><Tag>b</Tag><Tag>c</Tag><Tag>d</Tag>
+          </Tag.Group>
+          <p>gap=12</p>
+          <Tag.Group gap={12}>
+            <Tag>a</Tag><Tag>b</Tag><Tag>c</Tag><Tag>d</Tag>
+          </Tag.Group>
+        </Card.Body>
+      </Card.Root>
+    </div>
+  );
+}
+```
+
+데모 라우팅 등록 — NAV에 `Tag` 추가.
+
+---
+
+## 6. 접근성 (a11y)
+
+### 6.1 기본 (clickable 아님, removable 아님)
+- `<span>` — 시맨틱 없음. 단순 텍스트 라벨.
+
+### 6.2 clickable
+- `role="button"`, `tabIndex=0`, Enter/Space 키 활성.
+- aria-disabled="true" (disabled 시).
+
+### 6.3 removable
+- 별도 `<button aria-label="Remove">` (X 버튼).
+- Tag 자체와 별도 포커스. Tab으로 X 버튼 도달.
+- Enter/Space 키 활성.
+- e.stopPropagation()로 Tag onClick 차단.
+
+### 6.4 dot variant
+- dot은 `aria-hidden="true"` (장식 표시).
+- 텍스트 라벨이 의미 전달.
+
+### 6.5 색상 대비
+- preset 색상은 디자인 단계에서 light/dark 모두 WCAG AA 대비 검증 완료.
+- 임의 hex 색상은 사용자 책임 (자동 readableFg는 단순 luminance 기반).
+
+---
+
+## 7. 설계 결정 사항 (rationale)
+
+### 7.1 Tag 정식 + Chip alias
+**이유**: Tag는 의미 중심(블로그 태그·카테고리), Chip은 시각 중심(알약형 모양). 두 어휘가 industry에 공존 → 사용자 친숙성 위해 둘 다 export. 코드 중복은 zero (alias).
+
+### 7.2 9 preset color 고정
+**이유**: 너무 많으면 디자인 일관성 깨짐 (Ant Design 14색은 과함). 9색은 status 표현과 카테고리 표현 모두 충분 + 디자인 검증 가능 분량.
+
+### 7.3 dot variant 별도
+**이유**: 점 indicator는 "이 항목은 X 카테고리/상태" 시각 패턴이 강함. solid/subtle/outline로는 표현 부자연. 별도 variant로 분리해 의도 명확.
+
+### 7.4 임의 hex 지원
+**이유**: 디자인 시스템 외 컬러(브랜드, 사용자 선택) 필요한 케이스. preset 9색만으론 부족. 자동 readableFg 계산이 100% 완벽하진 않으나 실용적 절충.
+
+### 7.5 hover effect 미포함 (v1)
+**이유**: CSS-in-JS의 :hover 한계 (별도 className 또는 inline style + onMouseEnter 둘 다 비싼 방법). 단순 cursor + 포커스 outline만으로 인터랙션 충분. v1.1에서 추가 검토.
+
+### 7.6 Tag.Group은 단순 flex helper
+**이유**: 의미적 grouping (role="list" 등)도 가능하나 대부분의 경우 시각만 필요. 명시적 시맨틱 필요 시 사용자가 직접 `<ul>` 사용. 과한 추상 회피.
+
+### 7.7 removable X 버튼이 별도 button
+**이유**: `<span onClick>` 안에 `<span onClick stopPropagation>` 같은 nested handler 패턴은 a11y 약함. button이면 키보드 + 스크린리더 자동.
+
+### 7.8 size = pill (border-radius = height/2)
+**이유**: 알약형이 Tag/Chip의 표준. rectangular는 `Badge`가 더 적합 (별도 컴포넌트 후보).
+
+---
+
+## 8. Edge cases
+
+### 8.1 children 빈 값
+```tsx
+<Tag />
+<Tag>{null}</Tag>
+```
+- 빈 Tag 렌더 (아이콘만 있을 수도). 시각: padding만 있는 작은 동그라미.
+- 의도적 — icon만 있는 Tag도 가능.
+
+### 8.2 매우 긴 라벨
+```tsx
+<Tag>This is a very long label that doesn't fit in one line</Tag>
+```
+- 기본 `display: inline-flex`로 한 줄 유지 (그대로 가로 확장).
+- text-overflow ellipsis 적용 안 함 (사용자가 className으로 추가 가능).
+
+### 8.3 색상 prop이 잘못된 string
+```tsx
+<Tag color="not-a-real-color" />
+```
+- `parseColor` 실패 → fallback으로 c 자체 사용 (CSS가 무시할 가능성).
+- 시각: 아무 색도 안 입혀짐 (browser default).
+- v1은 별도 검증 안 함. 콘솔 경고도 안 함 (false positive 우려).
+
+### 8.4 removable onRemove 없음
+```tsx
+<Tag removable />
+```
+- X 버튼은 표시되지만 클릭해도 아무 일 안 일어남.
+- v1은 검증 안 함. 사용자 책임.
+
+### 8.5 clickable이지만 onClick 없음
+- 마찬가지로 클릭해도 동작 없음. Tab으로 포커스만 가능.
+
+### 8.6 color prop 변화 시 transition
+- bg/fg가 갑자기 바뀜. transition 없음 (variant 변화도 동일).
+- v1은 무전환. 깜빡임 신경쓰이면 사용자가 className에 transition 추가.
+
+### 8.7 SSR
+- color 계산은 동기적, navigator/window 무관. 안전.
+
+### 8.8 dot variant + 매우 작은 size
+```tsx
+<Tag size="sm" variant="dot">x</Tag>
+```
+- 점이 6px, 텍스트 11px. 시각 대비 적당.
+- 사용자 customize 시 dotSize 별도 prop은 v1 미포함.
+
+---
+
+## 9. 구현 단계 (Phase)
+
+### Phase 1: 신설
+1. `src/components/Tag/Tag.types.ts`
+2. `src/components/Tag/Tag.colors.ts`
+3. `src/components/Tag/Tag.tsx`
+4. `src/components/Tag/TagGroup.tsx`
+5. `src/components/Tag/Tag.assembly.tsx`
+6. `src/components/Tag/index.ts`
+7. `src/components/index.ts`에 추가
+8. `npm run typecheck` + `npm run build`
+
+**선결조건**: plan 023 (Icon)이 먼저 구현되어야 함 (X 아이콘 사용). 만약 Icon이 아직 없으면 임시로 inline SVG 사용 후 Icon 도입 시 교체.
+
+### Phase 2: 데모 페이지
+1. `demo/src/pages/TagPage.tsx` 작성 (§5)
+2. NAV 등록
+3. 시각 회귀 — 모든 색상·variant·size 조합 (light/dark)
+4. removable, clickable 인터랙션 확인
+5. 키보드 (Tab, Enter, Space) 확인
+
+### Phase 3: 정리
+- [ ] `docs/candidates.md`에서 2번 항목 제거 + plan 링크
+- [ ] README.md에 Tag 섹션 추가
+
+---
+
+## 10. 향후 확장 (v1.1+)
+
+| 항목 | 설명 |
+|---|---|
+| Animated dismiss | onRemove 시 페이드아웃 후 unmount |
+| Selectable / toggle | aria-pressed 기반 toggle 칩 |
+| Avatar 슬롯 baked-in | `<Tag avatar={...} />` |
+| Hover overlay | clickable 시 호버 색상 변화 (CSS injection) |
+| Dropdown 통합 | Tag 클릭 시 dropdown 열기 (`<Tag dropdown={...}>`) |
+| 색상 자동 lighten/darken | 임의 hex의 dark 테마 가독성 자동 보정 |
+| Counter 합성 | `<Tag>+3</Tag>` 패턴 표준화 |
+
+---
+
+## 11. 체크리스트
+
+- [ ] `src/components/Tag/` 6개 파일
+- [ ] `npm run typecheck` 통과
+- [ ] `npm run build` 통과
+- [ ] TagPage 모든 섹션 (light/dark) 정상
+- [ ] 9 preset 색상 모두 시각 검증
+- [ ] 4 variant 모두 시각 검증
+- [ ] 3 size 모두 시각 검증
+- [ ] 임의 hex 색상 작동 (#ff6b35 등)
+- [ ] removable + onRemove 정상
+- [ ] clickable + onClick + 키보드 정상
+- [ ] disabled 정상
+- [ ] Tag.Group gap 변화 정상
+- [ ] Chip alias 동일 동작
+- [ ] `docs/candidates.md` 2번 제거 + 링크
+- [ ] README.md 업데이트

--- a/docs/plans/028-numberinput-component.md
+++ b/docs/plans/028-numberinput-component.md
@@ -1,0 +1,616 @@
+# NumberInput 컴포넌트 설계문서
+
+## Context
+
+숫자 전용 입력 컴포넌트 `NumberInput` 추가. native `<input type="number">`는 다음 한계가 있어 라이브러리에서 자체 컴포넌트가 필요:
+
+1. **시각 일관성 부재** — 브라우저별 stepper UI 다름 (Chrome 화살표, Firefox 스피너, Safari 미표시).
+2. **정밀도 제어 불가** — 0.1 + 0.2 = 0.30000000000000004 같은 부동소수점 문제.
+3. **휠 스크롤 동작이 위험** — 페이지 스크롤 중 의도치 않은 값 변경.
+4. **format / locale 미지원** — "1,234.56" 같은 천 단위 콤마 표시 불가.
+5. **prefix/suffix 슬롯 부재** — "$100", "75%" 같은 단위 표시 어려움.
+6. **range constraint 시각 피드백 부재** — min/max 초과 시 invalid 시각 약함.
+
+본 컴포넌트는 발견·필터·금액·수량 등 모든 숫자 입력 시나리오 흡수.
+
+참고 (prior art):
+- **Mantine NumberInput** — 가장 풍부. min/max/step/precision/clampBehavior/decimalSeparator/thousandsSeparator/fixedDecimalScale/allowDecimal/allowNegative/prefix/suffix.
+- **Chakra `NumberInput`** — Compound (Root, Field, IncrementStepper, DecrementStepper). a11y 표준.
+- **react-aria `useNumberField`** — 가장 완성도 높은 a11y. Intl.NumberFormat 기반 locale 자동.
+- **Ant Design `InputNumber`** — formatter/parser 함수 prop. step·precision.
+- **Material UI** — TextField + type="number" 정도, 자체 NumberInput 없음.
+- **HTML5 spec** — `<input type="number">`의 `valueAsNumber`, `stepUp()`, `stepDown()` API 참고.
+
+본 레포 내부 참조:
+- `src/components/Icon/` (plan 023) — stepper 버튼의 `<Icon name="chevron-up" />`, `<Icon name="chevron-down" />`.
+- `src/components/PathInput/PathInputRoot.tsx` — 텍스트 입력 패턴 (focus/blur, onChange) 참조.
+- `src/components/_shared/useControllable.ts` — controlled/uncontrolled 통합.
+- `src/components/Toast/colors.ts` — invalid state 색상 참고 (severity 추출 후 통일).
+
+---
+
+## 0. TL;DR
+
+```tsx
+// 1. 가장 단순
+<NumberInput defaultValue={0} />
+
+// 2. min/max/step
+<NumberInput min={0} max={100} step={5} defaultValue={50} />
+
+// 3. controlled
+<NumberInput value={value} onValueChange={setValue} />
+
+// 4. precision (소수점 자릿수)
+<NumberInput precision={2} step={0.01} defaultValue={1.5} />
+// → 입력값이 1.5 → blur 시 "1.50" 표시 (precision=2 강제)
+
+// 5. format (천 단위 콤마)
+<NumberInput format="thousand" defaultValue={1000000} />
+// → "1,000,000"
+
+// 6. prefix / suffix
+<NumberInput prefix="$" defaultValue={99.99} precision={2} />
+<NumberInput suffix="%" min={0} max={100} />
+
+// 7. 비활성 / readonly
+<NumberInput disabled defaultValue={42} />
+<NumberInput readOnly defaultValue={42} />
+
+// 8. 사이즈
+<NumberInput size="sm" />
+<NumberInput size="md" />
+<NumberInput size="lg" />
+
+// 9. compound (커스텀 stepper UI)
+<NumberInput.Root value={v} onValueChange={setV}>
+  <NumberInput.Decrement>−</NumberInput.Decrement>
+  <NumberInput.Field />
+  <NumberInput.Increment>+</NumberInput.Increment>
+</NumberInput.Root>
+
+// 10. allowNegative / allowDecimal
+<NumberInput allowNegative={false} allowDecimal={false} />
+```
+
+핵심 원칙:
+- **외부 value: number | null** (string 아님). null = 빈 입력.
+- **내부 표시: string** — locale 포맷 적용된 표시 문자열. blur 시 정규화.
+- **clamp**: min/max 초과 시 blur 시점에 자동 보정 (또는 즉시, `clampBehavior` prop).
+- **stepper 버튼**: 우측 세로 위/아래. 또는 사용자 compound 자유 합성.
+- **키보드**: Arrow Up/Down (±step), Shift+Arrow (×10), PgUp/PgDn (×10), Home/End (min/max).
+- **휠**: 포커스 중에만 작동 (페이지 스크롤 보호). `disableWheel` 옵션.
+- **a11y**: `role="spinbutton"`, `aria-valuenow/min/max`, `aria-invalid`.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. value: `number | null`. null = 빈 입력 허용.
+2. min/max/step/precision props.
+3. `format: "plain" | "thousand"` — 천 단위 콤마.
+4. `prefix`, `suffix` — string 또는 ReactNode.
+5. `size: "sm" | "md" | "lg"`.
+6. `theme: "light" | "dark"`.
+7. `allowNegative` (기본 true), `allowDecimal` (기본 true).
+8. `clampBehavior: "blur" | "input" | "none"` — 기본 "blur".
+9. `disableWheel: boolean` — 기본 false (포커스 중 휠 작동).
+10. 키보드: Arrow ±step, Shift+Arrow ±step×10, PgUp/PgDn ±step×10, Home/End min/max.
+11. stepper 버튼 (자동) + compound 패턴 (커스텀).
+12. controlled/uncontrolled.
+13. validation 시각: invalid 시 `aria-invalid="true"` + 빨간 outline.
+14. focus/blur/keydown 표준 props pass-through.
+15. compound: `NumberInput.Root`, `.Field`, `.Increment`, `.Decrement`.
+16. 배럴 export.
+
+### Non-goals (v1)
+- 통화·언어별 자동 포맷 (Intl.NumberFormat 통합) — v1.1.
+- 분수 표시 (1/2) — v1 안 함.
+- 단위 변환 (kg ↔ lb) — v1 안 함.
+- BigInt 지원 — v1은 Number만. 1e15 이상은 정밀도 보장 안 함.
+- 자동 RTL — v1 LTR 가정.
+- 슬라이더와의 동기화 (Slider+NumberInput compound) — v1 별도.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/NumberInput/NumberInput.types.ts`
+
+```ts
+import type { CSSProperties, InputHTMLAttributes, ReactNode } from "react";
+
+export type NumberInputSize = "sm" | "md" | "lg";
+export type NumberInputTheme = "light" | "dark";
+export type NumberInputFormat = "plain" | "thousand";
+export type ClampBehavior = "blur" | "input" | "none";
+
+export interface NumberInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "value" | "defaultValue" | "onChange" | "type" | "size"> {
+  /** controlled value. null = 빈 입력. */
+  value?: number | null;
+  defaultValue?: number | null;
+  onValueChange?: (value: number | null) => void;
+
+  min?: number;
+  max?: number;
+  /** 기본 1. */
+  step?: number;
+  /** 소수점 자릿수. precision=2 면 1.5 → "1.50" 표시 + 강제 반올림. */
+  precision?: number;
+
+  /** 기본 "plain". */
+  format?: NumberInputFormat;
+
+  /** 음수 허용. 기본 true. */
+  allowNegative?: boolean;
+
+  /** 소수 허용. 기본 true. false면 정수만. */
+  allowDecimal?: boolean;
+
+  /** 기본 "blur". */
+  clampBehavior?: ClampBehavior;
+
+  /** 기본 false. true면 포커스 중 휠 비활성. */
+  disableWheel?: boolean;
+
+  /** 좌측 prefix. "$", "₩" 등. */
+  prefix?: ReactNode;
+
+  /** 우측 suffix. "%", "kg" 등. */
+  suffix?: ReactNode;
+
+  /** stepper 버튼 표시. 기본 true. */
+  showStepper?: boolean;
+
+  size?: NumberInputSize;
+  theme?: NumberInputTheme;
+  disabled?: boolean;
+  readOnly?: boolean;
+  invalid?: boolean;     // 외부에서 invalid 강제 (form validation 등)
+  placeholder?: string;
+  autoFocus?: boolean;
+  required?: boolean;
+
+  className?: string;
+  style?: CSSProperties;
+
+  inputClassName?: string;
+  inputStyle?: CSSProperties;
+}
+
+export interface NumberInputRootProps extends Omit<NumberInputProps, "showStepper" | "prefix" | "suffix"> {
+  children: ReactNode;
+}
+
+export interface NumberInputFieldProps {
+  className?: string;
+  style?: CSSProperties;
+  placeholder?: string;
+  "aria-label"?: string;
+}
+
+export interface NumberInputStepButtonProps {
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+  "aria-label"?: string;
+}
+```
+
+### 2.2 utils — `src/components/NumberInput/NumberInput.utils.ts`
+
+```ts
+/** 부동소수점 안전 round. precision=2 → Math.round(v*100)/100. */
+export function roundToPrecision(v: number, precision: number): number {
+  if (precision <= 0) return Math.round(v);
+  const factor = Math.pow(10, precision);
+  return Math.round(v * factor) / factor;
+}
+
+/** clamp. */
+export function clamp(v: number, min: number | undefined, max: number | undefined): number {
+  let r = v;
+  if (min !== undefined && r < min) r = min;
+  if (max !== undefined && r > max) r = max;
+  return r;
+}
+
+/** number → 표시 문자열. */
+export function formatNumber(
+  v: number,
+  precision: number | undefined,
+  format: "plain" | "thousand",
+): string {
+  let s: string;
+  if (precision !== undefined) {
+    s = v.toFixed(precision);
+  } else {
+    s = String(v);
+  }
+  if (format === "thousand") {
+    const [intPart, decPart] = s.split(".");
+    const withCommas = intPart!.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    s = decPart !== undefined ? `${withCommas}.${decPart}` : withCommas;
+  }
+  return s;
+}
+
+/** 사용자 입력 문자열 → number | null. */
+export function parseNumber(s: string, allowNegative: boolean, allowDecimal: boolean): number | null {
+  if (s.trim() === "") return null;
+  // 콤마 제거
+  let cleaned = s.replace(/,/g, "");
+  // 음수 차단
+  if (!allowNegative && cleaned.startsWith("-")) cleaned = cleaned.replace(/-/g, "");
+  // 소수점 차단
+  if (!allowDecimal) cleaned = cleaned.replace(/\./g, "");
+  const n = Number(cleaned);
+  if (Number.isNaN(n)) return null;
+  return n;
+}
+
+/** 입력 문자열 검증 (typing 중간 단계 허용 — "-", "1.", ".5" 등). */
+export function isValidPartialInput(s: string, allowNegative: boolean, allowDecimal: boolean): boolean {
+  if (s === "") return true;
+  if (!allowNegative && s.includes("-")) return false;
+  if (!allowDecimal && s.includes(".")) return false;
+  // 정규식
+  const allowedChars = allowNegative
+    ? (allowDecimal ? /^-?\d*(\.\d*)?$/ : /^-?\d*$/)
+    : (allowDecimal ? /^\d*(\.\d*)?$/ : /^\d*$/);
+  // thousand 콤마는 표시만 — 입력 중에는 콤마 허용 후 parse 단계 제거
+  const withoutCommas = s.replace(/,/g, "");
+  return allowedChars.test(withoutCommas);
+}
+```
+
+### 2.3 컴포넌트 — `src/components/NumberInput/NumberInput.tsx`
+
+(주요 로직 — 전체 구현은 §2.4 참조)
+
+```tsx
+export function NumberInput(props: NumberInputProps) {
+  const {
+    value: controlledValue, defaultValue, onValueChange,
+    min, max, step = 1, precision,
+    format = "plain", allowNegative = true, allowDecimal = true,
+    clampBehavior = "blur", disableWheel = false,
+    prefix, suffix, showStepper = true,
+    size = "md", theme = "light",
+    disabled, readOnly, invalid: invalidProp, placeholder, autoFocus, required,
+    className, style, inputClassName, inputStyle,
+    onFocus, onBlur, onKeyDown, onWheel,
+    ...rest
+  } = props;
+
+  // value (controlled / uncontrolled)
+  const [internalValue, setInternalValue] = useState<number | null>(defaultValue ?? null);
+  const value = controlledValue !== undefined ? controlledValue : internalValue;
+  const setValue = useCallback((next: number | null) => {
+    if (controlledValue === undefined) setInternalValue(next);
+    onValueChange?.(next);
+  }, [controlledValue, onValueChange]);
+
+  // 표시 문자열
+  const [displayValue, setDisplayValue] = useState<string>(() =>
+    value === null ? "" : formatNumber(value, precision, format)
+  );
+  const [isFocused, setIsFocused] = useState(false);
+
+  // value 변경 시 displayValue 동기화 (단 focus 중엔 사용자 입력 우선)
+  useEffect(() => {
+    if (!isFocused) {
+      setDisplayValue(value === null ? "" : formatNumber(value, precision, format));
+    }
+  }, [value, precision, format, isFocused]);
+
+  const isOutOfRange = value !== null && (
+    (min !== undefined && value < min) || (max !== undefined && value > max)
+  );
+  const computedInvalid = invalidProp || isOutOfRange;
+
+  // 키보드 / 휠 / 스텝 / 포커스 / blur / change 핸들러는 §2.4 참조
+
+  return (
+    <div ... wrapper>
+      {prefix && <span ...>{prefix}</span>}
+      <input ... />
+      {suffix && <span ...>{suffix}</span>}
+      {showStepper && (
+        <div ... stepper>
+          <button onClick={() => stepUp()}>↑</button>
+          <button onClick={() => stepDown()}>↓</button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+### 2.4 핵심 동작 명세
+
+#### 4.1 stepUp / stepDown
+```ts
+const stepUp = () => {
+  const cur = value ?? 0;
+  let next = cur + step;
+  if (precision !== undefined) next = roundToPrecision(next, precision);
+  if (clampBehavior !== "none") next = clamp(next, min, max);
+  setValue(next);
+};
+const stepDown = () => { /* same with -step */ };
+```
+
+#### 4.2 onChange (typing)
+```ts
+const handleChange = (e) => {
+  const raw = e.target.value;
+  if (!isValidPartialInput(raw, allowNegative, allowDecimal)) return; // 무시
+  setDisplayValue(raw);
+  // value 즉시 갱신 — 단 빈 문자열은 null
+  if (raw.trim() === "") {
+    setValue(null);
+  } else {
+    let n = parseNumber(raw, allowNegative, allowDecimal);
+    if (n !== null) {
+      if (clampBehavior === "input") n = clamp(n, min, max);
+      setValue(n);
+    }
+  }
+};
+```
+
+#### 4.3 onBlur (정규화)
+```ts
+const handleBlur = (e) => {
+  setIsFocused(false);
+  if (value !== null) {
+    let v = value;
+    if (precision !== undefined) v = roundToPrecision(v, precision);
+    if (clampBehavior !== "none") v = clamp(v, min, max);
+    setValue(v);
+    setDisplayValue(formatNumber(v, precision, format));
+  } else {
+    setDisplayValue("");
+  }
+  onBlur?.(e);
+};
+```
+
+#### 4.4 키보드
+```ts
+const handleKeyDown = (e) => {
+  onKeyDown?.(e);
+  if (e.defaultPrevented) return;
+  let multiplier = 1;
+  if (e.shiftKey) multiplier = 10;
+
+  switch (e.key) {
+    case "ArrowUp":
+      e.preventDefault();
+      stepBy(step * multiplier); return;
+    case "ArrowDown":
+      e.preventDefault();
+      stepBy(-step * multiplier); return;
+    case "PageUp":
+      e.preventDefault();
+      stepBy(step * 10); return;
+    case "PageDown":
+      e.preventDefault();
+      stepBy(-step * 10); return;
+    case "Home":
+      if (min !== undefined) {
+        e.preventDefault();
+        setValue(min);
+      }
+      return;
+    case "End":
+      if (max !== undefined) {
+        e.preventDefault();
+        setValue(max);
+      }
+      return;
+  }
+};
+```
+
+#### 4.5 휠
+```ts
+const handleWheel = (e) => {
+  if (disableWheel || !isFocused || disabled || readOnly) return;
+  e.preventDefault();
+  if (e.deltaY < 0) stepUp();
+  else stepDown();
+};
+```
+
+### 2.5 compound 패턴
+
+```tsx
+// NumberInput.Root → Context provider
+// NumberInput.Field → input
+// NumberInput.Increment / Decrement → step 버튼
+
+const Ctx = createContext<{ stepUp, stepDown, value, ... }>(null);
+
+export function NumberInputRoot(props: NumberInputRootProps) {
+  // ... 동일 state 관리
+  return <Ctx.Provider value={...}>{children}</Ctx.Provider>;
+}
+
+export function NumberInputField(props: NumberInputFieldProps) {
+  const ctx = useContext(Ctx);
+  return <input ... />;
+}
+
+export function NumberInputIncrement(props: NumberInputStepButtonProps) {
+  const ctx = useContext(Ctx);
+  return <button onClick={ctx.stepUp}>{props.children ?? "+"}</button>;
+}
+```
+
+NumberInput 단일 컴포넌트는 내부적으로 NumberInput.Root + Field + Increment + Decrement 합성.
+
+### 2.6 배럴 — `src/components/NumberInput/index.ts`
+
+```ts
+export { NumberInput } from "./NumberInput";
+export type {
+  NumberInputProps,
+  NumberInputRootProps,
+  NumberInputFieldProps,
+  NumberInputStepButtonProps,
+  NumberInputSize,
+  NumberInputTheme,
+  NumberInputFormat,
+  ClampBehavior,
+} from "./NumberInput.types";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/NumberInput/
+├── NumberInput.tsx
+├── NumberInput.types.ts
+├── NumberInput.utils.ts
+├── NumberInputRoot.tsx
+├── NumberInputField.tsx
+├── NumberInputStepButton.tsx (Increment/Decrement 공유)
+├── NumberInput.styles.ts
+└── index.ts
+```
+
+---
+
+## 4. 데모 페이지 — `demo/src/pages/NumberInputPage.tsx`
+
+```tsx
+export function NumberInputPage() {
+  const [v, setV] = useState<number | null>(50);
+
+  return (
+    <div>
+      <h1>NumberInput</h1>
+
+      <Card.Root><Card.Header>Basic</Card.Header><Card.Body>
+        <NumberInput defaultValue={0} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>min/max/step</Card.Header><Card.Body>
+        <NumberInput min={0} max={100} step={5} defaultValue={50} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Controlled</Card.Header><Card.Body>
+        <NumberInput value={v} onValueChange={setV} min={0} max={100} />
+        <p>Value: {v}</p>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>precision=2 + step=0.01</Card.Header><Card.Body>
+        <NumberInput precision={2} step={0.01} defaultValue={1.5} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Thousand format</Card.Header><Card.Body>
+        <NumberInput format="thousand" defaultValue={1234567} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Prefix / Suffix</Card.Header><Card.Body>
+        <NumberInput prefix="$" defaultValue={99.99} precision={2} />
+        <NumberInput suffix="%" min={0} max={100} defaultValue={75} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>allowNegative=false / allowDecimal=false</Card.Header><Card.Body>
+        <NumberInput allowNegative={false} allowDecimal={false} placeholder="positive integer only" />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Sizes</Card.Header><Card.Body>
+        <NumberInput size="sm" defaultValue={1} />
+        <NumberInput size="md" defaultValue={2} />
+        <NumberInput size="lg" defaultValue={3} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Disabled / readOnly / invalid</Card.Header><Card.Body>
+        <NumberInput disabled defaultValue={42} />
+        <NumberInput readOnly defaultValue={42} />
+        <NumberInput invalid defaultValue={42} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Compound (custom UI)</Card.Header><Card.Body>
+        <NumberInput.Root defaultValue={5} min={0} max={20}>
+          <NumberInput.Decrement>−</NumberInput.Decrement>
+          <NumberInput.Field />
+          <NumberInput.Increment>+</NumberInput.Increment>
+        </NumberInput.Root>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Dark theme</Card.Header><Card.Body style={{background:"#1f2937",padding:16}}>
+        <NumberInput theme="dark" defaultValue={42} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Wheel disabled</Card.Header><Card.Body>
+        <NumberInput disableWheel defaultValue={0} />
+      </Card.Body></Card.Root>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. 접근성 (a11y)
+
+- `role="spinbutton"` (input에).
+- `aria-valuenow`, `aria-valuemin`, `aria-valuemax`.
+- `aria-invalid` 동기화.
+- stepper 버튼: `aria-label="Increase"`, `aria-label="Decrease"`.
+- 키보드: Arrow Up/Down 표준. 스크린리더가 자동 안내.
+- 휠: 포커스 중에만 — 페이지 스크롤 보호.
+
+---
+
+## 6. Edge cases
+
+- **빈 입력 → null** — placeholder 표시.
+- **min > max** — 무시 (사용자 잘못). 콘솔 경고 가능 (v1 미포함).
+- **step=0** — 무한 step 방지 위해 stepBy 호출 시 무시 (또는 기본 1).
+- **precision 음수** — 무시 (정수 처리 동일).
+- **부동소수점**: 0.1 + 0.2 → roundToPrecision으로 처리.
+- **format="thousand" + decimal**: "1,234.56" 형식 유지.
+- **paste**: 사용자가 "1,234"를 붙여넣기 → cleaned = "1234" → 1234.
+- **IME**: 한글 IME는 숫자 입력에 영향 없음.
+- **clampBehavior="input"**: 100인 max에 사용자가 200 타이핑 시 즉시 100으로 clamp → 사용자가 100 이상 입력 불가능. UX 거슬릴 수 있어 기본 "blur".
+- **focus 중 prop value 외부에서 변경**: displayValue는 사용자 입력 보존, value만 prop 따라감.
+
+---
+
+## 7. 구현 단계
+
+### Phase 1: 코어
+1. types, utils
+2. NumberInput 단일 컴포넌트 (Root + Field + Stepper 합성)
+3. compound exports
+4. 배럴
+
+### Phase 2: 데모
+
+### Phase 3: 정리
+- candidates.md에서 3번 제거 + 링크
+- README 업데이트
+
+---
+
+## 8. 체크리스트
+- [ ] 8개 파일 작성
+- [ ] typecheck / build 통과
+- [ ] 데모 페이지 모든 섹션 정상 (light/dark)
+- [ ] 키보드 (Arrow, Shift+Arrow, PgUp/PgDn, Home/End) 작동
+- [ ] 휠 (disableWheel 분기 포함) 작동
+- [ ] precision 부동소수점 안전
+- [ ] format=thousand 천 단위 콤마
+- [ ] prefix/suffix 정렬
+- [ ] compound API 작동
+- [ ] candidates.md / README 업데이트

--- a/docs/plans/029-stack-grid-component.md
+++ b/docs/plans/029-stack-grid-component.md
@@ -1,0 +1,472 @@
+# Stack / HStack / VStack / Grid 레이아웃 primitive 설계문서
+
+## Context
+
+`gap` 기반 flex/grid 레이아웃 primitive 4종 추가. 라이브러리 사용자(및 라이브러리 자체 데모·문서·Form)가 매번 손으로 `display: flex; gap: 12px; align-items: center` 같은 inline style 적는 비용을 제거.
+
+라이브러리는 현재 layout helper가 없음 — 모든 컴포넌트가 자체 layout을 직접 처리. Form 4종(향후), AppShell parts(plan 039), 데모 페이지 등이 모두 이 primitive에 의존하면 일관성·생산성 모두 개선.
+
+참고 (prior art):
+- **Chakra `Stack`/`HStack`/`VStack`** — direction prop, divider 지원. 가장 영향력.
+- **Mantine `Stack`/`Group`/`Grid`** — Group은 horizontal stack alias.
+- **Radix UI primitives** — layout primitive 미제공.
+- **Tailwind UI** — utility class 직접 (라이브러리 추상 없음).
+- **Vanilla Extract / Stitches** — `Box`, `Stack` 같은 primitive 권장.
+- **TanStack Layout** — primitives N/A.
+
+본 레포 내부 참조:
+- `src/components/Card/` — Card 자체가 flex layout 사용 — 참고용.
+- `tsconfig.json` — strict 옵션.
+
+---
+
+## 0. TL;DR
+
+```tsx
+// 1. Stack — 기본 vertical (= VStack)
+<Stack gap={12}>
+  <button>One</button>
+  <button>Two</button>
+  <button>Three</button>
+</Stack>
+
+// 2. HStack — horizontal
+<HStack gap={8} align="center">
+  <Avatar />
+  <span>Name</span>
+  <button>Action</button>
+</HStack>
+
+// 3. VStack — vertical (Stack alias)
+<VStack gap={16}>...</VStack>
+
+// 4. Stack with direction prop
+<Stack direction="row" gap={12} wrap>
+  <Tag>react</Tag>
+  <Tag>typescript</Tag>
+</Stack>
+
+// 5. align / justify
+<HStack align="center" justify="space-between">
+  <Logo />
+  <Nav />
+  <UserMenu />
+</HStack>
+
+// 6. divider
+<VStack gap={12} divider={<hr />}>
+  <Section1 />
+  <Section2 />
+  <Section3 />
+</VStack>
+
+// 7. Grid — CSS grid
+<Grid columns={3} gap={16}>
+  <Card />
+  <Card />
+  <Card />
+</Grid>
+
+// 8. Grid with template
+<Grid templateColumns="200px 1fr 100px" gap={12}>
+  <Sidebar />
+  <Main />
+  <Aside />
+</Grid>
+
+// 9. Responsive (단순 — number 또는 object)
+<Grid columns={{ base: 1, md: 2, lg: 3 }} gap={16}>
+  ...
+</Grid>
+```
+
+핵심 원칙:
+- **gap 기반** — margin 사용 안 함. CSS gap (`gap: 12px`)으로 일관 spacing.
+- **HStack/VStack은 Stack의 thin wrapper** — direction 고정.
+- **Grid는 별도** — flex와 기능 다름.
+- **divider는 자식 사이에만 — `Children.toArray + map + insert`** 패턴.
+- **inline style 기반** — CSS class 추가 의존 없음 (Tailwind 무관).
+- **HTMLAttributes pass-through** — 추가 props 자유.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. `Stack` (default vertical) — `direction`, `gap`, `align`, `justify`, `wrap`, `divider`.
+2. `HStack` — Stack with direction="row".
+3. `VStack` — Stack with direction="column" (default와 동일, alias).
+4. `Grid` — CSS grid 기반. `columns`, `templateColumns`, `templateRows`, `gap`, `rowGap`, `columnGap`.
+5. `inline?: boolean` — display: inline-flex / inline-grid.
+6. responsive `columns` (단순 객체 기반).
+7. divider 패턴 (자식 사이에만).
+8. `as?` polymorphic (default `<div>`).
+9. HTMLAttributes pass-through.
+
+### Non-goals (v1)
+- **Box primitive** — generic styled `<div>`. 별도 후보.
+- **Container primitive** — max-width centered. 별도 후보 (검토 대상).
+- **Center / Spacer / AspectRatio** — 별도 후보.
+- **CSS class 기반 시스템** — inline style만.
+- **Theme-aware spacing tokens** (예: `gap="md"` → 토큰 매핑) — v1.1+. 일단 number/string만.
+- **breakpoints 자체 정의** — 사용자가 외부에서 미디어쿼리로 처리하거나, columns 단순 객체 기반 접근.
+- **container queries** — v2+.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Stack/Stack.types.ts`
+
+```ts
+import type { CSSProperties, ElementType, HTMLAttributes, ReactNode } from "react";
+
+export type StackDirection = "row" | "column" | "row-reverse" | "column-reverse";
+export type StackAlign = "start" | "center" | "end" | "stretch" | "baseline";
+export type StackJustify = "start" | "center" | "end" | "space-between" | "space-around" | "space-evenly";
+
+/** Responsive value type. */
+export type Responsive<T> = T | { base?: T; sm?: T; md?: T; lg?: T; xl?: T };
+
+export interface StackProps extends Omit<HTMLAttributes<HTMLElement>, "children"> {
+  /** flex-direction. 기본 "column". */
+  direction?: StackDirection;
+
+  /** gap. number(px) 또는 string. 기본 0. */
+  gap?: number | string;
+
+  /** align-items. */
+  align?: StackAlign;
+
+  /** justify-content. */
+  justify?: StackJustify;
+
+  /** flex-wrap. 기본 false (nowrap). */
+  wrap?: boolean;
+
+  /** inline-flex. 기본 false. */
+  inline?: boolean;
+
+  /** 자식 사이에 삽입할 divider 노드 (또는 () => ReactNode). */
+  divider?: ReactNode | (() => ReactNode);
+
+  /** polymorphic — default "div". */
+  as?: ElementType;
+
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface GridProps extends Omit<HTMLAttributes<HTMLElement>, "children"> {
+  /** 단순 columns. 1 = 1단, 3 = 3단. 또는 responsive 객체. */
+  columns?: Responsive<number>;
+
+  /** 직접 grid-template-columns. 우선순위 높음. */
+  templateColumns?: string;
+
+  /** 직접 grid-template-rows. */
+  templateRows?: string;
+
+  /** auto rows. */
+  autoRows?: string;
+
+  /** gap. */
+  gap?: number | string;
+  rowGap?: number | string;
+  columnGap?: number | string;
+
+  /** align-items. */
+  align?: StackAlign;
+  justify?: StackJustify;
+
+  /** inline-grid. */
+  inline?: boolean;
+
+  as?: ElementType;
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.2 Stack 컴포넌트 — `src/components/Stack/Stack.tsx`
+
+```tsx
+import { Children, isValidElement, type CSSProperties } from "react";
+import type { StackProps } from "./Stack.types";
+
+const alignMap: Record<string, string> = {
+  start: "flex-start",
+  center: "center",
+  end: "flex-end",
+  stretch: "stretch",
+  baseline: "baseline",
+};
+
+const justifyMap: Record<string, string> = {
+  start: "flex-start",
+  center: "center",
+  end: "flex-end",
+  "space-between": "space-between",
+  "space-around": "space-around",
+  "space-evenly": "space-evenly",
+};
+
+export function Stack(props: StackProps) {
+  const {
+    direction = "column",
+    gap = 0,
+    align,
+    justify,
+    wrap = false,
+    inline = false,
+    divider,
+    as: Component = "div",
+    children,
+    className,
+    style,
+    ...rest
+  } = props;
+
+  const baseStyle: CSSProperties = {
+    display: inline ? "inline-flex" : "flex",
+    flexDirection: direction,
+    gap: typeof gap === "number" ? `${gap}px` : gap,
+    flexWrap: wrap ? "wrap" : "nowrap",
+    ...(align ? { alignItems: alignMap[align] } : {}),
+    ...(justify ? { justifyContent: justifyMap[justify] } : {}),
+    ...style,
+  };
+
+  // divider가 있으면 자식 사이에 삽입
+  let content: ReactNode = children;
+  if (divider !== undefined && children !== undefined) {
+    const arr = Children.toArray(children).filter(Boolean);
+    const interleaved: ReactNode[] = [];
+    arr.forEach((child, i) => {
+      if (i > 0) {
+        const div = typeof divider === "function" ? divider() : divider;
+        interleaved.push(<Fragment key={`__div-${i}`}>{div}</Fragment>);
+      }
+      interleaved.push(child);
+    });
+    content = interleaved;
+  }
+
+  return (
+    <Component className={className} style={baseStyle} {...rest}>
+      {content}
+    </Component>
+  );
+}
+```
+
+### 2.3 HStack / VStack — `src/components/Stack/HStack.tsx`
+
+```tsx
+export function HStack(props: Omit<StackProps, "direction">) {
+  return <Stack direction="row" {...props} />;
+}
+
+export function VStack(props: Omit<StackProps, "direction">) {
+  return <Stack direction="column" {...props} />;
+}
+```
+
+### 2.4 Grid — `src/components/Stack/Grid.tsx`
+
+```tsx
+export function Grid(props: GridProps) {
+  const {
+    columns,
+    templateColumns,
+    templateRows,
+    autoRows,
+    gap, rowGap, columnGap,
+    align, justify,
+    inline = false,
+    as: Component = "div",
+    children, className, style, ...rest
+  } = props;
+
+  // columns → templateColumns 변환
+  let resolvedTemplate = templateColumns;
+  if (!resolvedTemplate && columns !== undefined) {
+    if (typeof columns === "number") {
+      resolvedTemplate = `repeat(${columns}, minmax(0, 1fr))`;
+    } else {
+      // responsive 객체 — base만 처리 (sm/md/lg는 v1 미디어쿼리 미지원, base 사용)
+      // v1.1+에서 useMediaQuery로 동적 결정
+      const base = columns.base ?? columns.md ?? columns.sm ?? columns.lg ?? columns.xl ?? 1;
+      resolvedTemplate = `repeat(${base}, minmax(0, 1fr))`;
+    }
+  }
+
+  const baseStyle: CSSProperties = {
+    display: inline ? "inline-grid" : "grid",
+    ...(resolvedTemplate ? { gridTemplateColumns: resolvedTemplate } : {}),
+    ...(templateRows ? { gridTemplateRows: templateRows } : {}),
+    ...(autoRows ? { gridAutoRows: autoRows } : {}),
+    ...(gap !== undefined ? { gap: typeof gap === "number" ? `${gap}px` : gap } : {}),
+    ...(rowGap !== undefined ? { rowGap: typeof rowGap === "number" ? `${rowGap}px` : rowGap } : {}),
+    ...(columnGap !== undefined ? { columnGap: typeof columnGap === "number" ? `${columnGap}px` : columnGap } : {}),
+    ...(align ? { alignItems: alignMap[align] } : {}),
+    ...(justify ? { justifyContent: justifyMap[justify] } : {}),
+    ...style,
+  };
+
+  return <Component className={className} style={baseStyle} {...rest}>{children}</Component>;
+}
+```
+
+### 2.5 배럴 — `src/components/Stack/index.ts`
+
+```ts
+export { Stack } from "./Stack";
+export { HStack } from "./HStack";
+export { VStack } from "./VStack";
+export { Grid } from "./Grid";
+export type {
+  StackProps,
+  GridProps,
+  StackDirection,
+  StackAlign,
+  StackJustify,
+  Responsive,
+} from "./Stack.types";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/Stack/
+├── Stack.tsx
+├── HStack.tsx
+├── VStack.tsx
+├── Grid.tsx
+├── Stack.types.ts
+└── index.ts
+```
+
+---
+
+## 4. 데모 페이지 — `demo/src/pages/StackPage.tsx`
+
+```tsx
+export function StackPage() {
+  return (
+    <div>
+      <h1>Stack / HStack / VStack / Grid</h1>
+
+      <Card.Root><Card.Header>Stack (vertical default)</Card.Header><Card.Body>
+        <Stack gap={12}>
+          <Btn>One</Btn><Btn>Two</Btn><Btn>Three</Btn>
+        </Stack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>HStack</Card.Header><Card.Body>
+        <HStack gap={8} align="center">
+          <Btn>One</Btn><Btn>Two</Btn><Btn>Three</Btn>
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>HStack with align/justify</Card.Header><Card.Body>
+        <HStack align="center" justify="space-between" style={{width:300}}>
+          <span>Logo</span><nav>Nav</nav><span>User</span>
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Stack with divider</Card.Header><Card.Body>
+        <VStack gap={12} divider={<hr style={{border:0,borderTop:"1px solid #ddd",margin:0}} />}>
+          <p>Section 1</p>
+          <p>Section 2</p>
+          <p>Section 3</p>
+        </VStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Wrap</Card.Header><Card.Body>
+        <HStack gap={6} wrap>
+          {Array.from({length:20},(_,i)=><Tag key={i}>tag-{i}</Tag>)}
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Grid columns=3</Card.Header><Card.Body>
+        <Grid columns={3} gap={12}>
+          {Array.from({length:9},(_,i)=><div key={i} style={{padding:16,background:"#f3f4f6"}}>{i+1}</div>)}
+        </Grid>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Grid templateColumns</Card.Header><Card.Body>
+        <Grid templateColumns="200px 1fr 100px" gap={12}>
+          <div style={{background:"#dbeafe",padding:8}}>Sidebar 200</div>
+          <div style={{background:"#fef3c7",padding:8}}>Main 1fr</div>
+          <div style={{background:"#fee2e2",padding:8}}>Aside 100</div>
+        </Grid>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Grid 다양한 row/column gap</Card.Header><Card.Body>
+        <Grid columns={3} rowGap={20} columnGap={4}>
+          {Array.from({length:6},(_,i)=><div key={i} style={{padding:8,background:"#f3f4f6"}}>{i+1}</div>)}
+        </Grid>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>polymorphic as</Card.Header><Card.Body>
+        <Stack as="ul" gap={4}>
+          <li>List item 1</li>
+          <li>List item 2</li>
+        </Stack>
+      </Card.Body></Card.Root>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. 접근성 (a11y)
+
+- 시맨틱 영향 없음 (단순 div).
+- `as` prop으로 의미 있는 태그 (ul, nav, section 등)로 변경 가능.
+- divider는 시각만 — `<hr>` 사용 시 자동 a11y.
+
+---
+
+## 6. Edge cases
+
+- **자식 0개**: 빈 컨테이너. style 적용되지만 시각 영향 없음.
+- **자식 1개 + divider**: divider 삽입 안 됨 (사이가 없음). 의도된 동작.
+- **gap=0**: 기본 — 동작 정상.
+- **wrap + nowrap이 혼재**: `wrap=true` 우선.
+- **inline + 부모가 inline 아님**: 자체 inline-flex 시각만 영향.
+- **responsive columns**: v1은 base만 사용 — sm/md/lg 무시. 사용자가 미디어쿼리 직접 처리. v1.1+에서 `useMediaQuery` 통합.
+
+---
+
+## 7. 구현 단계
+
+### Phase 1: 코어
+1. types
+2. Stack
+3. HStack / VStack alias
+4. Grid
+5. 배럴
+6. components/index.ts
+
+### Phase 2: 데모
+
+### Phase 3: 정리
+- candidates.md에서 4번 제거 + 링크
+- README
+
+---
+
+## 8. 체크리스트
+- [ ] 6개 파일
+- [ ] typecheck / build
+- [ ] 데모 모든 섹션
+- [ ] divider 작동
+- [ ] polymorphic as 작동
+- [ ] candidates / README

--- a/docs/plans/030-fileupload-component.md
+++ b/docs/plans/030-fileupload-component.md
@@ -1,0 +1,606 @@
+# FileUpload / Dropzone 설계문서
+
+## Context
+
+파일 선택 + 드래그 앤 드롭 영역을 표준화한 `FileUpload` 컴포넌트 추가. 단일 컴포넌트가 다음 두 모드를 모두 지원:
+- **버튼 모드**: "파일 선택" 버튼만 노출. 클릭 시 파일 다이얼로그.
+- **Dropzone 모드**: 큰 영역. 드래그 앤 드롭 + 클릭 시 다이얼로그.
+
+native `<input type="file">`은 다음 한계:
+- 시각 통일 어려움 (브라우저별 다름).
+- 드래그 앤 드롭 별도 핸들러 필요.
+- 파일 미리보기·진행률·검증 표시 슬롯 없음.
+
+참고 (prior art):
+- **react-dropzone** — 가장 유명. `useDropzone` 훅 + render prop. accept 필터, multiple, maxSize 등.
+- **filepond** — 풀 기능 (이미지 미리보기, 자동 업로드).
+- **uppy** — 큰 라이브러리. 청크 업로드, 진행률.
+- **shadcn ui** 등 — 자체 dropzone 패턴.
+
+본 레포 내부 참조:
+- `src/components/Icon/` (plan 023) — `<Icon name="upload" />`, `<Icon name="x" />`.
+- `src/components/Progress/` (설계됨, 022) — 업로드 진행률 표시 합성.
+- `src/components/Stack/` (plan 029) — 파일 리스트 레이아웃.
+- `src/components/PathInput/PathInputInput.tsx:55` — 기존 drop effect 처리 참조.
+
+---
+
+## 0. TL;DR
+
+```tsx
+// 1. Dropzone 모드 (기본)
+<FileUpload onFiles={(files) => setFiles(files)}>
+  <Icon name="upload" size="xl" />
+  <p>여기로 파일을 드롭하거나 클릭하여 선택</p>
+</FileUpload>
+
+// 2. 버튼 모드
+<FileUpload variant="button">파일 선택</FileUpload>
+
+// 3. accept (MIME 또는 확장자)
+<FileUpload accept="image/*" />
+<FileUpload accept=".pdf,.doc,.docx" />
+
+// 4. multiple
+<FileUpload multiple onFiles={(files) => ...} />
+
+// 5. 크기 제한
+<FileUpload maxSize={5 * 1024 * 1024} onFiles={...} onReject={(rejected) => alert(rejected[0].reason)} />
+
+// 6. 갯수 제한
+<FileUpload maxFiles={3} multiple />
+
+// 7. 미리보기 슬롯 (compound)
+<FileUpload.Root>
+  <FileUpload.Dropzone />
+  <FileUpload.Preview /> {/* 선택된 파일 리스트 */}
+</FileUpload.Root>
+
+// 8. 진행률 (외부 업로드 후 prop 주입)
+<FileUpload.Root>
+  <FileUpload.Dropzone />
+  <FileUpload.Preview
+    files={files}
+    progress={(file) => uploadProgress[file.name] ?? 0}
+  />
+</FileUpload.Root>
+
+// 9. controlled
+<FileUpload files={files} onFiles={setFiles} />
+
+// 10. validate (사용자 정의)
+<FileUpload validate={(file) => file.name.endsWith(".csv") ? null : "CSV만 허용"} />
+```
+
+핵심 원칙:
+- **두 변형(variant)**: `dropzone` (기본, 큰 영역), `button` (단순 트리거).
+- **Dropzone은 클릭 시도 작동** — Dropzone이 곧 input 트리거.
+- **검증**: accept(MIME/ext) + maxSize + maxFiles + 사용자 validate.
+- **거부 콜백**: `onReject(rejections: { file, reason }[])` — 사용자에게 알림 책임.
+- **controlled / uncontrolled**.
+- **시각 상태**: idle / dragOver / disabled.
+- **headless 우선** — Compound 패턴으로 자유 합성.
+- **a11y**: 키보드로 dropzone 클릭 (Enter/Space) → 파일 다이얼로그.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. `variant: "dropzone" | "button"`.
+2. `accept` (MIME 또는 확장자 콤마 리스트).
+3. `multiple`, `maxFiles`, `maxSize` (bytes).
+4. `validate?: (file: File) => string | null` — null = 통과.
+5. `onFiles(files: File[])`, `onReject(rejections: FileRejection[])`.
+6. controlled (`files` + `onFiles`) / uncontrolled (`defaultFiles`).
+7. drag over 시각 피드백.
+8. compound — `.Root`, `.Dropzone`, `.Trigger`, `.Preview`, `.Item`.
+9. theme light/dark.
+10. disabled 처리.
+11. 키보드 활성 (Enter/Space).
+12. 배럴 export.
+
+### Non-goals (v1)
+- 자동 업로드 (HTTP) — 사용자가 onFiles 받아 처리.
+- 청크 업로드.
+- 이미지 미리보기 자동 생성 (URL.createObjectURL) — Preview는 파일명만, 사용자가 자체 미리보기 합성.
+- 진행률 자체 관리 — props로 받음 (외부 상태).
+- 클립보드 paste 지원 — v1.1+.
+- 폴더 업로드 (`webkitdirectory`) — v1.1+.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/FileUpload/FileUpload.types.ts`
+
+```ts
+import type { CSSProperties, ReactNode } from "react";
+
+export type FileUploadVariant = "dropzone" | "button";
+export type FileUploadTheme = "light" | "dark";
+
+export interface FileRejection {
+  file: File;
+  reason: "type" | "size" | "count" | "validate";
+  message: string;
+}
+
+export interface FileUploadRootProps {
+  variant?: FileUploadVariant;
+  theme?: FileUploadTheme;
+
+  files?: File[];
+  defaultFiles?: File[];
+  onFiles?: (files: File[]) => void;
+
+  accept?: string;
+  multiple?: boolean;
+  maxFiles?: number;
+  maxSize?: number; // bytes
+
+  validate?: (file: File) => string | null;
+  onReject?: (rejections: FileRejection[]) => void;
+
+  disabled?: boolean;
+
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+/** 단일 컴포넌트 모드 (compound 안 쓰는 경우) — Root + Dropzone/Trigger 통합. */
+export interface FileUploadProps extends FileUploadRootProps {
+  children?: ReactNode;
+}
+
+export interface FileUploadDropzoneProps {
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+export interface FileUploadTriggerProps {
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+export interface FileUploadPreviewProps {
+  files?: File[];
+  progress?: (file: File) => number;
+  onRemove?: (file: File) => void;
+  className?: string;
+  style?: CSSProperties;
+  children?: (file: File, index: number) => ReactNode;
+}
+
+export interface FileUploadItemProps {
+  file: File;
+  progress?: number;
+  onRemove?: () => void;
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.2 Context — `src/components/FileUpload/FileUploadContext.ts`
+
+```ts
+import { createContext, useContext } from "react";
+
+export interface FileUploadContextValue {
+  files: File[];
+  setFiles: (next: File[]) => void;
+  addFiles: (incoming: File[]) => void;  // 검증 + 추가
+  removeFile: (file: File) => void;
+  openDialog: () => void;
+  isDragOver: boolean;
+  disabled: boolean;
+  variant: "dropzone" | "button";
+  theme: "light" | "dark";
+  accept: string | undefined;
+  multiple: boolean;
+  maxFiles: number | undefined;
+  maxSize: number | undefined;
+}
+
+export const FileUploadContext = createContext<FileUploadContextValue | null>(null);
+
+export function useFileUploadContext(): FileUploadContextValue {
+  const ctx = useContext(FileUploadContext);
+  if (!ctx) throw new Error("FileUpload.* must be used within <FileUpload.Root>");
+  return ctx;
+}
+```
+
+### 2.3 Root — `src/components/FileUpload/FileUploadRoot.tsx`
+
+```tsx
+export function FileUploadRoot(props: FileUploadRootProps) {
+  const {
+    variant = "dropzone", theme = "light",
+    files: controlledFiles, defaultFiles, onFiles,
+    accept, multiple = false, maxFiles, maxSize,
+    validate, onReject, disabled = false,
+    className, style, children,
+  } = props;
+
+  const [internalFiles, setInternalFiles] = useState<File[]>(defaultFiles ?? []);
+  const files = controlledFiles ?? internalFiles;
+  const setFiles = useCallback((next: File[]) => {
+    if (controlledFiles === undefined) setInternalFiles(next);
+    onFiles?.(next);
+  }, [controlledFiles, onFiles]);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const validateFiles = useCallback((incoming: File[]): { accepted: File[]; rejected: FileRejection[] } => {
+    const accepted: File[] = [];
+    const rejected: FileRejection[] = [];
+
+    for (const file of incoming) {
+      // type 검증
+      if (accept && !matchesAccept(file, accept)) {
+        rejected.push({ file, reason: "type", message: `Type ${file.type || "unknown"} not allowed` });
+        continue;
+      }
+      // size 검증
+      if (maxSize !== undefined && file.size > maxSize) {
+        rejected.push({ file, reason: "size", message: `File too large (max ${formatBytes(maxSize)})` });
+        continue;
+      }
+      // 사용자 validate
+      if (validate) {
+        const msg = validate(file);
+        if (msg) {
+          rejected.push({ file, reason: "validate", message: msg });
+          continue;
+        }
+      }
+      accepted.push(file);
+    }
+
+    return { accepted, rejected };
+  }, [accept, maxSize, validate]);
+
+  const addFiles = useCallback((incoming: File[]) => {
+    if (disabled) return;
+    const { accepted, rejected: typeRejected } = validateFiles(incoming);
+    let toAdd = multiple ? [...files, ...accepted] : accepted.slice(0, 1);
+
+    // maxFiles 검증
+    let countRejected: FileRejection[] = [];
+    if (maxFiles !== undefined && toAdd.length > maxFiles) {
+      const overflow = toAdd.slice(maxFiles);
+      countRejected = overflow.map((f) => ({ file: f, reason: "count", message: `Max ${maxFiles} files` }));
+      toAdd = toAdd.slice(0, maxFiles);
+    }
+
+    setFiles(toAdd);
+    const allRejected = [...typeRejected, ...countRejected];
+    if (allRejected.length > 0) onReject?.(allRejected);
+  }, [disabled, validateFiles, multiple, files, maxFiles, onReject, setFiles]);
+
+  const removeFile = useCallback((file: File) => {
+    setFiles(files.filter((f) => f !== file));
+  }, [files, setFiles]);
+
+  const openDialog = useCallback(() => {
+    if (disabled) return;
+    inputRef.current?.click();
+  }, [disabled]);
+
+  // 드래그 핸들러
+  const handleDragEnter = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (!disabled) setIsDragOver(true);
+  };
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+  };
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+  };
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    if (disabled) return;
+    const dropped = Array.from(e.dataTransfer.files);
+    addFiles(dropped);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(e.target.files ?? []);
+    addFiles(selected);
+    // input value reset (같은 파일 재선택 가능)
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  const ctx: FileUploadContextValue = {
+    files, setFiles, addFiles, removeFile, openDialog,
+    isDragOver, disabled, variant, theme,
+    accept, multiple, maxFiles, maxSize,
+  };
+
+  return (
+    <FileUploadContext.Provider value={ctx}>
+      <div
+        className={className}
+        style={style}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept={accept}
+          multiple={multiple}
+          disabled={disabled}
+          onChange={handleInputChange}
+          style={{ display: "none" }}
+          aria-hidden="true"
+        />
+        {children}
+      </div>
+    </FileUploadContext.Provider>
+  );
+}
+```
+
+### 2.4 Dropzone / Trigger / Preview / Item — `src/components/FileUpload/...`
+
+```tsx
+export function FileUploadDropzone(props: FileUploadDropzoneProps) {
+  const ctx = useFileUploadContext();
+  const handleClick = () => ctx.openDialog();
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      ctx.openDialog();
+    }
+  };
+  // 시각 변화: dragOver 시 보더·배경 변경
+  return (
+    <div
+      role="button"
+      tabIndex={ctx.disabled ? -1 : 0}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      data-drag-over={ctx.isDragOver || undefined}
+      data-disabled={ctx.disabled || undefined}
+      style={{
+        padding: 32, border: `2px dashed ${ctx.isDragOver ? "#2563eb" : "#d1d5db"}`,
+        borderRadius: 8, textAlign: "center", cursor: ctx.disabled ? "not-allowed" : "pointer",
+        background: ctx.isDragOver ? "rgba(37,99,235,0.05)" : "transparent",
+        opacity: ctx.disabled ? 0.5 : 1, transition: "all 120ms ease",
+        ...props.style,
+      }}
+      className={props.className}
+    >
+      {props.children ?? (
+        <>
+          <Icon name="upload" size="xl" />
+          <p>여기로 파일을 드롭하거나 클릭하여 선택</p>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function FileUploadTrigger(props: FileUploadTriggerProps) {
+  const ctx = useFileUploadContext();
+  return (
+    <button type="button" onClick={ctx.openDialog} disabled={ctx.disabled} className={props.className} style={props.style}>
+      {props.children ?? "파일 선택"}
+    </button>
+  );
+}
+
+export function FileUploadPreview(props: FileUploadPreviewProps) {
+  const ctx = useFileUploadContext();
+  const files = props.files ?? ctx.files;
+  return (
+    <div className={props.className} style={props.style}>
+      {files.map((file, i) => (
+        props.children ? props.children(file, i) :
+          <FileUploadItem
+            key={`${file.name}-${i}`}
+            file={file}
+            progress={props.progress?.(file)}
+            onRemove={() => (props.onRemove ?? ctx.removeFile)(file)}
+          />
+      ))}
+    </div>
+  );
+}
+
+export function FileUploadItem(props: FileUploadItemProps) {
+  return (
+    <div style={{display:"flex",alignItems:"center",gap:8,padding:8,borderRadius:4,background:"#f9fafb"}}>
+      <Icon name="upload" size="sm" />
+      <span style={{flex:1}}>{props.file.name}</span>
+      <span style={{fontSize:12,color:"#6b7280"}}>{formatBytes(props.file.size)}</span>
+      {props.progress !== undefined && (
+        <progress value={props.progress} max={100} />
+      )}
+      {props.onRemove && (
+        <button onClick={props.onRemove} aria-label="Remove">
+          <Icon name="x" size="sm" />
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+### 2.5 utils
+
+```ts
+export function matchesAccept(file: File, accept: string): boolean {
+  const tokens = accept.split(",").map((t) => t.trim());
+  return tokens.some((tok) => {
+    if (tok.startsWith(".")) {
+      return file.name.toLowerCase().endsWith(tok.toLowerCase());
+    }
+    if (tok.endsWith("/*")) {
+      const prefix = tok.slice(0, -2);
+      return file.type.startsWith(prefix);
+    }
+    return file.type === tok;
+  });
+}
+
+export function formatBytes(b: number): string {
+  if (b < 1024) return `${b} B`;
+  if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`;
+  if (b < 1024 * 1024 * 1024) return `${(b / 1024 / 1024).toFixed(1)} MB`;
+  return `${(b / 1024 / 1024 / 1024).toFixed(1)} GB`;
+}
+```
+
+### 2.6 단일 컴포넌트 + compound assembly
+
+```tsx
+// FileUpload (단일 사용 — Dropzone 또는 Button)
+export function FileUpload(props: FileUploadProps) {
+  const { variant = "dropzone", children, ...rest } = props;
+  return (
+    <FileUploadRoot variant={variant} {...rest}>
+      {variant === "dropzone"
+        ? <FileUploadDropzone>{children}</FileUploadDropzone>
+        : <FileUploadTrigger>{children}</FileUploadTrigger>}
+    </FileUploadRoot>
+  );
+}
+
+FileUpload.Root = FileUploadRoot;
+FileUpload.Dropzone = FileUploadDropzone;
+FileUpload.Trigger = FileUploadTrigger;
+FileUpload.Preview = FileUploadPreview;
+FileUpload.Item = FileUploadItem;
+
+// Dropzone alias
+export { FileUploadDropzone as Dropzone };
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/FileUpload/
+├── FileUpload.tsx              ← 단일 + compound
+├── FileUploadRoot.tsx
+├── FileUploadDropzone.tsx
+├── FileUploadTrigger.tsx
+├── FileUploadPreview.tsx
+├── FileUploadItem.tsx
+├── FileUploadContext.ts
+├── FileUpload.utils.ts
+├── FileUpload.types.ts
+└── index.ts
+```
+
+---
+
+## 4. 데모 페이지 — `demo/src/pages/FileUploadPage.tsx`
+
+```tsx
+export function FileUploadPage() {
+  const [files, setFiles] = useState<File[]>([]);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  return (
+    <div>
+      <h1>FileUpload / Dropzone</h1>
+
+      <Card.Root><Card.Header>Dropzone (basic)</Card.Header><Card.Body>
+        <FileUpload onFiles={setFiles} />
+        <p>Selected: {files.length} files</p>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Button mode</Card.Header><Card.Body>
+        <FileUpload variant="button">파일 선택</FileUpload>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>accept="image/*"</Card.Header><Card.Body>
+        <FileUpload accept="image/*" multiple />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>maxSize=1MB + onReject</Card.Header><Card.Body>
+        <FileUpload
+          maxSize={1024 * 1024}
+          onReject={(r) => setErrors(r.map((x) => `${x.file.name}: ${x.message}`))}
+        />
+        {errors.map((e, i) => <p key={i} style={{color:"red"}}>{e}</p>)}
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Compound + Preview</Card.Header><Card.Body>
+        <FileUpload.Root multiple onFiles={setFiles}>
+          <FileUpload.Dropzone />
+          <FileUpload.Preview />
+        </FileUpload.Root>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Disabled</Card.Header><Card.Body>
+        <FileUpload disabled />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Custom validator</Card.Header><Card.Body>
+        <FileUpload
+          validate={(f) => f.name.endsWith(".csv") ? null : "CSV만 허용"}
+          onReject={(r) => alert(r[0]?.message)}
+        />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Dark theme</Card.Header><Card.Body style={{background:"#1f2937",padding:16}}>
+        <FileUpload theme="dark" />
+      </Card.Body></Card.Root>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. 접근성 (a11y)
+
+- Dropzone: `role="button"`, `tabIndex=0`, Enter/Space 키 활성.
+- Trigger: 표준 button.
+- input[type=file]: `aria-hidden="true"` (시각 숨김 + 키보드 미접근 — 항상 wrapper button을 통해 trigger).
+- 드래그 안내는 시각적 — 스크린리더 전용 텍스트 추가 가능 (v1.1+).
+- 거부된 파일 알림: `onReject` 콜백 + 사용자 책임 (Toast 등).
+
+---
+
+## 6. Edge cases
+
+- **input value reset**: 같은 파일 재선택을 위해 onChange 후 `value=""` 강제.
+- **multiple=false인데 여러 파일 드롭**: 첫 파일만 받음 (slice(0,1)).
+- **maxFiles=3 + 이미 2 + 새로 3 추가**: 5 → 3개로 truncate, 2개 reject (count).
+- **빈 input change**: 다이얼로그 닫고 무선택 → addFiles([]).
+- **iframe에서 파일 다이얼로그**: 일부 브라우저 차단 가능. v1 한계.
+- **동일 파일 재드롭**: 같은 파일이지만 File 객체 인스턴스는 다름 → 중복 추가됨. 사용자가 dedupe 책임 (v1).
+- **SSR**: `File` 객체는 브라우저 전용 — 서버에서 import 안전, 사용 시점에만 접근.
+
+---
+
+## 7. 구현 단계
+- Phase 1: 코어 컴포넌트 + Context
+- Phase 2: 데모
+- Phase 3: 정리
+
+## 8. 체크리스트
+- [ ] 10개 파일
+- [ ] typecheck/build
+- [ ] Dropzone 모드 모든 시나리오
+- [ ] Button 모드
+- [ ] accept/maxSize/maxFiles/validate 검증
+- [ ] 키보드 작동
+- [ ] candidates / README

--- a/docs/plans/031-image-component.md
+++ b/docs/plans/031-image-component.md
@@ -1,0 +1,366 @@
+# Image 컴포넌트 설계문서
+
+## Context
+
+native `<img>`만으로 처리 어려운 케이스를 흡수하는 `Image` 컴포넌트 추가:
+- **로딩 중 표시** — Skeleton 또는 blur placeholder.
+- **에러 시 fallback** — 실패 시 placeholder 또는 fallback URL.
+- **Lazy load** — IntersectionObserver 기반.
+- **Intrinsic ratio 보장** — width/height 비율 유지로 layout shift 방지.
+
+참고:
+- **Next.js `next/image`** — 가장 영향력. lazy, blur placeholder, sizes/srcSet 자동.
+- **Mantine `Image`** — fallback prop, fit, radius.
+- **Chakra `Image`** — fallbackSrc, ignoreFallback, htmlWidth/Height.
+
+본 레포 내부 참조:
+- `src/components/Skeleton/` (설계됨, plan 021) — 로딩 placeholder로 합성.
+- `src/components/Icon/` (plan 023) — 에러 fallback 아이콘.
+
+---
+
+## 0. TL;DR
+
+```tsx
+// 1. 기본
+<Image src="/photo.jpg" alt="My photo" />
+
+// 2. 사이즈 (intrinsic ratio 유지)
+<Image src="..." alt="..." width={400} height={300} />
+
+// 3. fit
+<Image src="..." alt="..." width={200} height={200} fit="cover" />
+<Image src="..." alt="..." fit="contain" />
+
+// 4. fallback
+<Image src="/may-fail.jpg" alt="..." fallbackSrc="/default.png" />
+<Image src="/may-fail.jpg" alt="..." fallback={<div>이미지 없음</div>} />
+
+// 5. lazy
+<Image src="..." alt="..." lazy />
+
+// 6. blur placeholder
+<Image src="..." alt="..." placeholder="blur" blurDataURL="data:..." />
+
+// 7. radius
+<Image src="..." alt="..." radius={8} />
+<Image src="..." alt="..." radius="full" /> {/* 원형 */}
+
+// 8. onLoad / onError
+<Image src="..." alt="..." onLoad={...} onError={...} />
+
+// 9. status 관찰
+const status = useImageStatus(src); // "loading" | "loaded" | "error"
+```
+
+핵심 원칙:
+- **intrinsic ratio 보장** — width × height 명시 시 박스 미리 차지 → CLS 방지.
+- **로딩/에러 상태 자체 관리** — `<img>` 이벤트 listener.
+- **fallback 우선순위**: `onError` 시 fallback ReactNode > fallbackSrc > 기본 placeholder.
+- **lazy**: native `loading="lazy"` 우선, 미지원 브라우저는 IntersectionObserver fallback.
+- **`object-fit` 매핑** — fit="cover" / "contain" / "fill" / "none" / "scale-down".
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. src, alt 필수.
+2. width, height (number/string).
+3. fit: "cover" | "contain" | "fill" | "none" | "scale-down".
+4. fallbackSrc (URL) + fallback (ReactNode) — 둘 중 우선.
+5. lazy (boolean) — 기본 false. true면 native lazy + IntersectionObserver fallback.
+6. placeholder: "skeleton" | "blur" | "none".
+7. blurDataURL (placeholder=blur 일 때).
+8. radius — number(px) | "full" (50%) | string.
+9. onLoad, onError 콜백.
+10. `useImageStatus(src)` 훅 — 사용자가 자체 UI 만들 때.
+11. theme light/dark (placeholder 색상).
+12. ImgHTMLAttributes pass-through (style, className 등).
+
+### Non-goals (v1)
+- 자동 srcSet / sizes — 사용자가 직접.
+- WebP 자동 변환.
+- 이미지 크롭 / resize 클라이언트 처리.
+- Next.js Image처럼 서버 변환.
+- progressive loading.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Image/Image.types.ts`
+
+```ts
+import type { CSSProperties, ImgHTMLAttributes, ReactNode } from "react";
+
+export type ImageFit = "cover" | "contain" | "fill" | "none" | "scale-down";
+export type ImagePlaceholder = "skeleton" | "blur" | "none";
+export type ImageRadius = number | "full" | string;
+export type ImageStatus = "loading" | "loaded" | "error";
+export type ImageTheme = "light" | "dark";
+
+export interface ImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, "loading" | "placeholder"> {
+  src: string;
+  alt: string;
+  width?: number | string;
+  height?: number | string;
+  fit?: ImageFit;
+  radius?: ImageRadius;
+
+  fallbackSrc?: string;
+  fallback?: ReactNode;
+
+  lazy?: boolean;
+  placeholder?: ImagePlaceholder;
+  blurDataURL?: string;
+
+  theme?: ImageTheme;
+
+  onLoad?: () => void;
+  onError?: () => void;
+
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.2 useImageStatus 훅 — `src/components/Image/useImageStatus.ts`
+
+```ts
+export function useImageStatus(src: string): ImageStatus {
+  const [status, setStatus] = useState<ImageStatus>("loading");
+  useEffect(() => {
+    if (typeof Image === "undefined") return; // SSR
+    setStatus("loading");
+    const img = new window.Image();
+    img.onload = () => setStatus("loaded");
+    img.onerror = () => setStatus("error");
+    img.src = src;
+    return () => {
+      img.onload = null;
+      img.onerror = null;
+    };
+  }, [src]);
+  return status;
+}
+```
+
+### 2.3 Image 컴포넌트
+
+```tsx
+export function Image(props: ImageProps) {
+  const {
+    src, alt, width, height,
+    fit, radius,
+    fallbackSrc, fallback,
+    lazy = false, placeholder = "none", blurDataURL,
+    theme = "light",
+    onLoad, onError,
+    className, style,
+    ...rest
+  } = props;
+
+  const [status, setStatus] = useState<ImageStatus>("loading");
+  const [resolvedSrc, setResolvedSrc] = useState(src);
+
+  useEffect(() => {
+    setStatus("loading");
+    setResolvedSrc(src);
+  }, [src]);
+
+  const handleLoad = () => {
+    setStatus("loaded");
+    onLoad?.();
+  };
+  const handleError = () => {
+    if (fallbackSrc && resolvedSrc === src) {
+      setResolvedSrc(fallbackSrc);
+      return;
+    }
+    setStatus("error");
+    onError?.();
+  };
+
+  const radiusStyle = radius === "full" ? "50%" : typeof radius === "number" ? `${radius}px` : radius;
+
+  const containerStyle: CSSProperties = {
+    position: "relative",
+    display: "inline-block",
+    overflow: "hidden",
+    borderRadius: radiusStyle,
+    ...(width !== undefined ? { width: typeof width === "number" ? `${width}px` : width } : {}),
+    ...(height !== undefined ? { height: typeof height === "number" ? `${height}px` : height } : {}),
+    background: placeholder === "skeleton" ? (theme === "dark" ? "#374151" : "#f3f4f6") : undefined,
+    ...style,
+  };
+
+  const imgStyle: CSSProperties = {
+    width: "100%",
+    height: "100%",
+    display: "block",
+    ...(fit ? { objectFit: fit } : {}),
+    opacity: status === "loaded" ? 1 : 0,
+    transition: "opacity 200ms ease",
+  };
+
+  // 에러 상태 — fallback 노드 우선, 없으면 placeholder
+  if (status === "error") {
+    if (fallback) {
+      return <div className={className} style={containerStyle}>{fallback}</div>;
+    }
+    return (
+      <div className={className} style={{ ...containerStyle, display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <Icon name="error" size="lg" />
+      </div>
+    );
+  }
+
+  // blur placeholder
+  const blurOverlay = placeholder === "blur" && blurDataURL && status === "loading" ? (
+    <img
+      src={blurDataURL}
+      alt=""
+      aria-hidden="true"
+      style={{
+        position: "absolute", inset: 0, width: "100%", height: "100%",
+        objectFit: fit ?? "cover",
+        filter: "blur(20px)",
+        transform: "scale(1.1)",
+      }}
+    />
+  ) : null;
+
+  return (
+    <span className={className} style={containerStyle}>
+      {blurOverlay}
+      <img
+        src={resolvedSrc}
+        alt={alt}
+        loading={lazy ? "lazy" : undefined}
+        onLoad={handleLoad}
+        onError={handleError}
+        style={imgStyle}
+        {...rest}
+      />
+    </span>
+  );
+}
+```
+
+### 2.4 배럴
+
+```ts
+export { Image } from "./Image";
+export { useImageStatus } from "./useImageStatus";
+export type { ImageProps, ImageFit, ImagePlaceholder, ImageRadius, ImageStatus, ImageTheme } from "./Image.types";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/Image/
+├── Image.tsx
+├── Image.types.ts
+├── useImageStatus.ts
+└── index.ts
+```
+
+---
+
+## 4. 데모 페이지
+
+```tsx
+export function ImagePage() {
+  return (
+    <div>
+      <h1>Image</h1>
+
+      <Card.Root><Card.Header>Basic</Card.Header><Card.Body>
+        <Image src="https://picsum.photos/400/300" alt="Random" width={400} height={300} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>fit</Card.Header><Card.Body>
+        <HStack gap={16}>
+          {(["cover","contain","fill","scale-down"] as const).map(f => (
+            <div key={f} style={{textAlign:"center"}}>
+              <Image src="..." alt={f} width={150} height={150} fit={f} />
+              <p>{f}</p>
+            </div>
+          ))}
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>radius</Card.Header><Card.Body>
+        <HStack gap={16}>
+          <Image src="..." alt="" width={120} height={120} radius={0} />
+          <Image src="..." alt="" width={120} height={120} radius={12} />
+          <Image src="..." alt="" width={120} height={120} radius="full" />
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>fallback</Card.Header><Card.Body>
+        <Image src="https://broken-url.example.com/x.jpg" alt="broken" width={200} height={150} fallbackSrc="https://picsum.photos/200/150" />
+        <Image src="https://broken-url.example.com/y.jpg" alt="broken2" width={200} height={150} fallback={<p>이미지 없음</p>} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>lazy</Card.Header><Card.Body>
+        <p>스크롤 다운 시 로드</p>
+        <div style={{height:1200}} />
+        <Image src="..." alt="" lazy width={400} height={300} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>blur placeholder</Card.Header><Card.Body>
+        <Image src="..." alt="" width={400} height={300} placeholder="blur" blurDataURL="data:image/jpeg;base64,..." />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>skeleton placeholder</Card.Header><Card.Body>
+        <Image src="..." alt="" width={400} height={300} placeholder="skeleton" />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>useImageStatus 훅</Card.Header><Card.Body>
+        <CustomImageRenderer src="..." />
+      </Card.Body></Card.Root>
+    </div>
+  );
+}
+
+function CustomImageRenderer({ src }: { src: string }) {
+  const status = useImageStatus(src);
+  return <p>Status: {status}</p>;
+}
+```
+
+---
+
+## 5. 접근성
+
+- alt 필수 (typescript에서도). 빈 문자열이면 장식으로 처리 (`alt=""`).
+- 에러 fallback — alt 텍스트는 그대로 유지하지 않음 (fallback 컨텐츠 자체가 의미 표현).
+- blur overlay — `aria-hidden="true"` (장식).
+
+## 6. Edge cases
+
+- **src 변경**: useEffect로 status 리셋.
+- **fallbackSrc도 실패**: error 상태 → fallback ReactNode 또는 기본 아이콘.
+- **lazy + IntersectionObserver 미지원**: native loading="lazy"가 fallback (대부분의 모던 브라우저 지원).
+- **width/height 미지정**: intrinsic 사이즈 (CLS 위험 — 문서에 명시).
+- **빈 src ("")**: status가 영구 loading. v1은 사용자 책임.
+- **SSR**: useImageStatus는 useEffect 안 → 서버에서는 "loading" 그대로.
+
+---
+
+## 7. 구현 단계
+- Phase 1: 컴포넌트 + 훅
+- Phase 2: 데모
+- Phase 3: 정리
+
+## 8. 체크리스트
+- [ ] 4개 파일
+- [ ] typecheck/build
+- [ ] 모든 fit / radius / placeholder
+- [ ] fallback 작동
+- [ ] lazy 작동 (스크롤 검증)
+- [ ] candidates / README

--- a/docs/plans/032-confirminline-component.md
+++ b/docs/plans/032-confirminline-component.md
@@ -1,0 +1,466 @@
+# ConfirmInline 컴포넌트 설계문서
+
+## Context
+
+`ConfirmInline`은 **같은 버튼 자리에서 "한 번 더 클릭해서 확인"** 패턴을 구현한 컴포넌트.
+
+destructive 액션(삭제, 취소 등)에 모달 다이얼로그를 띄우는 것은 부담스러운 경우가 많음:
+- 인라인 위치(테이블 행 안 등)에서 모달은 컨텍스트 단절
+- 자주 반복되는 액션은 모달 = 마찰
+- 모바일에선 더 무거움
+
+대안: 첫 클릭 시 같은 자리에서 색상·텍스트만 변경 ("Click again to confirm"), 두 번째 클릭 시 실제 실행, 일정 시간 무클릭 시 idle 복귀.
+
+GitHub의 "Delete repository" 다이얼로그(타이핑 확인) vs Discord의 메시지 삭제 인라인 X (즉시 실행) 사이의 중간 — 가벼운 이중 확인.
+
+참고:
+- **Linear** — 이슈 삭제 시 인라인 "Click again" 패턴.
+- **GitHub** — 일부 minor destructive에 사용.
+- **VS Code** — workbench의 일부 액션에 사용.
+- **shadcn/ui** — confirm-on-click 패턴 (단순).
+
+본 레포 내부 참조:
+- `src/components/Button/` — 시각·키보드·disabled 패턴 참조.
+- `src/components/Icon/` (plan 023) — 아이콘 슬롯.
+- `src/components/_shared/` — timer 관리 패턴 참조.
+
+---
+
+## 0. TL;DR
+
+```tsx
+// 1. 가장 단순
+<ConfirmInline label="Delete" onConfirm={() => doDelete()} />
+// → 첫 클릭: "Click again to confirm" (빨간색)
+// → 둘째 클릭: onConfirm 호출
+// → 3초 무클릭: idle 복귀
+
+// 2. 라벨 커스터마이징
+<ConfirmInline
+  label="삭제"
+  confirmLabel="한 번 더 클릭하여 확인"
+  onConfirm={...}
+/>
+
+// 3. timeout 변경
+<ConfirmInline label="X" timeout={5000} onConfirm={...} />
+
+// 4. severity (색상)
+<ConfirmInline severity="warning" label="Cancel" onConfirm={...} />
+<ConfirmInline severity="error" label="Delete" onConfirm={...} /> {/* 기본 */}
+
+// 5. size / variant
+<ConfirmInline size="sm" variant="ghost" label="Remove" onConfirm={...} />
+
+// 6. 외부에서 reset 트리거
+const ref = useRef<ConfirmInlineHandle>(null);
+<ConfirmInline ref={ref} label="X" onConfirm={...} />
+ref.current?.reset();
+
+// 7. icon 슬롯
+<ConfirmInline icon={<Icon name="trash" />} label="Delete" onConfirm={...} />
+
+// 8. onPending 콜백 (pending 상태 진입 알림)
+<ConfirmInline
+  label="X"
+  onConfirm={...}
+  onPending={() => analytics.track("delete-pending")}
+/>
+```
+
+핵심 원칙:
+- **2-state**: idle ↔ pending. 외부 noop 동안 pending → timeout 후 idle 복귀.
+- **같은 자리**: 모달 없음. 버튼 자체가 변신.
+- **시각**: idle은 ghost/subtle, pending은 severity 색상 (기본 error=빨강).
+- **timeout 기본 3000ms** — 너무 짧으면 더블 클릭처럼 느낌, 너무 길면 인지 부담.
+- **focus blur 시 자동 reset** — 의도 없는 클릭 방지.
+- **a11y**: pending 상태 변화 시 `aria-live="polite"` 알림.
+- **Button 위에 얇게 — Button을 wrap하지 않고 자체 button**.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. `label` (idle), `confirmLabel` (pending), `onConfirm`.
+2. `timeout` 기본 3000.
+3. `severity: "default" | "warning" | "error"` — pending 색상.
+4. `variant: "primary" | "ghost" | "subtle"`.
+5. `size: "sm" | "md" | "lg"`.
+6. `theme: "light" | "dark"`.
+7. `icon` 슬롯.
+8. `disabled`.
+9. `onPending` 콜백 (pending 진입 시).
+10. `onCancel` 콜백 (timeout 자동 복귀 시).
+11. ref handle: `{ reset(): void; isPending: boolean }`.
+12. focus blur 시 자동 reset.
+13. 키보드 — Enter/Space 표준 button 동작. Esc → reset.
+14. a11y `aria-live`.
+
+### Non-goals (v1)
+- 사용자 타이핑 확인 ("Type DELETE to confirm") — Dialog 스타일 별도 (ConfirmDialog 후보).
+- 스와이프 확인 (모바일) — v1 없음.
+- 다단계 (3-click) — 2-click 고정.
+- 사용자 정의 progress bar (timeout 시각화) — v1.1+.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/ConfirmInline/ConfirmInline.types.ts`
+
+```ts
+import type { CSSProperties, ButtonHTMLAttributes, ReactNode } from "react";
+
+export type ConfirmInlineSize = "sm" | "md" | "lg";
+export type ConfirmInlineVariant = "primary" | "ghost" | "subtle";
+export type ConfirmInlineSeverity = "default" | "warning" | "error";
+export type ConfirmInlineTheme = "light" | "dark";
+export type ConfirmInlineState = "idle" | "pending";
+
+export interface ConfirmInlineHandle {
+  reset: () => void;
+  isPending: boolean;
+}
+
+export interface ConfirmInlineProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick"> {
+  label: string;
+  confirmLabel?: string;            // 기본 "Click again to confirm"
+  onConfirm: () => void;
+
+  timeout?: number;                 // 기본 3000
+  severity?: ConfirmInlineSeverity; // 기본 "error"
+  variant?: ConfirmInlineVariant;   // 기본 "ghost"
+  size?: ConfirmInlineSize;         // 기본 "md"
+  theme?: ConfirmInlineTheme;
+
+  icon?: ReactNode;
+
+  onPending?: () => void;
+  onCancel?: () => void;            // timeout 자동 복귀
+
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.2 컴포넌트 — `src/components/ConfirmInline/ConfirmInline.tsx`
+
+```tsx
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+
+const severityColors: Record<ConfirmInlineSeverity, Record<ConfirmInlineTheme, { bg: string; fg: string; border: string }>> = {
+  default: {
+    light: { bg: "#374151", fg: "#fff", border: "#374151" },
+    dark:  { bg: "#9ca3af", fg: "#0f172a", border: "#9ca3af" },
+  },
+  warning: {
+    light: { bg: "#f59e0b", fg: "#fff", border: "#f59e0b" },
+    dark:  { bg: "#fbbf24", fg: "#0f172a", border: "#fbbf24" },
+  },
+  error: {
+    light: { bg: "#dc2626", fg: "#fff", border: "#dc2626" },
+    dark:  { bg: "#ef4444", fg: "#0f172a", border: "#ef4444" },
+  },
+};
+
+const sizeStyles: Record<ConfirmInlineSize, { padding: string; fontSize: number; height: number; gap: number }> = {
+  sm: { padding: "0 8px", fontSize: 12, height: 24, gap: 4 },
+  md: { padding: "0 12px", fontSize: 13, height: 32, gap: 6 },
+  lg: { padding: "0 16px", fontSize: 14, height: 40, gap: 8 },
+};
+
+export const ConfirmInline = forwardRef<ConfirmInlineHandle, ConfirmInlineProps>((props, ref) => {
+  const {
+    label,
+    confirmLabel = "Click again to confirm",
+    onConfirm,
+    timeout = 3000,
+    severity = "error",
+    variant = "ghost",
+    size = "md",
+    theme = "light",
+    icon,
+    onPending,
+    onCancel,
+    disabled,
+    className,
+    style,
+    onBlur,
+    onKeyDown,
+    ...rest
+  } = props;
+
+  const [state, setState] = useState<ConfirmInlineState>("idle");
+  const timerRef = useRef<number | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    clearTimer();
+    setState((prev) => {
+      if (prev === "pending") onCancel?.();
+      return "idle";
+    });
+  }, [clearTimer, onCancel]);
+
+  // unmount cleanup
+  useEffect(() => {
+    return () => clearTimer();
+  }, [clearTimer]);
+
+  // ref handle
+  useImperativeHandle(ref, () => ({
+    reset,
+    isPending: state === "pending",
+  }), [reset, state]);
+
+  const handleClick = useCallback(() => {
+    if (disabled) return;
+    if (state === "idle") {
+      setState("pending");
+      onPending?.();
+      timerRef.current = window.setTimeout(() => {
+        setState("idle");
+        onCancel?.();
+        timerRef.current = null;
+      }, timeout);
+    } else {
+      // pending → confirm
+      clearTimer();
+      setState("idle");
+      onConfirm();
+    }
+  }, [disabled, state, timeout, onPending, onCancel, onConfirm, clearTimer]);
+
+  const handleBlur = useCallback((e: React.FocusEvent<HTMLButtonElement>) => {
+    onBlur?.(e);
+    if (state === "pending") reset();
+  }, [onBlur, state, reset]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLButtonElement>) => {
+    onKeyDown?.(e);
+    if (e.key === "Escape" && state === "pending") {
+      e.preventDefault();
+      reset();
+    }
+  }, [onKeyDown, state, reset]);
+
+  const sizeS = sizeStyles[size];
+  const palette = severityColors[severity][theme];
+
+  // variant + state별 스타일
+  let bg: string, fg: string, border: string;
+  if (state === "pending") {
+    bg = palette.bg;
+    fg = palette.fg;
+    border = palette.border;
+  } else {
+    if (variant === "primary") {
+      bg = palette.bg;
+      fg = palette.fg;
+      border = palette.border;
+    } else if (variant === "subtle") {
+      bg = theme === "dark" ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.04)";
+      fg = theme === "dark" ? "#e5e7eb" : "#374151";
+      border = "transparent";
+    } else { // ghost
+      bg = "transparent";
+      fg = theme === "dark" ? "#e5e7eb" : "#374151";
+      border = "transparent";
+    }
+  }
+
+  const buttonStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: sizeS.gap,
+    height: sizeS.height,
+    padding: sizeS.padding,
+    fontSize: sizeS.fontSize,
+    fontFamily: "inherit",
+    fontWeight: 500,
+    lineHeight: 1,
+    borderRadius: 6,
+    border: `1px solid ${border}`,
+    background: bg,
+    color: fg,
+    cursor: disabled ? "not-allowed" : "pointer",
+    opacity: disabled ? 0.5 : 1,
+    transition: "background 150ms ease, border-color 150ms ease, color 150ms ease",
+    userSelect: "none",
+    ...style,
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
+      disabled={disabled}
+      data-state={state}
+      data-severity={severity}
+      aria-live="polite"
+      className={className}
+      style={buttonStyle}
+      {...rest}
+    >
+      {icon}
+      <span>{state === "pending" ? confirmLabel : label}</span>
+    </button>
+  );
+});
+
+ConfirmInline.displayName = "ConfirmInline";
+```
+
+### 2.3 배럴
+
+```ts
+export { ConfirmInline } from "./ConfirmInline";
+export type {
+  ConfirmInlineProps,
+  ConfirmInlineHandle,
+  ConfirmInlineSize,
+  ConfirmInlineVariant,
+  ConfirmInlineSeverity,
+  ConfirmInlineState,
+  ConfirmInlineTheme,
+} from "./ConfirmInline.types";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/ConfirmInline/
+├── ConfirmInline.tsx
+├── ConfirmInline.types.ts
+└── index.ts
+```
+
+---
+
+## 4. 데모 페이지
+
+```tsx
+export function ConfirmInlinePage() {
+  const [count, setCount] = useState(0);
+  const ref = useRef<ConfirmInlineHandle>(null);
+
+  return (
+    <div>
+      <h1>ConfirmInline</h1>
+
+      <Card.Root><Card.Header>Basic — error</Card.Header><Card.Body>
+        <ConfirmInline label="Delete" onConfirm={() => setCount(c => c+1)} />
+        <p>Confirmed: {count}</p>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Severity</Card.Header><Card.Body>
+        <HStack gap={8}>
+          <ConfirmInline severity="default" label="Default" onConfirm={() => {}} />
+          <ConfirmInline severity="warning" label="Warning" onConfirm={() => {}} />
+          <ConfirmInline severity="error" label="Error" onConfirm={() => {}} />
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Variant</Card.Header><Card.Body>
+        <HStack gap={8}>
+          <ConfirmInline variant="primary" label="Primary" onConfirm={() => {}} />
+          <ConfirmInline variant="ghost" label="Ghost" onConfirm={() => {}} />
+          <ConfirmInline variant="subtle" label="Subtle" onConfirm={() => {}} />
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Size</Card.Header><Card.Body>
+        <HStack gap={8} align="center">
+          <ConfirmInline size="sm" label="Small" onConfirm={() => {}} />
+          <ConfirmInline size="md" label="Medium" onConfirm={() => {}} />
+          <ConfirmInline size="lg" label="Large" onConfirm={() => {}} />
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>With icon</Card.Header><Card.Body>
+        <ConfirmInline icon={<Icon name="trash" size="sm" />} label="Delete" onConfirm={() => {}} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>커스텀 라벨</Card.Header><Card.Body>
+        <ConfirmInline label="삭제" confirmLabel="한 번 더 클릭하여 확인" onConfirm={() => {}} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>timeout 변경</Card.Header><Card.Body>
+        <HStack gap={8}>
+          <ConfirmInline label="1s timeout" timeout={1000} onConfirm={() => {}} />
+          <ConfirmInline label="3s (default)" onConfirm={() => {}} />
+          <ConfirmInline label="10s" timeout={10000} onConfirm={() => {}} />
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>외부 reset</Card.Header><Card.Body>
+        <HStack gap={8}>
+          <ConfirmInline ref={ref} label="X" onConfirm={() => {}} />
+          <button onClick={() => ref.current?.reset()}>Reset</button>
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Disabled</Card.Header><Card.Body>
+        <ConfirmInline disabled label="Disabled" onConfirm={() => {}} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Dark theme</Card.Header><Card.Body style={{background:"#1f2937",padding:16}}>
+        <HStack gap={8}>
+          <ConfirmInline theme="dark" severity="error" label="Delete" onConfirm={() => {}} />
+          <ConfirmInline theme="dark" severity="warning" label="Cancel" onConfirm={() => {}} />
+        </HStack>
+      </Card.Body></Card.Root>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. 접근성
+
+- `<button>` 표준.
+- `aria-live="polite"` — 라벨 변경 시 알림.
+- Esc 키 → reset.
+- focus 잃으면 자동 reset (의도 없는 pending 상태 방지).
+- disabled 시 클릭/포커스 차단.
+
+---
+
+## 6. Edge cases
+
+- **빠른 더블클릭 (300ms 내)**: idle → pending → confirm 둘 다 처리됨. 정상 동작 (사용자가 빨리 두 번 누르면 즉시 확인).
+- **pending 중 prop 변화**: timeout 변경 시 기존 timer 취소 후 신규 timer (사용자 책임).
+- **focus 잃기 직전 enter**: blur가 onClick보다 먼저 발생할 수 있음 → reset 후 confirm 실패. 의도된 동작.
+- **컴포넌트 unmount 중 timer 진행**: cleanup으로 안전.
+- **disabled 변경 — pending 중**: pending이지만 disabled=true → 버튼 비활성. timeout은 그대로 진행.
+
+---
+
+## 7. 구현 단계
+- Phase 1: 컴포넌트
+- Phase 2: 데모
+- Phase 3: 정리
+
+## 8. 체크리스트
+- [ ] 3개 파일
+- [ ] typecheck/build
+- [ ] 모든 severity/variant/size 시각 정상 (light/dark)
+- [ ] timeout 자동 복귀
+- [ ] focus blur reset
+- [ ] Esc reset
+- [ ] ref reset
+- [ ] candidates / README

--- a/docs/plans/033-errorboundary-component.md
+++ b/docs/plans/033-errorboundary-component.md
@@ -1,0 +1,424 @@
+# ErrorBoundary 컴포넌트 설계문서
+
+## Context
+
+React error boundary + 스타일된 fallback UI를 표준화한 `ErrorBoundary` 컴포넌트 추가.
+
+React error boundary는 **클래스 컴포넌트로만** 가능 (hook으로 안 됨). 사용자가 매번 직접 작성하기 부담스러우므로 라이브러리에서 표준 fallback UI + reset 패턴을 제공.
+
+참고:
+- **react-error-boundary** (npm) — 가장 영향력. `ErrorBoundary` + `useErrorBoundary` + `withErrorBoundary` HOC + `FallbackComponent` prop.
+- **Sentry React Error Boundary** — Sentry 연동.
+- **Mantine** — `ErrorBoundary` 자체 미제공.
+- **shadcn/ui** — 자체 컴포넌트 미제공.
+
+본 레포 내부 참조:
+- `src/components/Icon/` (plan 023) — error 아이콘.
+- `src/components/Button/` — 재시도 버튼.
+
+---
+
+## 0. TL;DR
+
+```tsx
+// 1. 가장 단순
+<ErrorBoundary>
+  <RiskyComponent />
+</ErrorBoundary>
+
+// 2. 사용자 정의 fallback
+<ErrorBoundary fallback={<p>오류가 발생했습니다.</p>}>
+  <RiskyComponent />
+</ErrorBoundary>
+
+// 3. fallback render prop (error + reset 사용)
+<ErrorBoundary fallback={({ error, reset }) => (
+  <div>
+    <p>{error.message}</p>
+    <button onClick={reset}>다시 시도</button>
+  </div>
+)}>
+  <RiskyComponent />
+</ErrorBoundary>
+
+// 4. onError 콜백 (로깅/Sentry 등)
+<ErrorBoundary onError={(error, info) => Sentry.captureException(error)}>
+  <App />
+</ErrorBoundary>
+
+// 5. resetKeys — 외부 dependency 변경 시 자동 reset
+<ErrorBoundary resetKeys={[userId]}>
+  <UserProfile id={userId} />
+</ErrorBoundary>
+
+// 6. theme + 디버그 정보 토글
+<ErrorBoundary theme="dark" showDebugInfo>
+  <App />
+</ErrorBoundary>
+
+// 7. useErrorHandler 훅 — 자식 컴포넌트에서 명시적 throw
+function Inner() {
+  const handleError = useErrorHandler();
+  const fetchData = async () => {
+    try { await api.fetch(); }
+    catch (e) { handleError(e); } // ErrorBoundary로 전파
+  };
+}
+```
+
+핵심 원칙:
+- **클래스 컴포넌트** — React API 제약상 필수.
+- **기본 fallback UI** 제공 + 사용자 override 가능.
+- **`reset()` 메서드** — fallback에서 호출 시 children 다시 마운트 (state 리셋).
+- **`resetKeys`**: 키 배열 변경 시 자동 reset (data fetch 재시도 흔한 패턴).
+- **`onError` 콜백**: 로깅·모니터링 hook.
+- **fallback render prop** — error + reset 받아 자유 UI.
+- **`useErrorHandler` 훅**: 명시적 throw (try/catch 안에서 React tree에 전파).
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. `ErrorBoundary` 클래스 컴포넌트.
+2. `fallback`: ReactNode 또는 `({ error, reset, errorInfo }) => ReactNode`.
+3. 기본 fallback (사용자 미지정 시): "오류가 발생했습니다" + 재시도 버튼.
+4. `onError(error, errorInfo)` 콜백.
+5. `resetKeys: any[]` — 변경 시 자동 reset.
+6. `onReset()` 콜백.
+7. `theme: "light" | "dark"`.
+8. `showDebugInfo: boolean` — 기본 false. true면 error.message + stack 표시.
+9. `useErrorHandler()` 훅 — 자식에서 `throw` 외 명시적 에러 전파.
+10. `withErrorBoundary` HOC.
+
+### Non-goals (v1)
+- 비동기 에러 자동 캡처 (React 자체가 async error를 boundary에서 잡지 않음 — useErrorHandler로 우회).
+- Suspense boundary 자동 통합.
+- error reporting (Sentry 등) 자체 구현 — onError로 사용자 wiring.
+- nested boundary 자동 routing.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/ErrorBoundary/ErrorBoundary.types.ts`
+
+```ts
+import type { ErrorInfo, ReactNode } from "react";
+
+export type ErrorBoundaryTheme = "light" | "dark";
+
+export interface ErrorBoundaryFallbackProps {
+  error: Error;
+  errorInfo: ErrorInfo | null;
+  reset: () => void;
+}
+
+export type ErrorBoundaryFallback =
+  | ReactNode
+  | ((props: ErrorBoundaryFallbackProps) => ReactNode);
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ErrorBoundaryFallback;
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  onReset?: () => void;
+  resetKeys?: unknown[];
+  theme?: ErrorBoundaryTheme;
+  showDebugInfo?: boolean;
+}
+
+export interface ErrorBoundaryState {
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+}
+```
+
+### 2.2 컴포넌트 — `src/components/ErrorBoundary/ErrorBoundary.tsx`
+
+```tsx
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import type { ErrorBoundaryProps, ErrorBoundaryState } from "./ErrorBoundary.types";
+import { DefaultFallback } from "./DefaultFallback";
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null, errorInfo: null };
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.setState({ errorInfo });
+    this.props.onError?.(error, errorInfo);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    if (this.state.error && this.props.resetKeys) {
+      const keysChanged = !prevProps.resetKeys ||
+        this.props.resetKeys.length !== prevProps.resetKeys.length ||
+        this.props.resetKeys.some((k, i) => k !== prevProps.resetKeys![i]);
+      if (keysChanged) this.reset();
+    }
+  }
+
+  reset = () => {
+    this.setState({ error: null, errorInfo: null });
+    this.props.onReset?.();
+  };
+
+  render() {
+    const { error, errorInfo } = this.state;
+    const { children, fallback, theme = "light", showDebugInfo = false } = this.props;
+
+    if (error) {
+      const fbProps = { error, errorInfo, reset: this.reset };
+      if (typeof fallback === "function") return fallback(fbProps);
+      if (fallback !== undefined) return fallback;
+      return <DefaultFallback {...fbProps} theme={theme} showDebugInfo={showDebugInfo} />;
+    }
+
+    return children;
+  }
+}
+```
+
+### 2.3 DefaultFallback — `src/components/ErrorBoundary/DefaultFallback.tsx`
+
+```tsx
+import type { CSSProperties } from "react";
+import { Icon } from "../Icon";
+import type { ErrorBoundaryFallbackProps, ErrorBoundaryTheme } from "./ErrorBoundary.types";
+
+interface DefaultFallbackProps extends ErrorBoundaryFallbackProps {
+  theme: ErrorBoundaryTheme;
+  showDebugInfo: boolean;
+}
+
+const themes = {
+  light: { bg: "#fef2f2", border: "#fecaca", fg: "#7f1d1d", btnBg: "#dc2626", btnFg: "#fff" },
+  dark:  { bg: "#1f2937", border: "rgba(239,68,68,0.5)", fg: "#fca5a5", btnBg: "#ef4444", btnFg: "#0f172a" },
+} as const;
+
+export function DefaultFallback({ error, errorInfo, reset, theme, showDebugInfo }: DefaultFallbackProps) {
+  const t = themes[theme];
+
+  return (
+    <div role="alert" style={{
+      padding: 16, borderRadius: 8, border: `1px solid ${t.border}`,
+      background: t.bg, color: t.fg, fontFamily: "inherit",
+    }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+        <Icon name="error" size="lg" />
+        <strong style={{ fontSize: 14 }}>오류가 발생했습니다</strong>
+      </div>
+      <p style={{ margin: "4px 0", fontSize: 13 }}>{error.message}</p>
+      {showDebugInfo && (
+        <details style={{ marginTop: 8, fontSize: 11, fontFamily: "monospace" }}>
+          <summary style={{ cursor: "pointer" }}>Debug info</summary>
+          <pre style={{ whiteSpace: "pre-wrap", marginTop: 4 }}>{error.stack}</pre>
+          {errorInfo?.componentStack && (
+            <pre style={{ whiteSpace: "pre-wrap", marginTop: 4 }}>{errorInfo.componentStack}</pre>
+          )}
+        </details>
+      )}
+      <button
+        onClick={reset}
+        style={{
+          marginTop: 12, padding: "6px 12px", borderRadius: 4,
+          border: "none", background: t.btnBg, color: t.btnFg,
+          cursor: "pointer", fontSize: 13,
+        }}
+      >
+        다시 시도
+      </button>
+    </div>
+  );
+}
+```
+
+### 2.4 useErrorHandler — `src/components/ErrorBoundary/useErrorHandler.ts`
+
+```ts
+import { useCallback, useState } from "react";
+
+/**
+ * 자식 컴포넌트에서 명시적으로 에러를 ErrorBoundary로 전파.
+ *
+ * @example
+ *   const handleError = useErrorHandler();
+ *   try { await api.fetch(); } catch (e) { handleError(e); }
+ */
+export function useErrorHandler(): (error: unknown) => void {
+  const [, setError] = useState<Error | null>(null);
+
+  return useCallback((error: unknown) => {
+    setError(() => {
+      // setState 안에서 throw → React가 commit phase에 catch → ErrorBoundary로 전파
+      throw error instanceof Error ? error : new Error(String(error));
+    });
+  }, []);
+}
+```
+
+### 2.5 withErrorBoundary HOC
+
+```tsx
+import { ComponentType, type Ref, forwardRef } from "react";
+
+export function withErrorBoundary<P extends object>(
+  Component: ComponentType<P>,
+  boundaryProps?: Omit<ErrorBoundaryProps, "children">,
+): ComponentType<P> {
+  const Wrapped = forwardRef<unknown, P>((props, ref) => (
+    <ErrorBoundary {...boundaryProps}>
+      <Component {...props} ref={ref as Ref<any>} />
+    </ErrorBoundary>
+  ));
+  Wrapped.displayName = `withErrorBoundary(${Component.displayName ?? Component.name ?? "Anonymous"})`;
+  return Wrapped as ComponentType<P>;
+}
+```
+
+### 2.6 배럴
+
+```ts
+export { ErrorBoundary } from "./ErrorBoundary";
+export { useErrorHandler } from "./useErrorHandler";
+export { withErrorBoundary } from "./withErrorBoundary";
+export type {
+  ErrorBoundaryProps,
+  ErrorBoundaryFallback,
+  ErrorBoundaryFallbackProps,
+  ErrorBoundaryTheme,
+  ErrorBoundaryState,
+} from "./ErrorBoundary.types";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/ErrorBoundary/
+├── ErrorBoundary.tsx
+├── ErrorBoundary.types.ts
+├── DefaultFallback.tsx
+├── useErrorHandler.ts
+├── withErrorBoundary.tsx
+└── index.ts
+```
+
+---
+
+## 4. 데모 페이지
+
+```tsx
+function BuggyButton({ shouldFail }: { shouldFail: boolean }) {
+  if (shouldFail) throw new Error("의도적인 에러");
+  return <button>정상</button>;
+}
+
+export function ErrorBoundaryPage() {
+  const [fail, setFail] = useState(false);
+  const [resetKey, setResetKey] = useState(0);
+
+  return (
+    <div>
+      <h1>ErrorBoundary</h1>
+
+      <Card.Root><Card.Header>Basic — 기본 fallback</Card.Header><Card.Body>
+        <button onClick={() => setFail(true)}>에러 발생</button>
+        <ErrorBoundary onReset={() => setFail(false)}>
+          <BuggyButton shouldFail={fail} />
+        </ErrorBoundary>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>커스텀 fallback (render prop)</Card.Header><Card.Body>
+        <ErrorBoundary fallback={({ error, reset }) => (
+          <div style={{padding:12,background:"#fee",borderRadius:4}}>
+            <p>커스텀: {error.message}</p>
+            <button onClick={reset}>리셋</button>
+          </div>
+        )}>
+          <BuggyButton shouldFail={fail} />
+        </ErrorBoundary>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>resetKeys</Card.Header><Card.Body>
+        <button onClick={() => setResetKey(k => k+1)}>resetKey++</button>
+        <ErrorBoundary resetKeys={[resetKey]}>
+          <BuggyButton shouldFail={fail} />
+        </ErrorBoundary>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>showDebugInfo</Card.Header><Card.Body>
+        <ErrorBoundary showDebugInfo>
+          <BuggyButton shouldFail={fail} />
+        </ErrorBoundary>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>useErrorHandler 훅</Card.Header><Card.Body>
+        <ErrorBoundary>
+          <AsyncFetcher />
+        </ErrorBoundary>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Dark theme</Card.Header><Card.Body>
+        <ErrorBoundary theme="dark">
+          <BuggyButton shouldFail={fail} />
+        </ErrorBoundary>
+      </Card.Body></Card.Root>
+    </div>
+  );
+}
+
+function AsyncFetcher() {
+  const handleError = useErrorHandler();
+  return (
+    <button onClick={() => {
+      try { throw new Error("async!"); }
+      catch (e) { handleError(e); }
+    }}>
+      async 에러 트리거
+    </button>
+  );
+}
+```
+
+---
+
+## 5. 접근성
+
+- DefaultFallback: `role="alert"` — 에러 발생 시 자동 스크린리더 알림.
+- 재시도 버튼: 표준 button.
+- showDebugInfo의 `<details>`: 키보드 펼침/접힘.
+
+---
+
+## 6. Edge cases
+
+- **이벤트 핸들러 안 에러**: React boundary가 catch 안 함 — useErrorHandler로 명시 전파 필요.
+- **비동기 (setTimeout, promise)**: 동일. useErrorHandler 사용.
+- **render 중 에러 무한 반복**: 사용자 책임. v1 미보호.
+- **resetKeys 함수 비교**: shallow compare. 함수면 매번 다름 → 무한 리셋. 사용자 책임.
+- **부모 ErrorBoundary가 자식 ErrorBoundary 잡음**: React가 가장 가까운 boundary로 전파 — 자식이 먼저 잡음 정상.
+- **SSR**: getDerivedStateFromError + componentDidCatch는 서버에서도 정상 작동.
+
+---
+
+## 7. 구현 단계
+- Phase 1: 컴포넌트 + 훅 + HOC
+- Phase 2: 데모
+- Phase 3: 정리
+
+## 8. 체크리스트
+- [ ] 6개 파일
+- [ ] typecheck/build
+- [ ] 기본 fallback 작동
+- [ ] 커스텀 fallback (node + render prop) 작동
+- [ ] resetKeys 자동 리셋
+- [ ] useErrorHandler 작동
+- [ ] showDebugInfo 토글
+- [ ] dark theme
+- [ ] candidates / README

--- a/docs/plans/034-smartsearch-component.md
+++ b/docs/plans/034-smartsearch-component.md
@@ -1,0 +1,504 @@
+# SmartSearch 컴포넌트 설계문서
+
+## Context
+
+`SmartSearch`는 **`key:value` 토큰 + 연산자 기반 쿼리 빌더**.
+
+GitHub issues, Linear, Sentry 등에서 보이는 검색 패턴:
+```
+status:open assignee:alice priority:>=high label:bug created:>2026-01-01
+```
+
+자유 텍스트 입력에 토큰화된 쿼리 + 자동완성을 결합한 UI.
+
+native `<input>` + 단순 텍스트 검색만으로는 부족하고, CommandPalette는 다른 영역 (액션 실행 중심).
+
+참고:
+- **GitHub search bar** — `is:open author:foo label:bug`.
+- **Linear** — 더 풍부 (date 비교, multi-value).
+- **Sentry** — `is:resolved release:[2.0,2.1] !user.email:foo@bar`.
+- **Atlassian Jira JQL** — 전체 query language (지나치게 복잡).
+- **Radix combobox + tokenizer** — 자체 구현 패턴.
+- **react-search-autocomplete** — 단순 문자 매칭.
+
+본 레포 내부 참조:
+- `src/components/Combobox/` (설계됨, 014) — 자동완성 인프라 일부 활용 가능.
+- `src/components/Tag/` (plan 027) — 토큰 시각화에 사용.
+- `src/components/_shared/useFloating.ts` — 자동완성 드롭다운 floating.
+
+---
+
+## 0. TL;DR
+
+```tsx
+// 1. 기본 — 토큰 키 정의
+<SmartSearch
+  schema={{
+    keys: ["status", "assignee", "label", "priority"],
+    valuesByKey: {
+      status: ["open", "closed", "in-progress"],
+      priority: ["low", "medium", "high"],
+    },
+  }}
+  onQueryChange={(q) => doSearch(q)}
+/>
+
+// 2. controlled
+<SmartSearch
+  value={query}
+  onValueChange={setQuery}
+  schema={schema}
+/>
+
+// 3. 토큰 시각화 (chip vs text)
+<SmartSearch tokenStyle="chip" />  // 기본 — 칩 형태
+<SmartSearch tokenStyle="text" />  // 일반 텍스트 (모노스페이스)
+
+// 4. 비동기 value 자동완성
+<SmartSearch
+  schema={{
+    keys: ["assignee"],
+    asyncValues: async (key, q) => {
+      if (key === "assignee") return await api.searchUsers(q);
+      return [];
+    },
+  }}
+/>
+
+// 5. 연산자 (>=, <=, !)
+<SmartSearch
+  schema={{
+    keys: ["priority", "created"],
+    operators: { priority: ["=", ">=", "<="], created: [">", "<"] },
+  }}
+/>
+
+// 6. 파싱된 쿼리 출력
+<SmartSearch onParsedChange={(parsed) => {
+  // parsed: { tokens: [{key, op, value, raw}, ...], freeText: "..." }
+}} />
+```
+
+핵심 원칙:
+- **토큰 + 자유 텍스트 혼합**: `status:open foo bar` → 토큰 1 + freeText "foo bar".
+- **시각**: 칩 형태가 기본 (Tag 컴포넌트 활용).
+- **자동완성**: 키 입력 시 키 후보 → 콜론 후 값 후보 → 완료 후 토큰 칩.
+- **키보드 네비**: ↑/↓ 자동완성 이동, Enter 선택, Tab 자동완성, Backspace 토큰 삭제.
+- **schema 기반 검증** — 알려진 키만 허용 옵션.
+- **연산자**: `>`, `<`, `>=`, `<=`, `!` (negation), 기본 `=`.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. 텍스트 입력 + 토큰 칩 혼합 표시.
+2. `schema`: keys 화이트리스트 + valuesByKey + operators.
+3. 자동완성 드롭다운 (키, 값, 연산자).
+4. 비동기 값 (`asyncValues`).
+5. 파싱: `{ tokens: ParsedToken[], freeText: string }` 형태로 export.
+6. controlled (`value`, `onValueChange`) / uncontrolled.
+7. 토큰 시각: chip / text.
+8. 키보드 네비: Arrow up/down, Enter, Tab, Backspace, Esc.
+9. theme light/dark.
+10. placeholder.
+11. 클릭으로 토큰 제거.
+12. 입력 도중 invalid token 시각 표시.
+
+### Non-goals (v1)
+- 복합 boolean (`AND`, `OR`, 괄호) — v2.
+- 정규식 검색.
+- 자동 추천 (스마트 hint) — v1.1+.
+- 검색 history.
+- 모바일 키보드 최적화.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/SmartSearch/SmartSearch.types.ts`
+
+```ts
+export type SmartSearchOperator = "=" | "!=" | ">" | "<" | ">=" | "<=" | "!";
+export type SmartSearchTheme = "light" | "dark";
+export type SmartSearchTokenStyle = "chip" | "text";
+
+export interface SmartSearchSchema {
+  keys: string[];
+  valuesByKey?: Partial<Record<string, string[]>>;
+  asyncValues?: (key: string, query: string) => Promise<string[]>;
+  operators?: Partial<Record<string, SmartSearchOperator[]>>;
+  /** 알 수 없는 키 허용 여부. 기본 true (자유 입력). */
+  allowUnknownKeys?: boolean;
+}
+
+export interface ParsedToken {
+  key: string;
+  operator: SmartSearchOperator;
+  value: string;
+  raw: string;        // 원본 문자열 (예: "status:open")
+  start: number;      // value 문자열 내 위치
+  end: number;
+}
+
+export interface ParsedQuery {
+  tokens: ParsedToken[];
+  freeText: string;
+}
+
+export interface SmartSearchProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  onQueryChange?: (parsed: ParsedQuery) => void;
+
+  schema?: SmartSearchSchema;
+
+  placeholder?: string;
+  tokenStyle?: SmartSearchTokenStyle;
+  theme?: SmartSearchTheme;
+  disabled?: boolean;
+
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.2 파서 — `src/components/SmartSearch/SmartSearch.parser.ts`
+
+```ts
+const TOKEN_REGEX = /(\w+)(=|!=|>=|<=|>|<|:!|:)((?:"[^"]*"|\S+))/g;
+
+export function parseQuery(input: string): ParsedQuery {
+  const tokens: ParsedToken[] = [];
+  let lastIndex = 0;
+  let freeText = "";
+
+  let match;
+  // copy regex
+  const re = new RegExp(TOKEN_REGEX.source, "g");
+  while ((match = re.exec(input)) !== null) {
+    const [raw, key, opRaw, valRaw] = match;
+    let operator: SmartSearchOperator;
+    if (opRaw === ":") operator = "=";
+    else if (opRaw === ":!") operator = "!=";
+    else operator = opRaw as SmartSearchOperator;
+
+    const value = valRaw!.replace(/^"|"$/g, ""); // unquote
+
+    // freeText 누적 (직전 위치까지)
+    freeText += input.slice(lastIndex, match.index);
+    lastIndex = match.index + raw!.length;
+
+    tokens.push({
+      key: key!,
+      operator,
+      value,
+      raw: raw!,
+      start: match.index,
+      end: match.index + raw!.length,
+    });
+  }
+  freeText += input.slice(lastIndex);
+  freeText = freeText.trim().replace(/\s+/g, " ");
+
+  return { tokens, freeText };
+}
+```
+
+### 2.3 컴포넌트 (개요) — `src/components/SmartSearch/SmartSearch.tsx`
+
+전체 구현은 길어 핵심만 요약. (실제 작성 시 ~500줄)
+
+```tsx
+export function SmartSearch(props: SmartSearchProps) {
+  const {
+    value: controlledValue, defaultValue = "", onValueChange, onQueryChange,
+    schema, placeholder = "Search...", tokenStyle = "chip", theme = "light",
+    disabled, className, style,
+  } = props;
+
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const value = controlledValue ?? internalValue;
+  const setValue = (v: string) => {
+    if (controlledValue === undefined) setInternalValue(v);
+    onValueChange?.(v);
+  };
+
+  // 파싱
+  const parsed = useMemo(() => parseQuery(value), [value]);
+  useEffect(() => {
+    onQueryChange?.(parsed);
+  }, [parsed, onQueryChange]);
+
+  // 자동완성
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  // 현재 caret 위치 기반 — 어떤 종류의 자동완성을 보일지 결정
+  const [caretPos, setCaretPos] = useState(0);
+  const completionContext = useMemo(() => analyzeContext(value, caretPos, schema), [value, caretPos, schema]);
+  // completionContext: { type: "key" | "value" | "operator", currentToken: ... }
+
+  // 자동완성 후보 생성
+  useEffect(() => {
+    if (!schema) { setSuggestions([]); return; }
+    if (completionContext.type === "key") {
+      const partial = completionContext.partial.toLowerCase();
+      setSuggestions(schema.keys.filter((k) => k.toLowerCase().includes(partial)));
+    } else if (completionContext.type === "value") {
+      const key = completionContext.key;
+      const partial = completionContext.partial.toLowerCase();
+      const staticVals = schema.valuesByKey?.[key] ?? [];
+      const filtered = staticVals.filter((v) => v.toLowerCase().includes(partial));
+      setSuggestions(filtered);
+      // async values
+      if (schema.asyncValues) {
+        schema.asyncValues(key, partial).then((async) => {
+          setSuggestions([...filtered, ...async]);
+        });
+      }
+    } else {
+      setSuggestions([]);
+    }
+  }, [completionContext, schema]);
+
+  const handleSelect = (suggestion: string) => {
+    // 현재 caret 위치의 token을 suggestion으로 교체
+    const next = applySuggestion(value, caretPos, suggestion, completionContext);
+    setValue(next);
+    setOpen(false);
+    inputRef.current?.focus();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (!open) {
+      // open 트리거 (입력 시작 등)
+      return;
+    }
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex((i) => Math.min(i + 1, suggestions.length - 1));
+        return;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(i - 1, 0));
+        return;
+      case "Enter":
+        if (suggestions[activeIndex]) {
+          e.preventDefault();
+          handleSelect(suggestions[activeIndex]!);
+        }
+        return;
+      case "Tab":
+        if (suggestions[activeIndex]) {
+          e.preventDefault();
+          handleSelect(suggestions[activeIndex]!);
+        }
+        return;
+      case "Escape":
+        setOpen(false);
+        return;
+    }
+  };
+
+  // 토큰 칩 + 자유 텍스트 시각 렌더링
+  // chip 스타일은 토큰만 칩으로 표시, 사용자 입력은 textarea/input으로
+  // 단순화 위해 v1은 단일 textarea + overlay positioning 회피 → 단순 input.
+
+  return (
+    <div className={className} style={{position:"relative", ...style}}>
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => { setValue(e.target.value); setOpen(true); setCaretPos(e.target.selectionStart ?? 0); }}
+        onKeyDown={handleKeyDown}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        onSelect={(e) => setCaretPos((e.target as HTMLInputElement).selectionStart ?? 0)}
+        placeholder={placeholder}
+        disabled={disabled}
+        style={{ width: "100%", padding: 8, fontSize: 13, fontFamily: "monospace" }}
+      />
+      {open && suggestions.length > 0 && (
+        <div role="listbox" style={{
+          position:"absolute", top:"100%", left:0, right:0, background: theme === "dark" ? "#1f2937" : "#fff",
+          border: "1px solid #ddd", borderRadius: 4, boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
+          maxHeight: 240, overflowY: "auto", zIndex: 10,
+        }}>
+          {suggestions.map((s, i) => (
+            <div
+              key={s}
+              role="option"
+              aria-selected={i === activeIndex}
+              onMouseDown={(e) => { e.preventDefault(); handleSelect(s); }}
+              style={{
+                padding: "6px 10px",
+                background: i === activeIndex ? (theme==="dark"?"#374151":"#f3f4f6") : "transparent",
+                cursor: "pointer",
+              }}
+            >
+              {s}
+            </div>
+          ))}
+        </div>
+      )}
+      {/* tokenStyle="chip" 시 토큰 시각화는 별도 overlay (v1.1+ 검토 — v1은 단순 텍스트 + 자동완성만) */}
+    </div>
+  );
+}
+```
+
+### 2.4 분석 헬퍼 — analyzeContext
+
+```ts
+interface CompletionContext {
+  type: "key" | "value" | "operator" | "none";
+  partial: string;
+  key?: string;
+}
+
+function analyzeContext(value: string, caretPos: number, schema?: SmartSearchSchema): CompletionContext {
+  // caret 위치 기준 직전 단어 추출
+  const before = value.slice(0, caretPos);
+  const lastSpace = before.lastIndexOf(" ");
+  const token = before.slice(lastSpace + 1);
+
+  // ":" 포함이면 value 자동완성
+  const colonIdx = token.indexOf(":");
+  if (colonIdx >= 0) {
+    return {
+      type: "value",
+      key: token.slice(0, colonIdx),
+      partial: token.slice(colonIdx + 1),
+    };
+  }
+  // operator (>=, <= 등) 포함이면 value 자동완성
+  const opMatch = token.match(/^(\w+)(>=|<=|>|<|!=|=)(.*)$/);
+  if (opMatch) {
+    return {
+      type: "value",
+      key: opMatch[1]!,
+      partial: opMatch[3]!,
+    };
+  }
+
+  // 그 외 — key 자동완성
+  return {
+    type: "key",
+    partial: token,
+  };
+}
+
+function applySuggestion(value: string, caretPos: number, suggestion: string, ctx: CompletionContext): string {
+  const before = value.slice(0, caretPos);
+  const after = value.slice(caretPos);
+  const lastSpace = before.lastIndexOf(" ");
+  const tokenStart = lastSpace + 1;
+
+  if (ctx.type === "key") {
+    return value.slice(0, tokenStart) + suggestion + ":" + after;
+  } else if (ctx.type === "value") {
+    return value.slice(0, tokenStart) + ctx.key + ":" + suggestion + " " + after;
+  }
+  return value;
+}
+```
+
+### 2.5 배럴
+
+```ts
+export { SmartSearch } from "./SmartSearch";
+export { parseQuery } from "./SmartSearch.parser";
+export type { SmartSearchProps, SmartSearchSchema, ParsedQuery, ParsedToken, SmartSearchOperator, SmartSearchTheme, SmartSearchTokenStyle } from "./SmartSearch.types";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/SmartSearch/
+├── SmartSearch.tsx
+├── SmartSearch.parser.ts
+├── SmartSearch.types.ts
+└── index.ts
+```
+
+---
+
+## 4. 데모 페이지
+
+```tsx
+const SCHEMA: SmartSearchSchema = {
+  keys: ["status", "assignee", "label", "priority", "created"],
+  valuesByKey: {
+    status: ["open", "closed", "in-progress"],
+    label: ["bug", "feature", "docs"],
+    priority: ["low", "medium", "high"],
+  },
+  operators: { priority: ["=", ">=", "<="], created: [">", "<"] },
+};
+
+export function SmartSearchPage() {
+  const [parsed, setParsed] = useState<ParsedQuery | null>(null);
+  return (
+    <div>
+      <h1>SmartSearch</h1>
+      <Card.Root><Card.Header>Basic</Card.Header><Card.Body>
+        <SmartSearch schema={SCHEMA} onQueryChange={setParsed} placeholder="status:open author:..." />
+        <pre style={{marginTop:12,fontSize:12}}>{JSON.stringify(parsed, null, 2)}</pre>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Async values</Card.Header><Card.Body>
+        <SmartSearch schema={{
+          ...SCHEMA,
+          asyncValues: async (key, q) => key === "assignee" ? ["alice","bob","charlie"].filter(u => u.includes(q)) : [],
+        }} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Dark</Card.Header><Card.Body style={{background:"#1f2937",padding:16}}>
+        <SmartSearch theme="dark" schema={SCHEMA} />
+      </Card.Body></Card.Root>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. 접근성
+
+- input: `role="combobox"`, `aria-expanded`, `aria-controls`.
+- 자동완성 드롭다운: `role="listbox"`, 항목 `role="option" aria-selected`.
+- 키보드 네비 표준.
+
+---
+
+## 6. Edge cases
+
+- **콜론만 입력**: `status:` → value 자동완성 (빈 partial).
+- **따옴표 값**: `label:"good first issue"` — 파서가 따옴표 안 공백 보존.
+- **숫자 비교**: `priority:>=5` — 문자열로 처리. 사용자가 컨슈머에서 number로 변환.
+- **알 수 없는 키 + allowUnknownKeys=false**: 토큰 시각으로 invalid 표시 (v1은 단순 텍스트 입력 — 시각 검증 v1.1+).
+- **빈 입력**: parsed.tokens=[], freeText="".
+
+---
+
+## 7. 구현 단계
+- Phase 1: 파서 + 컴포넌트
+- Phase 2: 데모
+- Phase 3: 정리
+
+## 8. 체크리스트
+- [ ] 4개 파일
+- [ ] typecheck/build
+- [ ] parseQuery 단위 정확
+- [ ] key/value/operator 자동완성
+- [ ] 키보드 네비
+- [ ] async values
+- [ ] candidates / README

--- a/docs/plans/035-qrcode-component.md
+++ b/docs/plans/035-qrcode-component.md
@@ -1,0 +1,307 @@
+# QRCode 컴포넌트 설계문서
+
+## Context
+
+텍스트/URL을 SVG 기반 QR code로 렌더링하는 `QRCode` 컴포넌트.
+
+자체 구현 vs 라이브러리 의존 결정:
+- **option A — 자체 구현**: QR 알고리즘은 ISO/IEC 18004 표준이지만 정확한 구현은 비용 큼 (Reed-Solomon 에러 코드 + 마스킹 + 인코딩 모드 4종).
+- **option B — qrcode-generator (npm, ~10kb)**: 가장 가볍고 의존 없음.
+- **option C — qrcode (npm, ~50kb)**: 풀 기능 (canvas/svg/string 변환).
+
+**결정**: option B — `qrcode-generator` 사용. 단일 의존, MIT, ~10kb gzipped, ESM 호환. 자체 구현은 라이브러리 정체성과 안 맞고 (UI 라이브러리), 검증된 알고리즘이 더 안전.
+
+참고:
+- **react-qr-code** — `qrcode.react` 또는 자체 구현. 다양한 패키지 존재.
+- **Mantine** — 자체 미제공, 외부 의존.
+- **Mantine UI 호환 패턴** — value, size, level, fgColor, bgColor 표준 props.
+
+본 레포 내부 참조:
+- `package.json` — peer dependencies 검토 (qrcode-generator 추가).
+- `src/components/Image/` (plan 031) — fallback 패턴 참고.
+
+---
+
+## 0. TL;DR
+
+```tsx
+// 1. 가장 단순
+<QRCode value="https://example.com" />
+
+// 2. 사이즈
+<QRCode value="..." size={240} />
+
+// 3. error correction level
+<QRCode value="..." level="H" /> // H = highest, L/M/Q/H
+
+// 4. 색상
+<QRCode value="..." fgColor="#3b82f6" bgColor="#fff" />
+
+// 5. margin (quiet zone)
+<QRCode value="..." margin={4} />
+
+// 6. 중앙 로고
+<QRCode value="https://example.com" level="H">
+  <img src="/logo.png" width={48} height={48} />
+</QRCode>
+
+// 7. label (스크린리더)
+<QRCode value="..." label="결제 QR" />
+```
+
+핵심 원칙:
+- **SVG 출력** — 벡터, 무한 확대, 인쇄 안전.
+- **error correction**: L (~7%) / M (~15%) / Q (~25%) / H (~30%).
+- **중앙 로고 슬롯**: children 사용 시 가운데 absolute 배치 (logo 크기는 사용자 책임, level=H 권장).
+- **최대한 단순**: prop 적게.
+- **a11y**: `role="img"` + `aria-label`.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. value (string).
+2. size (number, px).
+3. level: "L" | "M" | "Q" | "H".
+4. fgColor, bgColor.
+5. margin (모듈 단위, default 4).
+6. children 슬롯 (중앙 로고).
+7. label (a11y).
+8. 외부 의존: `qrcode-generator`.
+
+### Non-goals (v1)
+- Canvas 출력.
+- PNG export 버튼 (별도 합성).
+- 동적 데이터 인코딩 모드 자동 선택.
+- byte 모드 외 (numeric/alphanumeric/kanji 자동 선택은 라이브러리가 처리).
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/QRCode/QRCode.types.ts`
+
+```ts
+import type { CSSProperties, ReactNode } from "react";
+
+export type QRCodeLevel = "L" | "M" | "Q" | "H";
+
+export interface QRCodeProps {
+  value: string;
+  size?: number;             // 기본 200
+  level?: QRCodeLevel;        // 기본 "M"
+  fgColor?: string;           // 기본 "#000"
+  bgColor?: string;           // 기본 "#fff"
+  margin?: number;            // 모듈 단위. 기본 4
+  label?: string;             // a11y aria-label
+  children?: ReactNode;       // 중앙 로고
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.2 컴포넌트 — `src/components/QRCode/QRCode.tsx`
+
+```tsx
+import { useMemo } from "react";
+// @ts-expect-error: qrcode-generator는 default export
+import qrcodeGenerator from "qrcode-generator";
+import type { QRCodeProps } from "./QRCode.types";
+
+export function QRCode(props: QRCodeProps) {
+  const {
+    value, size = 200, level = "M",
+    fgColor = "#000", bgColor = "#fff",
+    margin = 4, label, children,
+    className, style,
+  } = props;
+
+  const matrix = useMemo(() => {
+    // qrcode-generator 사용
+    const qr = qrcodeGenerator(0, level); // 0 = type number 자동
+    qr.addData(value);
+    qr.make();
+    const moduleCount = qr.getModuleCount();
+    const m: boolean[][] = [];
+    for (let r = 0; r < moduleCount; r++) {
+      const row: boolean[] = [];
+      for (let c = 0; c < moduleCount; c++) {
+        row.push(qr.isDark(r, c));
+      }
+      m.push(row);
+    }
+    return m;
+  }, [value, level]);
+
+  const moduleCount = matrix.length;
+  const totalModules = moduleCount + margin * 2;
+  const modulePx = size / totalModules;
+
+  return (
+    <div
+      role="img"
+      aria-label={label ?? `QR code for ${value}`}
+      className={className}
+      style={{
+        position: "relative",
+        display: "inline-block",
+        width: size, height: size,
+        background: bgColor,
+        ...style,
+      }}
+    >
+      <svg
+        viewBox={`0 0 ${totalModules} ${totalModules}`}
+        width={size}
+        height={size}
+        style={{ display: "block" }}
+        aria-hidden="true"
+      >
+        <rect width={totalModules} height={totalModules} fill={bgColor} />
+        {matrix.flatMap((row, r) =>
+          row.map((dark, c) => dark ? (
+            <rect
+              key={`${r}-${c}`}
+              x={c + margin}
+              y={r + margin}
+              width={1}
+              height={1}
+              fill={fgColor}
+            />
+          ) : null)
+        )}
+      </svg>
+      {children && (
+        <div style={{
+          position: "absolute",
+          top: "50%", left: "50%",
+          transform: "translate(-50%, -50%)",
+          background: bgColor,
+          padding: 4,
+          borderRadius: 4,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+### 2.3 배럴
+
+```ts
+export { QRCode } from "./QRCode";
+export type { QRCodeProps, QRCodeLevel } from "./QRCode.types";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/QRCode/
+├── QRCode.tsx
+├── QRCode.types.ts
+└── index.ts
+```
+
+---
+
+## 4. package.json 추가
+
+```json
+"dependencies": {
+  "qrcode-generator": "^1.4.4",
+  ...기존
+}
+```
+
+---
+
+## 5. 데모 페이지
+
+```tsx
+export function QRCodePage() {
+  return (
+    <div>
+      <h1>QRCode</h1>
+      <Card.Root><Card.Header>Basic</Card.Header><Card.Body>
+        <QRCode value="https://example.com" />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Sizes</Card.Header><Card.Body>
+        <HStack gap={16}>
+          <QRCode value="A" size={80} />
+          <QRCode value="A" size={150} />
+          <QRCode value="A" size={240} />
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Error correction levels</Card.Header><Card.Body>
+        <HStack gap={16}>
+          {(["L","M","Q","H"] as const).map(l => (
+            <div key={l} style={{textAlign:"center"}}>
+              <QRCode value="https://example.com" level={l} />
+              <p>{l}</p>
+            </div>
+          ))}
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>색상</Card.Header><Card.Body>
+        <HStack gap={16}>
+          <QRCode value="A" fgColor="#3b82f6" />
+          <QRCode value="A" fgColor="#10b981" />
+          <QRCode value="A" fgColor="#fff" bgColor="#0f172a" />
+        </HStack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>중앙 로고</Card.Header><Card.Body>
+        <QRCode value="https://example.com" level="H" size={200}>
+          <div style={{width:40,height:40,background:"#3b82f6",borderRadius:4,display:"flex",alignItems:"center",justifyContent:"center",color:"#fff",fontWeight:700}}>P</div>
+        </QRCode>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>긴 텍스트</Card.Header><Card.Body>
+        <QRCode value="The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog." level="L" />
+      </Card.Body></Card.Root>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. 접근성
+
+- `role="img"` + `aria-label` (필수 — 라벨 미지정 시 value 사용).
+- 내부 SVG는 `aria-hidden="true"` (장식).
+
+---
+
+## 7. Edge cases
+
+- **빈 value**: `qrcode-generator`가 어떻게 처리하는지 확인 필요. 빈 매트릭스 또는 에러. → 권장: value 빈 문자열 시 placeholder div 표시 (v1 단순 — 사용자 책임).
+- **매우 긴 value (~3000자+)**: type number 자동 증가. 너무 길면 라이브러리 에러 throw → ErrorBoundary로 처리.
+- **유니코드/한글**: byte 모드 자동 선택 → UTF-8 인코딩.
+- **중앙 로고가 너무 큼**: QR 인식 실패. level=H 권장 + 로고 크기 ≤ 25% 사이즈.
+
+---
+
+## 8. 구현 단계
+- Phase 1: package.json 의존 추가 + 컴포넌트
+- Phase 2: 데모
+- Phase 3: 정리
+
+## 9. 체크리스트
+- [ ] 3개 파일 + package.json
+- [ ] typecheck/build
+- [ ] 다양한 사이즈/level/색상 시각 확인
+- [ ] 실제 QR 스캐너로 인식 확인
+- [ ] 중앙 로고 표시 + level=H 인식 검증
+- [ ] candidates / README

--- a/docs/plans/036-changelog-component.md
+++ b/docs/plans/036-changelog-component.md
@@ -1,0 +1,428 @@
+# Changelog 컴포넌트 설계문서
+
+## Context
+
+버전별 변경 로그를 표시하는 `Changelog` 컴포넌트. "Keep a Changelog" 표준 (https://keepachangelog.com/) 카테고리 채택:
+- **Added** — 신규 기능
+- **Changed** — 기존 기능 변경
+- **Deprecated** — 곧 제거될 기능
+- **Removed** — 제거된 기능
+- **Fixed** — 버그 수정
+- **Security** — 보안 관련
+
+데이터 소스 결정 (v1):
+- **option A**: 마크다운 파일 자동 파싱 (CHANGELOG.md) — 파서 복잡, 의존 추가.
+- **option B**: 컴포넌트 props로 구조화된 데이터 받음 — 명확, 단순.
+
+→ **option B** 채택. 사용자가 자체 마크다운 파서 + 변환 로직 자유롭게 사용.
+
+참고:
+- **Keep a Changelog** — 마크다운 포맷 표준.
+- **Algolia DocSearch** — 변경 로그 페이지 패턴.
+- **Auth0 changelog** — 카드형 + 카테고리 필터.
+- **Linear changelog** — 시간순 + 풍부한 내용.
+
+본 레포 내부 참조:
+- `src/components/Tag/` (plan 027) — 카테고리 칩.
+- `src/components/Stack/` (plan 029) — 레이아웃.
+- `src/components/Accordion/` (설계됨, 022) — 펼침/접힘.
+
+---
+
+## 0. TL;DR
+
+```tsx
+// 1. 기본
+<Changelog
+  entries={[
+    {
+      version: "1.2.0",
+      date: "2026-04-26",
+      changes: {
+        added: ["새 컴포넌트 X", "Y 기능"],
+        fixed: ["Z 버그 수정"],
+      },
+    },
+    {
+      version: "1.1.0",
+      date: "2026-03-15",
+      changes: { changed: ["A 동작 변경"] },
+    },
+  ]}
+/>
+
+// 2. 펼침/접힘
+<Changelog entries={...} collapsible defaultOpenLatest />
+// → 최신 버전만 펼침, 나머지 접힘
+
+// 3. 검색/필터
+<Changelog entries={...} searchable filterByCategory />
+
+// 4. 헤더 슬롯
+<Changelog entries={...} title="Plastic 변경 로그" subtitle="릴리스 노트" />
+
+// 5. 단일 entry 렌더 (compound)
+<Changelog.Root>
+  {entries.map((e) => (
+    <Changelog.Entry key={e.version} version={e.version} date={e.date}>
+      <Changelog.Section type="added" items={e.changes.added} />
+      <Changelog.Section type="fixed" items={e.changes.fixed} />
+    </Changelog.Entry>
+  ))}
+</Changelog.Root>
+```
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. `entries` prop — 구조화 데이터 배열.
+2. 6 카테고리: added/changed/deprecated/removed/fixed/security.
+3. 카테고리별 색상 (Tag 컴포넌트 활용).
+4. `collapsible` — 각 entry 펼침/접힘.
+5. `defaultOpenLatest` — 최신만 펼침.
+6. `searchable` — 입력으로 변경 항목 필터.
+7. `filterByCategory` — 카테고리 토글 필터.
+8. compound — `Root`, `Entry`, `Section`.
+9. theme light/dark.
+10. version + date + 기타 메타 (author, link).
+
+### Non-goals (v1)
+- 마크다운 자동 파싱 (KAC.md → entries) — 사용자가 직접.
+- RSS feed 생성.
+- diff between versions.
+- 사용자 댓글/피드백.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Changelog/Changelog.types.ts`
+
+```ts
+export type ChangelogCategory = "added" | "changed" | "deprecated" | "removed" | "fixed" | "security";
+
+export interface ChangelogChanges {
+  added?: string[];
+  changed?: string[];
+  deprecated?: string[];
+  removed?: string[];
+  fixed?: string[];
+  security?: string[];
+}
+
+export interface ChangelogEntry {
+  version: string;        // "1.2.0"
+  date?: string;          // ISO date 권장
+  changes: ChangelogChanges;
+  /** 커밋 / PR / blog 링크. */
+  link?: string;
+  /** 추가 설명 (예: 릴리스 노트). */
+  description?: string;
+}
+
+export interface ChangelogProps {
+  entries: ChangelogEntry[];
+  title?: string;
+  subtitle?: string;
+  collapsible?: boolean;
+  defaultOpenLatest?: boolean;
+  searchable?: boolean;
+  filterByCategory?: boolean;
+  theme?: "light" | "dark";
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.2 카테고리 색상 매핑
+
+```ts
+const categoryColors: Record<ChangelogCategory, "blue" | "green" | "yellow" | "red" | "gray" | "purple"> = {
+  added: "green",
+  changed: "blue",
+  deprecated: "yellow",
+  removed: "red",
+  fixed: "purple",
+  security: "red",
+};
+
+const categoryLabels: Record<ChangelogCategory, string> = {
+  added: "Added",
+  changed: "Changed",
+  deprecated: "Deprecated",
+  removed: "Removed",
+  fixed: "Fixed",
+  security: "Security",
+};
+```
+
+### 2.3 컴포넌트
+
+```tsx
+export function Changelog(props: ChangelogProps) {
+  const {
+    entries, title, subtitle,
+    collapsible = false, defaultOpenLatest = false,
+    searchable = false, filterByCategory = false,
+    theme = "light", className, style,
+  } = props;
+
+  const [search, setSearch] = useState("");
+  const [activeCategories, setActiveCategories] = useState<Set<ChangelogCategory>>(
+    new Set(["added","changed","deprecated","removed","fixed","security"])
+  );
+  const [openVersions, setOpenVersions] = useState<Set<string>>(() => {
+    if (defaultOpenLatest && entries.length > 0) return new Set([entries[0]!.version]);
+    if (collapsible) return new Set();
+    return new Set(entries.map((e) => e.version));
+  });
+
+  const filteredEntries = useMemo(() => {
+    return entries.map((entry) => {
+      const filteredChanges: ChangelogChanges = {};
+      (Object.keys(entry.changes) as ChangelogCategory[]).forEach((cat) => {
+        if (!activeCategories.has(cat)) return;
+        const items = entry.changes[cat]?.filter((i) =>
+          search === "" || i.toLowerCase().includes(search.toLowerCase())
+        ) ?? [];
+        if (items.length > 0) filteredChanges[cat] = items;
+      });
+      return { ...entry, changes: filteredChanges };
+    }).filter((e) => Object.keys(e.changes).length > 0);
+  }, [entries, search, activeCategories]);
+
+  const toggleVersion = (v: string) => {
+    setOpenVersions((s) => {
+      const next = new Set(s);
+      next.has(v) ? next.delete(v) : next.add(v);
+      return next;
+    });
+  };
+
+  const toggleCategory = (c: ChangelogCategory) => {
+    setActiveCategories((s) => {
+      const next = new Set(s);
+      next.has(c) ? next.delete(c) : next.add(c);
+      return next;
+    });
+  };
+
+  return (
+    <div className={className} style={style}>
+      {(title || subtitle) && (
+        <div style={{marginBottom: 16}}>
+          {title && <h2 style={{margin:0}}>{title}</h2>}
+          {subtitle && <p style={{margin:0,color:"#6b7280"}}>{subtitle}</p>}
+        </div>
+      )}
+
+      {(searchable || filterByCategory) && (
+        <div style={{marginBottom:16, display:"flex", gap:12, alignItems:"center"}}>
+          {searchable && (
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="검색..."
+              style={{flex:1, padding:6}}
+            />
+          )}
+          {filterByCategory && (
+            <div style={{display:"flex",gap:4}}>
+              {(["added","changed","fixed","removed","security"] as ChangelogCategory[]).map((c) => (
+                <Tag
+                  key={c}
+                  clickable
+                  variant={activeCategories.has(c) ? "solid" : "outline"}
+                  color={categoryColors[c]}
+                  size="sm"
+                  onClick={() => toggleCategory(c)}
+                >
+                  {categoryLabels[c]}
+                </Tag>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <Stack gap={16}>
+        {filteredEntries.map((entry) => {
+          const isOpen = !collapsible || openVersions.has(entry.version);
+          return (
+            <article key={entry.version} style={{
+              border: `1px solid ${theme==="dark"?"#374151":"#e5e7eb"}`,
+              borderRadius: 8, padding: 16,
+            }}>
+              <header
+                style={{display:"flex",alignItems:"center",gap:12,cursor:collapsible?"pointer":"default"}}
+                onClick={collapsible ? () => toggleVersion(entry.version) : undefined}
+              >
+                <h3 style={{margin:0}}>{entry.version}</h3>
+                {entry.date && <Tag size="sm" color="gray" variant="outline">{entry.date}</Tag>}
+                {entry.link && (
+                  <a href={entry.link} target="_blank" rel="noopener noreferrer" onClick={(e)=>e.stopPropagation()} style={{marginLeft:"auto"}}>
+                    <Icon name="external-link" size="sm" />
+                  </a>
+                )}
+                {collapsible && (
+                  <Icon
+                    name="chevron-down"
+                    rotate={isOpen ? 180 : 0}
+                    style={{marginLeft:entry.link?0:"auto"}}
+                  />
+                )}
+              </header>
+
+              {entry.description && isOpen && (
+                <p style={{marginTop:8,color:"#6b7280"}}>{entry.description}</p>
+              )}
+
+              {isOpen && (
+                <Stack gap={12} style={{marginTop:12}}>
+                  {(Object.keys(entry.changes) as ChangelogCategory[]).map((cat) => {
+                    const items = entry.changes[cat];
+                    if (!items || items.length === 0) return null;
+                    return (
+                      <div key={cat}>
+                        <Tag color={categoryColors[cat]} size="sm">{categoryLabels[cat]}</Tag>
+                        <ul style={{margin:"8px 0 0", paddingLeft:24}}>
+                          {items.map((it, i) => <li key={i}>{it}</li>)}
+                        </ul>
+                      </div>
+                    );
+                  })}
+                </Stack>
+              )}
+            </article>
+          );
+        })}
+        {filteredEntries.length === 0 && (
+          <p style={{textAlign:"center",color:"#9ca3af"}}>검색 결과 없음</p>
+        )}
+      </Stack>
+    </div>
+  );
+}
+```
+
+### 2.4 Compound API (선택)
+
+```tsx
+export const ChangelogRoot: FC<{children:ReactNode}> = ({children}) => <div>{children}</div>;
+export const ChangelogEntry: FC<{version:string,date?:string,children:ReactNode}> = ({version,date,children}) => (...);
+export const ChangelogSection: FC<{type:ChangelogCategory,items:string[]}> = ({type,items}) => (...);
+
+Changelog.Root = ChangelogRoot;
+Changelog.Entry = ChangelogEntry;
+Changelog.Section = ChangelogSection;
+```
+
+### 2.5 배럴
+
+```ts
+export { Changelog } from "./Changelog";
+export type { ChangelogProps, ChangelogEntry, ChangelogChanges, ChangelogCategory } from "./Changelog.types";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/Changelog/
+├── Changelog.tsx
+├── ChangelogRoot.tsx
+├── ChangelogEntry.tsx
+├── ChangelogSection.tsx
+├── Changelog.types.ts
+└── index.ts
+```
+
+---
+
+## 4. 데모 페이지
+
+```tsx
+const SAMPLE: ChangelogEntry[] = [
+  {
+    version: "1.2.0",
+    date: "2026-04-26",
+    changes: {
+      added: ["Icon 컴포넌트", "LineNumbers 컴포넌트", "Calendar 분리"],
+      fixed: ["DatePicker locale 버그"],
+    },
+    link: "https://github.com/.../releases/tag/v1.2.0",
+  },
+  {
+    version: "1.1.0",
+    date: "2026-03-15",
+    changes: {
+      added: ["Combobox", "DatePicker"],
+      changed: ["Select API 정리"],
+    },
+  },
+  {
+    version: "1.0.0",
+    date: "2026-01-01",
+    description: "최초 안정 릴리스.",
+    changes: {
+      added: ["Button, Card, Toast, Dialog 외 15개 컴포넌트"],
+    },
+  },
+];
+
+export function ChangelogPage() {
+  return (
+    <div>
+      <h1>Changelog</h1>
+      <Card.Root><Card.Header>Basic</Card.Header><Card.Body>
+        <Changelog entries={SAMPLE} />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Collapsible + open latest</Card.Header><Card.Body>
+        <Changelog entries={SAMPLE} collapsible defaultOpenLatest />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Searchable + filter</Card.Header><Card.Body>
+        <Changelog entries={SAMPLE} searchable filterByCategory />
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Header</Card.Header><Card.Body>
+        <Changelog entries={SAMPLE} title="Plastic Releases" subtitle="버전별 변경 로그" />
+      </Card.Body></Card.Root>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. 접근성
+
+- `<article>` 시맨틱.
+- 헤더 `<h3>`.
+- collapsible: button 시맨틱 + aria-expanded.
+- 링크: target="_blank" + rel="noopener".
+
+## 6. Edge cases
+- 빈 entries: "변경 로그 없음" 표시 (v1 미포함, 사용자 책임).
+- 빈 카테고리: 자동 숨김.
+- 검색 결과 0: "검색 결과 없음".
+- 한 entry에 모든 카테고리 동시: 모두 표시.
+
+## 7. 구현 단계
+- Phase 1: 컴포넌트
+- Phase 2: 데모
+- Phase 3: 정리
+
+## 8. 체크리스트
+- [ ] 6개 파일
+- [ ] typecheck/build
+- [ ] 모든 카테고리 시각 정상
+- [ ] collapsible 작동
+- [ ] search 필터
+- [ ] category 토글
+- [ ] candidates / README

--- a/docs/plans/037-alert-component.md
+++ b/docs/plans/037-alert-component.md
@@ -1,0 +1,637 @@
+# Alert 컴포넌트 설계문서 (severity 추출 포함)
+
+## Context
+
+본 plan은 **2개 단계**로 구성:
+
+### Phase 0 — `_shared/severity.ts` 횡단 추상 추출 (Toast 마이그레이션 포함)
+- 현재 Toast가 자체 `colors.ts`로 갖고 있는 severity(`success/error/warning/info/default`) 토큰 + 아이콘 매핑을 `src/components/_shared/severity.ts`로 추출.
+- `_shared/SeverityIcon.tsx`, `_shared/DismissButton.tsx` 부품 추출 — 향후 Alert/Banner/InlineMessage가 모두 공유.
+- Toast가 새 추출된 토큰·부품을 사용하도록 마이그레이션.
+
+### Phase 1 — `Alert` 컴포넌트 신설
+- 컨텐츠 흐름 내부 영구 알림 박스.
+- `_shared/severity.ts` 사용.
+- title/description/action/dismiss 슬롯.
+
+본 문서가 두 Phase를 모두 정의 — 서로 의존이라 분리 시 불필요한 PR 분할.
+
+참고:
+- **Mantine Alert** — `variant: filled | light | outline`, `color`, `icon`, `withCloseButton`.
+- **Chakra Alert** — `Alert.Root`, `Alert.Icon`, `Alert.Title`, `Alert.Description` compound.
+- **Material UI Alert** — `severity`, `variant`, `action` slot, `onClose`.
+- **Ant Design Alert** — `type`, `closable`, `banner` (인라인이지만 풀폭).
+- **Apple HIG** — banner은 다름 (지속). Alert는 모달성.
+
+본 레포 내부 참조:
+- `src/components/Toast/colors.ts` — 추출 대상 (line 18~).
+- `src/components/Toast/ToastIcon.tsx` — DefaultVariantIcon (line 18~) 추출 대상.
+- `src/components/Toast/ToastClose.tsx` — DismissButton 추출 대상.
+- `src/components/Icon/` (plan 023) — 아이콘 시스템.
+- `src/components/_shared/` — 추출 위치.
+- `tsconfig.json` — strict.
+
+---
+
+## 0. TL;DR
+
+```tsx
+// 1. 가장 단순 — severity만
+<Alert severity="info">정보 메시지입니다.</Alert>
+<Alert severity="warning">경고가 있습니다.</Alert>
+<Alert severity="error">에러가 발생했습니다.</Alert>
+<Alert severity="success">성공했습니다.</Alert>
+
+// 2. title + description
+<Alert severity="error" title="저장 실패">
+  네트워크 연결을 확인하고 다시 시도해주세요.
+</Alert>
+
+// 3. dismissable
+<Alert severity="info" dismissable onDismiss={() => setVisible(false)}>
+  Beta 기능입니다.
+</Alert>
+
+// 4. variant
+<Alert severity="warning" variant="solid">Solid bg</Alert>
+<Alert severity="warning" variant="subtle">Subtle bg (default)</Alert>
+<Alert severity="warning" variant="outline">Outline only</Alert>
+<Alert severity="warning" variant="left-accent">Left accent bar</Alert>
+
+// 5. action 슬롯
+<Alert severity="info" action={<Button size="sm">자세히</Button>}>
+  새 업데이트가 있습니다.
+</Alert>
+
+// 6. icon override
+<Alert severity="info" icon={<Icon name="info" />}>...</Alert>
+<Alert severity="info" icon={false}>아이콘 없음</Alert>
+
+// 7. compound
+<Alert.Root severity="success">
+  <Alert.Icon />
+  <Alert.Content>
+    <Alert.Title>완료</Alert.Title>
+    <Alert.Description>작업이 성공적으로 완료되었습니다.</Alert.Description>
+  </Alert.Content>
+  <Alert.Action><Button size="sm">보기</Button></Alert.Action>
+  <Alert.Dismiss />
+</Alert.Root>
+```
+
+핵심 원칙:
+- **severity 기반** — `_shared/severity.ts` 토큰 사용.
+- **4 variant**: solid / subtle / outline / left-accent.
+- **compound**: Root + Icon + Content (Title/Description) + Action + Dismiss.
+- **dismissable optional**: 외부 상태 또는 자동 unmount.
+- **a11y**: `role="alert"` (error/warning) 또는 `role="status"` (info/success).
+
+---
+
+## 1. Goals / Non-goals
+
+### Phase 0 Goals
+- `src/components/_shared/severity.ts`:
+  - `Severity` 타입.
+  - `SeverityPalette` 인터페이스 + 5 severity × light/dark 토큰.
+  - `severityIcons` 맵 (severity → IconName).
+- `src/components/_shared/SeverityIcon.tsx` — severity 받아 아이콘 렌더.
+- `src/components/_shared/DismissButton.tsx` — X 버튼.
+- Toast 마이그레이션:
+  - Toast/colors.ts 삭제 (또는 import severity).
+  - ToastIcon이 `<SeverityIcon variant={variant} theme={theme} />` 사용.
+  - ToastClose가 `<DismissButton />` 사용 또는 같은 디자인.
+  - 시각·동작 100% 동일.
+
+### Phase 1 Goals (Alert)
+1. `severity: "default" | "success" | "info" | "warning" | "error"`.
+2. `variant: "solid" | "subtle" | "outline" | "left-accent"` (기본 "subtle").
+3. `title?: ReactNode`, `description?: ReactNode`, children = description shorthand.
+4. `icon?: ReactNode | false` — false면 미표시.
+5. `dismissable?: boolean` + `onDismiss?: () => void`.
+6. `action?: ReactNode` 슬롯.
+7. theme.
+8. compound: Root, Icon, Content, Title, Description, Action, Dismiss.
+9. a11y: severity별 role/aria-live.
+
+### Non-goals (v1)
+- Auto-dismiss timer (Toast 영역).
+- Banner 통합 (별도 plan 038).
+- Animation (페이드 등) — v1 즉시 표시/제거.
+- Stacking — 단일 Alert.
+
+---
+
+## 2. Phase 0 — `_shared/severity.ts` 추출
+
+### 2.1 타입 — `src/components/_shared/severity.ts`
+
+```ts
+export type Severity = "default" | "success" | "info" | "warning" | "error";
+export type SeverityTheme = "light" | "dark";
+
+export interface SeverityPalette {
+  /** solid bg + fg */
+  solidBg: string;
+  solidFg: string;
+  /** subtle bg + fg + border */
+  subtleBg: string;
+  subtleFg: string;
+  subtleBorder: string;
+  /** outline border + fg */
+  outlineBorder: string;
+  outlineFg: string;
+  /** left-accent bar 색상 */
+  accentBar: string;
+  /** icon foreground (subtle/outline variant에서) */
+  iconFg: string;
+  /** ARIA role */
+  ariaRole: "alert" | "status";
+  /** ARIA live */
+  ariaLive: "assertive" | "polite";
+}
+
+export const severityPalettes: Record<Severity, Record<SeverityTheme, SeverityPalette>> = {
+  default: {
+    light: {
+      solidBg: "#374151", solidFg: "#fff",
+      subtleBg: "#f3f4f6", subtleFg: "#374151", subtleBorder: "rgba(0,0,0,0.06)",
+      outlineBorder: "#9ca3af", outlineFg: "#374151",
+      accentBar: "#9ca3af",
+      iconFg: "#374151",
+      ariaRole: "status", ariaLive: "polite",
+    },
+    dark: {
+      solidBg: "#9ca3af", solidFg: "#0f172a",
+      subtleBg: "rgba(255,255,255,0.06)", subtleFg: "#e5e7eb", subtleBorder: "rgba(255,255,255,0.08)",
+      outlineBorder: "rgba(255,255,255,0.2)", outlineFg: "#e5e7eb",
+      accentBar: "#9ca3af",
+      iconFg: "#e5e7eb",
+      ariaRole: "status", ariaLive: "polite",
+    },
+  },
+  success: {
+    light: {
+      solidBg: "#16a34a", solidFg: "#fff",
+      subtleBg: "#dcfce7", subtleFg: "#166534", subtleBorder: "rgba(22,163,74,0.18)",
+      outlineBorder: "#16a34a", outlineFg: "#166534",
+      accentBar: "#16a34a",
+      iconFg: "#16a34a",
+      ariaRole: "status", ariaLive: "polite",
+    },
+    dark: {
+      solidBg: "#22c55e", solidFg: "#0f172a",
+      subtleBg: "rgba(34,197,94,0.14)", subtleFg: "#86efac", subtleBorder: "rgba(34,197,94,0.3)",
+      outlineBorder: "#22c55e", outlineFg: "#86efac",
+      accentBar: "#22c55e",
+      iconFg: "#22c55e",
+      ariaRole: "status", ariaLive: "polite",
+    },
+  },
+  info: {
+    light: {
+      solidBg: "#2563eb", solidFg: "#fff",
+      subtleBg: "#dbeafe", subtleFg: "#1e40af", subtleBorder: "rgba(37,99,235,0.18)",
+      outlineBorder: "#2563eb", outlineFg: "#1e40af",
+      accentBar: "#2563eb",
+      iconFg: "#2563eb",
+      ariaRole: "status", ariaLive: "polite",
+    },
+    dark: {
+      solidBg: "#3b82f6", solidFg: "#0f172a",
+      subtleBg: "rgba(59,130,246,0.14)", subtleFg: "#93c5fd", subtleBorder: "rgba(59,130,246,0.3)",
+      outlineBorder: "#3b82f6", outlineFg: "#93c5fd",
+      accentBar: "#3b82f6",
+      iconFg: "#3b82f6",
+      ariaRole: "status", ariaLive: "polite",
+    },
+  },
+  warning: {
+    light: {
+      solidBg: "#d97706", solidFg: "#fff",
+      subtleBg: "#fef3c7", subtleFg: "#92400e", subtleBorder: "rgba(217,119,6,0.18)",
+      outlineBorder: "#d97706", outlineFg: "#92400e",
+      accentBar: "#d97706",
+      iconFg: "#d97706",
+      ariaRole: "alert", ariaLive: "assertive",
+    },
+    dark: {
+      solidBg: "#f59e0b", solidFg: "#0f172a",
+      subtleBg: "rgba(245,158,11,0.14)", subtleFg: "#fcd34d", subtleBorder: "rgba(245,158,11,0.3)",
+      outlineBorder: "#f59e0b", outlineFg: "#fcd34d",
+      accentBar: "#f59e0b",
+      iconFg: "#f59e0b",
+      ariaRole: "alert", ariaLive: "assertive",
+    },
+  },
+  error: {
+    light: {
+      solidBg: "#dc2626", solidFg: "#fff",
+      subtleBg: "#fee2e2", subtleFg: "#991b1b", subtleBorder: "rgba(220,38,38,0.18)",
+      outlineBorder: "#dc2626", outlineFg: "#991b1b",
+      accentBar: "#dc2626",
+      iconFg: "#dc2626",
+      ariaRole: "alert", ariaLive: "assertive",
+    },
+    dark: {
+      solidBg: "#ef4444", solidFg: "#0f172a",
+      subtleBg: "rgba(239,68,68,0.14)", subtleFg: "#fca5a5", subtleBorder: "rgba(239,68,68,0.3)",
+      outlineBorder: "#ef4444", outlineFg: "#fca5a5",
+      accentBar: "#ef4444",
+      iconFg: "#ef4444",
+      ariaRole: "alert", ariaLive: "assertive",
+    },
+  },
+};
+
+import type { IconName } from "../Icon";
+
+/** severity → 기본 아이콘 이름 매핑. Icon 시스템(plan 023) 의존. */
+export const severityIcons: Record<Severity, IconName> = {
+  default: "info",
+  success: "success",
+  info: "info",
+  warning: "warning",
+  error: "error",
+};
+```
+
+### 2.2 SeverityIcon — `src/components/_shared/SeverityIcon.tsx`
+
+```tsx
+import type { CSSProperties } from "react";
+import { Icon, type IconSize } from "../Icon";
+import { severityIcons, severityPalettes, type Severity, type SeverityTheme } from "./severity";
+
+export interface SeverityIconProps {
+  severity: Severity;
+  theme?: SeverityTheme;
+  size?: IconSize | number;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function SeverityIcon(props: SeverityIconProps) {
+  const { severity, theme = "light", size = "md", className, style } = props;
+  const color = severityPalettes[severity][theme].iconFg;
+  return (
+    <span style={{ color, display: "inline-flex", ...style }} className={className}>
+      <Icon name={severityIcons[severity]} size={size} aria-hidden="true" />
+    </span>
+  );
+}
+```
+
+### 2.3 DismissButton — `src/components/_shared/DismissButton.tsx`
+
+```tsx
+import type { CSSProperties, ButtonHTMLAttributes } from "react";
+import { Icon } from "../Icon";
+
+export interface DismissButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
+  size?: "sm" | "md" | "lg";
+  "aria-label"?: string;
+}
+
+export function DismissButton(props: DismissButtonProps) {
+  const { size = "md", className, style, "aria-label": ariaLabel = "Dismiss", ...rest } = props;
+  const px = { sm: 14, md: 16, lg: 20 }[size];
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      className={className}
+      style={{
+        display: "inline-flex", alignItems: "center", justifyContent: "center",
+        width: px + 8, height: px + 8,
+        background: "transparent", border: "none", cursor: "pointer",
+        color: "currentColor", borderRadius: 4, opacity: 0.6,
+        transition: "opacity 120ms ease, background 120ms ease",
+        ...style,
+      }}
+      {...rest}
+    >
+      <Icon name="x" size={px} />
+    </button>
+  );
+}
+```
+
+### 2.4 _shared 배럴 — `src/components/_shared/index.ts`
+
+```ts
+export { useCopyToClipboard } from "./useCopyToClipboard";
+export type { UseCopyToClipboardOptions, UseCopyToClipboardReturn } from "./useCopyToClipboard";
+
+export { SeverityIcon } from "./SeverityIcon";
+export type { SeverityIconProps } from "./SeverityIcon";
+
+export { DismissButton } from "./DismissButton";
+export type { DismissButtonProps } from "./DismissButton";
+
+export { severityPalettes, severityIcons } from "./severity";
+export type { Severity, SeverityTheme, SeverityPalette } from "./severity";
+```
+
+### 2.5 Toast 마이그레이션
+
+**삭제:**
+- `src/components/Toast/colors.ts`의 severity 색상 (또는 keep — 일단 severity import로 변경).
+- `ToastIcon.tsx`의 `DefaultVariantIcon` (5 케이스) — `<SeverityIcon severity={variant} theme={theme} />`로 교체.
+
+**수정:**
+- `ToastIcon.tsx`:
+  ```tsx
+  import { SeverityIcon } from "../_shared";
+
+  export const ToastIcon = forwardRef<HTMLDivElement, ToastIconProps>(
+    function ToastIcon({ children, className, style, ...rest }, ref) {
+      const { variant, theme } = useToastItemContext();
+      return (
+        <div ref={ref} className={className} style={{ ...iconWrapStyle, ...style }} {...rest}>
+          {children ?? <SeverityIcon severity={variant === "default" ? "default" : variant} theme={theme} size={20} />}
+        </div>
+      );
+    },
+  );
+  ```
+- `ToastClose.tsx` → `<DismissButton />` 사용.
+
+**검증:** Toast 데모 페이지에서 5 variants × light/dark 모두 시각·동작 동일.
+
+---
+
+## 3. Phase 1 — Alert 컴포넌트
+
+### 3.1 타입 — `src/components/Alert/Alert.types.ts`
+
+```ts
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+import type { Severity, SeverityTheme } from "../_shared/severity";
+
+export type AlertVariant = "solid" | "subtle" | "outline" | "left-accent";
+
+export interface AlertProps extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
+  severity?: Severity;
+  variant?: AlertVariant;
+  theme?: SeverityTheme;
+
+  title?: ReactNode;
+  description?: ReactNode;
+  /** description shorthand. */
+  children?: ReactNode;
+
+  icon?: ReactNode | false;
+
+  dismissable?: boolean;
+  onDismiss?: () => void;
+
+  action?: ReactNode;
+
+  className?: string;
+  style?: CSSProperties;
+}
+
+// compound
+export interface AlertRootProps extends Omit<AlertProps, "title" | "description" | "icon" | "dismissable" | "onDismiss" | "action"> {
+  children: ReactNode;
+}
+export interface AlertIconProps { children?: ReactNode; className?: string; style?: CSSProperties; }
+export interface AlertContentProps { children: ReactNode; className?: string; style?: CSSProperties; }
+export interface AlertTitleProps { children: ReactNode; className?: string; style?: CSSProperties; }
+export interface AlertDescriptionProps { children: ReactNode; className?: string; style?: CSSProperties; }
+export interface AlertActionProps { children: ReactNode; className?: string; style?: CSSProperties; }
+export interface AlertDismissProps { onClick?: () => void; className?: string; style?: CSSProperties; "aria-label"?: string; }
+```
+
+### 3.2 Context
+
+```ts
+const AlertContext = createContext<{ severity: Severity; theme: SeverityTheme; variant: AlertVariant; onDismiss?: () => void } | null>(null);
+function useAlertContext() {
+  const ctx = useContext(AlertContext);
+  if (!ctx) throw new Error("Alert.* must be used within Alert.Root");
+  return ctx;
+}
+```
+
+### 3.3 Root 단순 컴포넌트 — Alert
+
+```tsx
+export function Alert(props: AlertProps) {
+  const {
+    severity = "info",
+    variant = "subtle",
+    theme = "light",
+    title, description, children,
+    icon, dismissable = false, onDismiss,
+    action, className, style, ...rest
+  } = props;
+
+  const palette = severityPalettes[severity][theme];
+
+  // variant 별 스타일
+  let containerStyle: CSSProperties;
+  switch (variant) {
+    case "solid":
+      containerStyle = { background: palette.solidBg, color: palette.solidFg, border: "none" };
+      break;
+    case "subtle":
+      containerStyle = { background: palette.subtleBg, color: palette.subtleFg, border: `1px solid ${palette.subtleBorder}` };
+      break;
+    case "outline":
+      containerStyle = { background: "transparent", color: palette.outlineFg, border: `1px solid ${palette.outlineBorder}` };
+      break;
+    case "left-accent":
+      containerStyle = { background: palette.subtleBg, color: palette.subtleFg, border: "none", borderLeft: `4px solid ${palette.accentBar}` };
+      break;
+  }
+
+  const iconNode = icon === false ? null : (
+    icon ?? <SeverityIcon severity={severity} theme={theme} size="lg" />
+  );
+
+  return (
+    <div
+      role={palette.ariaRole}
+      aria-live={palette.ariaLive}
+      className={className}
+      style={{
+        display: "flex", alignItems: "flex-start", gap: 12,
+        padding: 12, borderRadius: 8,
+        ...containerStyle,
+        ...style,
+      }}
+      {...rest}
+    >
+      {iconNode && <div style={{flexShrink:0,marginTop:2}}>{iconNode}</div>}
+      <div style={{flex:1,minWidth:0}}>
+        {title && <div style={{fontWeight:600,marginBottom:description||children?2:0}}>{title}</div>}
+        {description && <div style={{fontSize:13}}>{description}</div>}
+        {children && !description && <div style={{fontSize:13}}>{children}</div>}
+        {action && <div style={{marginTop:8}}>{action}</div>}
+      </div>
+      {dismissable && (
+        <DismissButton
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          style={{flexShrink:0,color:"currentColor"}}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+### 3.4 Compound — `Alert.Root`, `.Icon`, `.Content`, `.Title`, `.Description`, `.Action`, `.Dismiss`
+
+(전체 코드 생략 — 위 단일 Alert와 동일 패턴, 부품별 분리. 사용자가 자유 합성 가능.)
+
+### 3.5 배럴
+
+```ts
+export { Alert } from "./Alert";
+export type { AlertProps, AlertVariant, ... } from "./Alert.types";
+```
+
+---
+
+## 4. 파일 구조
+
+```
+src/components/_shared/
+├── severity.ts              ← 신설
+├── SeverityIcon.tsx          ← 신설
+└── DismissButton.tsx         ← 신설
+
+src/components/Alert/
+├── Alert.tsx
+├── AlertRoot.tsx
+├── AlertIcon.tsx
+├── AlertContent.tsx
+├── AlertTitle.tsx
+├── AlertDescription.tsx
+├── AlertAction.tsx
+├── AlertDismiss.tsx
+├── AlertContext.ts
+├── Alert.types.ts
+└── index.ts
+```
+
+---
+
+## 5. 데모 페이지
+
+```tsx
+export function AlertPage() {
+  return (
+    <div>
+      <h1>Alert</h1>
+
+      <Card.Root><Card.Header>Severities</Card.Header><Card.Body>
+        <Stack gap={12}>
+          <Alert severity="default">Default 메시지</Alert>
+          <Alert severity="info">정보 메시지</Alert>
+          <Alert severity="success">성공 메시지</Alert>
+          <Alert severity="warning">경고 메시지</Alert>
+          <Alert severity="error">에러 메시지</Alert>
+        </Stack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Variants</Card.Header><Card.Body>
+        <Stack gap={12}>
+          {(["solid","subtle","outline","left-accent"] as const).map(v => (
+            <Alert key={v} severity="info" variant={v} title={v}>Variant: {v}</Alert>
+          ))}
+        </Stack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Title + Description</Card.Header><Card.Body>
+        <Alert severity="error" title="저장 실패">
+          네트워크 연결을 확인하고 다시 시도해주세요.
+        </Alert>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Dismissable</Card.Header><Card.Body>
+        <Alert severity="info" dismissable onDismiss={() => alert("dismiss")}>닫기 가능</Alert>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Action 슬롯</Card.Header><Card.Body>
+        <Alert severity="info" title="새 업데이트" action={<button>업데이트</button>}>
+          새로운 버전이 있습니다.
+        </Alert>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Custom icon</Card.Header><Card.Body>
+        <Alert severity="info" icon={<Icon name="help" />}>커스텀 아이콘</Alert>
+        <Alert severity="info" icon={false}>아이콘 없음</Alert>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Compound</Card.Header><Card.Body>
+        <Alert.Root severity="success">
+          <Alert.Icon />
+          <Alert.Content>
+            <Alert.Title>완료</Alert.Title>
+            <Alert.Description>작업이 성공적으로 완료되었습니다.</Alert.Description>
+          </Alert.Content>
+          <Alert.Action><button>보기</button></Alert.Action>
+          <Alert.Dismiss />
+        </Alert.Root>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Dark theme</Card.Header><Card.Body style={{background:"#1f2937",padding:16}}>
+        <Stack gap={12}>
+          <Alert theme="dark" severity="info">Dark info</Alert>
+          <Alert theme="dark" severity="error" variant="solid">Dark error solid</Alert>
+        </Stack>
+      </Card.Body></Card.Root>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. 접근성
+
+- error/warning: `role="alert"` + `aria-live="assertive"` (자동).
+- info/success: `role="status"` + `aria-live="polite"`.
+- dismiss: 별도 button, aria-label.
+- action 안의 button: 표준 button (사용자 책임).
+
+## 7. Edge cases
+- title만, description만, children만, 모두 없음 — 모두 정상 렌더 (빈 컨텐츠).
+- description + children 둘 다 — description 우선 (children 무시).
+- icon=false + description 없음 → 빈 컨텐츠 영역 (의도 — 사용자 자유).
+- dismissable=true 인데 onDismiss 없음 — 클릭해도 동작 없음 (외부 상태 미관리).
+
+## 8. 구현 단계
+
+### Phase 0
+1. `_shared/severity.ts` 작성
+2. `_shared/SeverityIcon.tsx`, `_shared/DismissButton.tsx` 작성
+3. `_shared/index.ts` 갱신
+4. Toast 마이그레이션 (ToastIcon, ToastClose 내부 교체)
+5. Toast 데모 회귀 검증
+
+### Phase 1
+6. Alert.tsx + compound 8개 파일
+7. 배럴
+8. components/index.ts
+9. typecheck/build
+
+### Phase 2
+10. AlertPage 데모
+
+### Phase 3
+11. candidates.md 1번 제거 + 링크
+12. README
+
+## 9. 체크리스트
+- [ ] _shared/severity.ts + SeverityIcon + DismissButton
+- [ ] Toast 마이그레이션 (시각 회귀 0)
+- [ ] Alert 신설 (compound + 단일)
+- [ ] 5 severity × 4 variant × 2 theme 매트릭스 시각 정상
+- [ ] dismissable / action / icon prop 정상
+- [ ] role/aria 자동 분기
+- [ ] candidates / README

--- a/docs/plans/038-banner-component.md
+++ b/docs/plans/038-banner-component.md
@@ -1,0 +1,345 @@
+# Banner 컴포넌트 설계문서
+
+## Context
+
+페이지 최상단 풀폭 가로 띠 공지 `Banner` 컴포넌트. Alert(037)와 형제 관계 — 공통 `_shared/severity.ts` 토큰 의존.
+
+**vs Alert 차별점**:
+
+| | Banner | Alert |
+|---|---|---|
+| 위치 | 페이지 최상단 풀폭 띠 | 컨텐츠 흐름 내부 박스 |
+| 너비 | 100% (뷰포트) | 부모 종속 |
+| 시각 무게 | 얇은 띠, 보더 위/아래만 | 풀 보더 + radius + 패딩 |
+| 의미 | 페이지/사이트 전반 공지 | 컨텐츠 영역 메시지 |
+| stack | 페이지 상단 1~몇 개 | 본문 곳곳 분산 |
+
+전제: plan 037이 Phase 0 (severity 추출)을 완료해야 본 plan 진행 가능.
+
+참고:
+- **Slack** 상단 banner — 워크스페이스 공지.
+- **GitHub** 상단 banner — incident, security alert.
+- **Linear** — 시스템 공지.
+- **Mantine** Banner 미제공 (Notification 또는 Alert로 대체).
+- **Apple HIG**: status bar / notification bar 가까움.
+
+본 레포 내부 참조:
+- `src/components/_shared/severity.ts` (plan 037 Phase 0).
+- `src/components/_shared/SeverityIcon.tsx`.
+- `src/components/_shared/DismissButton.tsx`.
+
+---
+
+## 0. TL;DR
+
+```tsx
+// 1. 가장 단순
+<Banner severity="info">새 기능이 출시되었습니다.</Banner>
+
+// 2. dismissable
+<Banner severity="info" dismissable onDismiss={() => setVisible(false)}>
+  Beta 기능을 사용하고 있습니다.
+</Banner>
+
+// 3. action 슬롯
+<Banner severity="warning" action={<Button size="sm">자세히 보기</Button>}>
+  유지보수가 예정되어 있습니다 (2026-04-30 02:00 KST).
+</Banner>
+
+// 4. sticky (스크롤해도 상단 고정)
+<Banner severity="error" sticky>중요: 시스템 점검 중</Banner>
+
+// 5. height variant
+<Banner severity="info" height="thin">한 줄짜리 얇은 띠</Banner>
+<Banner severity="info" height="normal">기본 (32px)</Banner>
+<Banner severity="info" height="tall">제목 + 본문</Banner>
+
+// 6. icon override
+<Banner severity="info" icon={false}>아이콘 없음</Banner>
+<Banner severity="info" icon={<Icon name="info" />}>커스텀</Banner>
+
+// 7. AppShell Header 안에 합성
+<AppShell>
+  <Banner severity="warning">유지보수 예정</Banner>
+  <Header>...</Header>
+  <Sidebar>...</Sidebar>
+  <Main>...</Main>
+</AppShell>
+
+// 8. compound
+<Banner.Root severity="info">
+  <Banner.Icon />
+  <Banner.Content>새 기능이 출시되었습니다.</Banner.Content>
+  <Banner.Action><Button>확인</Button></Banner.Action>
+  <Banner.Dismiss />
+</Banner.Root>
+```
+
+핵심 원칙:
+- **풀폭** — `width: 100%`. 부모가 풀폭 컨테이너여야 함 (AppShell, body 등).
+- **얇은 띠** — Alert보다 vertical padding 작음. height variant 3종.
+- **severity 토큰** — _shared/severity.ts 사용.
+- **선택적 sticky** — 스크롤 무관 상단 고정.
+- **dismissable** — 외부 상태 (또는 자동 unmount).
+- **a11y**: severity별 role/aria-live (Alert와 동일).
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. severity (5종).
+2. height: "thin" (24) | "normal" (32) | "tall" (48+ — title+desc).
+3. variant: "subtle"(기본) | "solid".
+4. dismissable + onDismiss.
+5. action 슬롯.
+6. icon prop (or false).
+7. sticky.
+8. theme.
+9. compound: Root, Icon, Content, Action, Dismiss.
+10. children = 단순 텍스트 또는 React 노드.
+
+### Non-goals (v1)
+- 자동 dismiss timer.
+- stacking 다중 banner 자동 큐.
+- 마키 / 슬라이드 텍스트.
+- countdown 자동 갱신.
+- close 후 localStorage로 영구 숨김 (v1.1+).
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/Banner/Banner.types.ts`
+
+```ts
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+import type { Severity, SeverityTheme } from "../_shared/severity";
+
+export type BannerVariant = "subtle" | "solid";
+export type BannerHeight = "thin" | "normal" | "tall";
+
+export interface BannerProps extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
+  severity?: Severity;
+  variant?: BannerVariant;
+  height?: BannerHeight;
+  theme?: SeverityTheme;
+
+  title?: ReactNode;          // height="tall" 일 때 사용
+  description?: ReactNode;
+  children?: ReactNode;       // description shorthand
+
+  icon?: ReactNode | false;
+  dismissable?: boolean;
+  onDismiss?: () => void;
+  action?: ReactNode;
+
+  sticky?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.2 컴포넌트 — `src/components/Banner/Banner.tsx`
+
+```tsx
+const heightMap: Record<BannerHeight, { padding: string; fontSize: number }> = {
+  thin: { padding: "4px 12px", fontSize: 12 },
+  normal: { padding: "8px 16px", fontSize: 13 },
+  tall: { padding: "12px 16px", fontSize: 13 },
+};
+
+export function Banner(props: BannerProps) {
+  const {
+    severity = "info", variant = "subtle", height = "normal", theme = "light",
+    title, description, children,
+    icon, dismissable = false, onDismiss,
+    action, sticky = false,
+    className, style, ...rest
+  } = props;
+
+  const palette = severityPalettes[severity][theme];
+  const h = heightMap[height];
+
+  let bgStyle: CSSProperties;
+  if (variant === "solid") {
+    bgStyle = { background: palette.solidBg, color: palette.solidFg };
+  } else {
+    bgStyle = {
+      background: palette.subtleBg,
+      color: palette.subtleFg,
+      borderTop: `1px solid ${palette.subtleBorder}`,
+      borderBottom: `1px solid ${palette.subtleBorder}`,
+    };
+  }
+
+  const iconNode = icon === false ? null : (icon ?? <SeverityIcon severity={severity} theme={theme} size="md" />);
+
+  return (
+    <div
+      role={palette.ariaRole}
+      aria-live={palette.ariaLive}
+      className={className}
+      style={{
+        width: "100%",
+        display: "flex",
+        alignItems: height === "tall" ? "flex-start" : "center",
+        gap: 12,
+        padding: h.padding,
+        fontSize: h.fontSize,
+        fontFamily: "inherit",
+        boxSizing: "border-box",
+        ...(sticky ? { position: "sticky", top: 0, zIndex: 50 } : {}),
+        ...bgStyle,
+        ...style,
+      }}
+      {...rest}
+    >
+      {iconNode && <div style={{flexShrink:0,display:"flex"}}>{iconNode}</div>}
+      <div style={{flex:1,minWidth:0}}>
+        {title && height === "tall" && <div style={{fontWeight:600,marginBottom:2}}>{title}</div>}
+        {description ?? children}
+      </div>
+      {action && <div style={{flexShrink:0}}>{action}</div>}
+      {dismissable && (
+        <DismissButton onClick={onDismiss} aria-label="Dismiss" style={{flexShrink:0,color:"currentColor"}} />
+      )}
+    </div>
+  );
+}
+```
+
+### 2.3 Compound
+
+```tsx
+const BannerCtx = createContext<{...} | null>(null);
+
+export const BannerRoot = ...
+export const BannerIcon = ...
+export const BannerContent = ...
+export const BannerAction = ...
+export const BannerDismiss = ...
+
+Banner.Root = BannerRoot;
+Banner.Icon = BannerIcon;
+Banner.Content = BannerContent;
+Banner.Action = BannerAction;
+Banner.Dismiss = BannerDismiss;
+```
+
+### 2.4 배럴
+
+```ts
+export { Banner } from "./Banner";
+export type { BannerProps, BannerVariant, BannerHeight } from "./Banner.types";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/Banner/
+├── Banner.tsx
+├── BannerRoot.tsx
+├── BannerIcon.tsx
+├── BannerContent.tsx
+├── BannerAction.tsx
+├── BannerDismiss.tsx
+├── BannerContext.ts
+├── Banner.types.ts
+└── index.ts
+```
+
+---
+
+## 4. 데모 페이지
+
+```tsx
+export function BannerPage() {
+  const [visible, setVisible] = useState(true);
+
+  return (
+    <div>
+      <h1>Banner</h1>
+
+      <Card.Root><Card.Header>Severities (subtle)</Card.Header><Card.Body>
+        <Stack gap={4}>
+          <Banner severity="default">Default</Banner>
+          <Banner severity="info">Info</Banner>
+          <Banner severity="success">Success</Banner>
+          <Banner severity="warning">Warning</Banner>
+          <Banner severity="error">Error</Banner>
+        </Stack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Variants</Card.Header><Card.Body>
+        <Stack gap={4}>
+          <Banner severity="info" variant="subtle">Subtle</Banner>
+          <Banner severity="info" variant="solid">Solid</Banner>
+        </Stack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Heights</Card.Header><Card.Body>
+        <Stack gap={4}>
+          <Banner severity="info" height="thin">Thin (24)</Banner>
+          <Banner severity="info" height="normal">Normal (32)</Banner>
+          <Banner severity="info" height="tall" title="제목">본문 텍스트</Banner>
+        </Stack>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Dismissable</Card.Header><Card.Body>
+        {visible && <Banner severity="warning" dismissable onDismiss={() => setVisible(false)}>닫기 가능</Banner>}
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Action</Card.Header><Card.Body>
+        <Banner severity="info" action={<button>자세히</button>}>새 업데이트</Banner>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Sticky (이 카드 안에서만 sticky)</Card.Header><Card.Body style={{maxHeight:200,overflow:"auto"}}>
+        <Banner severity="warning" sticky>Sticky banner</Banner>
+        <div style={{height:600,padding:16}}>스크롤 컨텐츠...</div>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Compound</Card.Header><Card.Body>
+        <Banner.Root severity="info">
+          <Banner.Icon />
+          <Banner.Content>compound API</Banner.Content>
+          <Banner.Action><button>OK</button></Banner.Action>
+          <Banner.Dismiss />
+        </Banner.Root>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Dark</Card.Header><Card.Body style={{background:"#1f2937",padding:0}}>
+        <Banner theme="dark" severity="info">Dark theme info</Banner>
+        <Banner theme="dark" severity="warning" variant="solid">Dark theme warning solid</Banner>
+      </Card.Body></Card.Root>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. 접근성
+
+- severity별 role/aria-live (Alert와 동일).
+- dismiss button: aria-label.
+- sticky banner는 키보드 사용자에게 항상 보임 — 좋음.
+
+## 6. Edge cases
+- 부모가 풀폭이 아니면 banner도 풀폭 아님. 사용자 책임.
+- height="tall" + title 없음: 정상 렌더 (description만).
+- action + dismiss 동시 — 우측 정렬 순서 (action → dismiss).
+
+## 7. 구현 단계
+- Phase 1: Banner 신설 (severity는 plan 037에서 이미 추출됨)
+- Phase 2: 데모
+- Phase 3: 정리
+
+## 8. 체크리스트
+- [ ] 9개 파일
+- [ ] typecheck/build
+- [ ] severity × variant × height × theme 매트릭스
+- [ ] dismissable, action, icon, sticky 정상
+- [ ] candidates / README

--- a/docs/plans/039-appshell-parts-component.md
+++ b/docs/plans/039-appshell-parts-component.md
@@ -1,0 +1,546 @@
+# Sidebar + Header + Footer (AppShell parts) 설계문서
+
+## Context
+
+AppShell 레이아웃의 1차 부품 3종 — `Sidebar`, `Header`, `Footer` — 묶음 신설.
+
+**왜 묶음인가**: 세 부품은 시각 토큰·간격·테마를 공유하며, 한 PR로 묶어 컨벤션 일관성 확보. 단독 사용도 가능하나 보통 함께 쓰임.
+
+**AppShell 본체와의 관계**: AppShell은 `검토 대상`(잠정 후보 아님). 본 plan은 부품만 정의하고 AppShell은 사용자가 자유롭게 grid/flex로 합성. 향후 AppShell이 후보로 채택되면 별도 plan으로 추가 (이 부품들이 그 슬롯에 들어감).
+
+전제: plan 029 (Stack/Grid)가 선행되면 합성 깔끔. 하지만 본 plan은 029 없이도 자체 구현 가능 (단순 flex/grid).
+
+참고:
+- **Mantine AppShell** — `<AppShell.Header>`, `<AppShell.Navbar>`, `<AppShell.Footer>`, `<AppShell.Aside>`. 가장 영향력.
+- **Chakra UI** — Layout primitives (Flex, Grid)로 직접 합성. 자체 AppShell 없음.
+- **Tailwind UI** — 패턴 제공 (코드 복사). 컴포넌트 없음.
+- **shadcn/ui** — Sidebar, Header 자체 컴포넌트 (최근 추가).
+
+본 레포 내부 참조:
+- `src/components/Stack/` (plan 029) — Stack/HStack 사용.
+- `src/components/Icon/` (plan 023) — collapse/menu 아이콘.
+- `src/components/_shared/` — Theme 토큰.
+
+---
+
+## 0. TL;DR
+
+```tsx
+// 1. 단독 Sidebar
+<Sidebar>
+  <SidebarItem>Home</SidebarItem>
+  <SidebarItem>Settings</SidebarItem>
+</Sidebar>
+
+// 2. collapsible
+<Sidebar collapsible defaultCollapsed>
+  ...
+</Sidebar>
+
+// 3. Header 단독
+<Header>
+  <Header.Section>
+    <Logo />
+  </Header.Section>
+  <Header.Section align="center">
+    <Nav />
+  </Header.Section>
+  <Header.Section align="end">
+    <UserMenu />
+  </Header.Section>
+</Header>
+
+// 4. Footer
+<Footer>
+  <p>© 2026 Plastic</p>
+</Footer>
+
+// 5. 합성된 AppShell-like layout (사용자가 grid 직접)
+<div style={{display:"grid",gridTemplate:"'h h' auto 's m' 1fr 'f f' auto / auto 1fr",height:"100vh"}}>
+  <Header style={{gridArea:"h"}}>...</Header>
+  <Sidebar style={{gridArea:"s"}}>...</Sidebar>
+  <main style={{gridArea:"m",overflow:"auto"}}>...</main>
+  <Footer style={{gridArea:"f"}}>...</Footer>
+</div>
+
+// 6. Sidebar with sections
+<Sidebar>
+  <Sidebar.Section title="Main">
+    <Sidebar.Item icon={<Icon name="home" />}>Home</Sidebar.Item>
+    <Sidebar.Item icon={<Icon name="search" />}>Search</Sidebar.Item>
+  </Sidebar.Section>
+  <Sidebar.Section title="Tools">
+    <Sidebar.Item>Reports</Sidebar.Item>
+  </Sidebar.Section>
+</Sidebar>
+
+// 7. selected state
+<Sidebar.Item selected>Active</Sidebar.Item>
+```
+
+핵심 원칙:
+- **단독 사용 가능** — Header/Sidebar/Footer 각각 독립.
+- **시각 일관성** — 같은 background/border 토큰.
+- **theme** light/dark.
+- **collapsible Sidebar** — 토글, narrow mode (icon-only).
+- **Header sections** — left/center/right 슬롯.
+- **Sidebar Item** — icon + label + selected/active state.
+- **a11y** — `<header>`, `<nav>`, `<footer>` 시맨틱.
+
+---
+
+## 1. Goals / Non-goals
+
+### Goals (v1)
+1. **`Header`** + `Header.Section`.
+2. **`Sidebar`** + `Sidebar.Section` + `Sidebar.Item`.
+3. **`Footer`**.
+4. Sidebar collapsible (icon-only mode).
+5. Sidebar.Item selected/disabled/icon.
+6. Header sections (start/center/end alignment).
+7. theme light/dark.
+8. width/height props.
+9. sticky props.
+10. polymorphic `as`.
+
+### Non-goals (v1)
+- Aside / right sidebar — v1.1.
+- nested sidebar items (tree).
+- breadcrumb 자동 — 별도 후보.
+- mobile drawer 모드 자동 전환 — v1.1.
+- backgrounds animation.
+- header search bar baked-in.
+
+---
+
+## 2. 공개 API
+
+### 2.1 타입 — `src/components/AppShellParts/types.ts`
+
+```ts
+import type { CSSProperties, ElementType, HTMLAttributes, ReactNode } from "react";
+
+export type AppShellPartsTheme = "light" | "dark";
+
+// Header
+export interface HeaderProps extends HTMLAttributes<HTMLElement> {
+  height?: number | string;     // 기본 56
+  sticky?: boolean;
+  theme?: AppShellPartsTheme;
+  as?: ElementType;
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface HeaderSectionProps extends HTMLAttributes<HTMLDivElement> {
+  align?: "start" | "center" | "end";
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+// Sidebar
+export interface SidebarProps extends HTMLAttributes<HTMLElement> {
+  width?: number | string;            // 기본 240
+  collapsedWidth?: number | string;   // 기본 60
+  collapsible?: boolean;
+  collapsed?: boolean;                // controlled
+  defaultCollapsed?: boolean;
+  onCollapseChange?: (collapsed: boolean) => void;
+  sticky?: boolean;
+  theme?: AppShellPartsTheme;
+  as?: ElementType;
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface SidebarSectionProps extends HTMLAttributes<HTMLDivElement> {
+  title?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+export interface SidebarItemProps extends Omit<HTMLAttributes<HTMLAnchorElement>, "onClick"> {
+  icon?: ReactNode;
+  selected?: boolean;
+  disabled?: boolean;
+  href?: string;
+  onClick?: (e: React.MouseEvent) => void;
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+// Footer
+export interface FooterProps extends HTMLAttributes<HTMLElement> {
+  height?: number | string;     // 기본 auto
+  sticky?: boolean;
+  theme?: AppShellPartsTheme;
+  as?: ElementType;
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+```
+
+### 2.2 Sidebar Context (collapse 상태 공유)
+
+```ts
+const SidebarContext = createContext<{ collapsed: boolean; theme: AppShellPartsTheme } | null>(null);
+function useSidebarContext() {
+  const ctx = useContext(SidebarContext);
+  return ctx ?? { collapsed: false, theme: "light" as const };
+}
+```
+
+### 2.3 Header — `src/components/AppShellParts/Header.tsx`
+
+```tsx
+const themes = {
+  light: { bg: "#fff", border: "#e5e7eb", fg: "#0f172a" },
+  dark: { bg: "#0f172a", border: "rgba(255,255,255,0.08)", fg: "#e5e7eb" },
+} as const;
+
+export function Header(props: HeaderProps) {
+  const { height = 56, sticky = false, theme = "light", as: Component = "header", children, className, style, ...rest } = props;
+  const t = themes[theme];
+
+  return (
+    <Component
+      className={className}
+      style={{
+        display: "flex", alignItems: "center", gap: 16,
+        height: typeof height === "number" ? `${height}px` : height,
+        padding: "0 16px",
+        background: t.bg, color: t.fg,
+        borderBottom: `1px solid ${t.border}`,
+        ...(sticky ? { position: "sticky", top: 0, zIndex: 30 } : {}),
+        boxSizing: "border-box",
+        ...style,
+      }}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+}
+
+export function HeaderSection(props: HeaderSectionProps) {
+  const { align = "start", className, style, children, ...rest } = props;
+  const justifyMap = { start: "flex-start", center: "center", end: "flex-end" } as const;
+
+  return (
+    <div
+      className={className}
+      style={{
+        display: "flex", alignItems: "center", gap: 12,
+        flex: align === "center" ? 1 : "none",
+        justifyContent: justifyMap[align],
+        ...(align === "end" ? { marginLeft: "auto" } : {}),
+        ...style,
+      }}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+Header.Section = HeaderSection;
+```
+
+### 2.4 Sidebar — `src/components/AppShellParts/Sidebar.tsx`
+
+```tsx
+export function Sidebar(props: SidebarProps) {
+  const {
+    width = 240, collapsedWidth = 60,
+    collapsible = false,
+    collapsed: controlledCollapsed, defaultCollapsed = false, onCollapseChange,
+    sticky = false, theme = "light", as: Component = "nav",
+    children, className, style, ...rest
+  } = props;
+
+  const [internalCollapsed, setInternalCollapsed] = useState(defaultCollapsed);
+  const collapsed = controlledCollapsed ?? internalCollapsed;
+  const setCollapsed = (next: boolean) => {
+    if (controlledCollapsed === undefined) setInternalCollapsed(next);
+    onCollapseChange?.(next);
+  };
+
+  const t = themes[theme];
+  const w = collapsed ? collapsedWidth : width;
+
+  return (
+    <SidebarContext.Provider value={{ collapsed, theme }}>
+      <Component
+        className={className}
+        style={{
+          display: "flex", flexDirection: "column",
+          width: typeof w === "number" ? `${w}px` : w,
+          height: "100%",
+          background: t.bg, color: t.fg,
+          borderRight: `1px solid ${t.border}`,
+          ...(sticky ? { position: "sticky", top: 0 } : {}),
+          transition: "width 200ms ease",
+          overflowY: "auto", overflowX: "hidden",
+          boxSizing: "border-box",
+          ...style,
+        }}
+        {...rest}
+      >
+        {children}
+        {collapsible && (
+          <button
+            onClick={() => setCollapsed(!collapsed)}
+            aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+            style={{
+              marginTop: "auto", padding: "8px 16px",
+              background: "transparent", border: "none", color: t.fg,
+              cursor: "pointer", display: "flex", alignItems: "center", gap: 8,
+            }}
+          >
+            <Icon name={collapsed ? "chevron-right" : "chevron-left"} size="sm" />
+            {!collapsed && <span>Collapse</span>}
+          </button>
+        )}
+      </Component>
+    </SidebarContext.Provider>
+  );
+}
+
+export function SidebarSection(props: SidebarSectionProps) {
+  const { title, children, className, style, ...rest } = props;
+  const { collapsed, theme } = useSidebarContext();
+  const t = themes[theme];
+
+  return (
+    <div className={className} style={{padding:"8px 0",...style}} {...rest}>
+      {title && !collapsed && (
+        <div style={{padding:"4px 16px",fontSize:11,fontWeight:600,color:`${t.fg}99`,textTransform:"uppercase",letterSpacing:0.5}}>
+          {title}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+export function SidebarItem(props: SidebarItemProps) {
+  const { icon, selected = false, disabled = false, href, onClick, children, className, style, ...rest } = props;
+  const { collapsed, theme } = useSidebarContext();
+  const t = themes[theme];
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (disabled) { e.preventDefault(); return; }
+    onClick?.(e);
+  };
+
+  const Component: ElementType = href ? "a" : "button";
+
+  return (
+    <Component
+      href={href}
+      onClick={handleClick}
+      disabled={Component === "button" ? disabled : undefined}
+      aria-current={selected ? "page" : undefined}
+      aria-disabled={disabled || undefined}
+      data-selected={selected || undefined}
+      className={className}
+      style={{
+        display: "flex", alignItems: "center", gap: 12,
+        padding: collapsed ? "10px" : "8px 16px",
+        justifyContent: collapsed ? "center" : "flex-start",
+        background: selected ? (theme === "dark" ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.05)") : "transparent",
+        color: selected ? "#2563eb" : t.fg,
+        textDecoration: "none",
+        border: "none",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+        fontSize: 13, fontWeight: selected ? 600 : 400,
+        width: "100%", textAlign: "left",
+        boxSizing: "border-box",
+        ...style,
+      }}
+      {...rest}
+    >
+      {icon && <span style={{flexShrink:0,display:"flex"}}>{icon}</span>}
+      {!collapsed && <span style={{flex:1,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{children}</span>}
+    </Component>
+  );
+}
+
+Sidebar.Section = SidebarSection;
+Sidebar.Item = SidebarItem;
+```
+
+### 2.5 Footer — `src/components/AppShellParts/Footer.tsx`
+
+```tsx
+export function Footer(props: FooterProps) {
+  const { height, sticky = false, theme = "light", as: Component = "footer", children, className, style, ...rest } = props;
+  const t = themes[theme];
+
+  return (
+    <Component
+      className={className}
+      style={{
+        display: "flex", alignItems: "center", gap: 16,
+        ...(height !== undefined ? { height: typeof height === "number" ? `${height}px` : height } : {}),
+        padding: "12px 16px",
+        background: t.bg, color: t.fg,
+        borderTop: `1px solid ${t.border}`,
+        ...(sticky ? { position: "sticky", bottom: 0, zIndex: 30 } : {}),
+        boxSizing: "border-box",
+        ...style,
+      }}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+}
+```
+
+### 2.6 배럴 — `src/components/AppShellParts/index.ts`
+
+```ts
+export { Header, HeaderSection } from "./Header";
+export { Sidebar, SidebarSection, SidebarItem } from "./Sidebar";
+export { Footer } from "./Footer";
+export type {
+  HeaderProps, HeaderSectionProps,
+  SidebarProps, SidebarSectionProps, SidebarItemProps,
+  FooterProps,
+  AppShellPartsTheme,
+} from "./types";
+```
+
+---
+
+## 3. 파일 구조
+
+```
+src/components/AppShellParts/
+├── Header.tsx
+├── Sidebar.tsx
+├── Footer.tsx
+├── SidebarContext.ts
+├── types.ts
+└── index.ts
+```
+
+---
+
+## 4. 데모 페이지
+
+```tsx
+export function AppShellPartsPage() {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div>
+      <h1>AppShell Parts (Sidebar + Header + Footer)</h1>
+
+      <Card.Root><Card.Header>Standalone Header</Card.Header><Card.Body style={{padding:0}}>
+        <Header>
+          <Header.Section>
+            <strong>plastic</strong>
+          </Header.Section>
+          <Header.Section align="center">
+            <button>Docs</button>
+            <button>Components</button>
+          </Header.Section>
+          <Header.Section align="end">
+            <button>Login</button>
+          </Header.Section>
+        </Header>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Standalone Sidebar</Card.Header><Card.Body style={{padding:0,height:400,display:"flex"}}>
+        <Sidebar collapsible collapsed={collapsed} onCollapseChange={setCollapsed}>
+          <Sidebar.Section title="Main">
+            <Sidebar.Item icon={<Icon name="search" />} selected>Search</Sidebar.Item>
+            <Sidebar.Item icon={<Icon name="info" />}>Info</Sidebar.Item>
+          </Sidebar.Section>
+          <Sidebar.Section title="Tools">
+            <Sidebar.Item icon={<Icon name="copy" />}>Copy</Sidebar.Item>
+            <Sidebar.Item icon={<Icon name="trash" />} disabled>Delete (disabled)</Sidebar.Item>
+          </Sidebar.Section>
+        </Sidebar>
+        <main style={{flex:1,padding:16}}>Main content</main>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Standalone Footer</Card.Header><Card.Body style={{padding:0}}>
+        <Footer>
+          <p style={{margin:0}}>© 2026 Plastic. All rights reserved.</p>
+        </Footer>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Full AppShell-like layout</Card.Header><Card.Body style={{padding:0}}>
+        <div style={{display:"grid",gridTemplate:"'h h' auto 's m' 1fr 'f f' auto / auto 1fr",height:500}}>
+          <Header style={{gridArea:"h"}}>
+            <Header.Section><strong>App</strong></Header.Section>
+            <Header.Section align="end"><Avatar /></Header.Section>
+          </Header>
+          <Sidebar style={{gridArea:"s"}} collapsible>
+            <Sidebar.Item icon={<Icon name="home" />} selected>Home</Sidebar.Item>
+            <Sidebar.Item icon={<Icon name="info" />}>About</Sidebar.Item>
+          </Sidebar>
+          <main style={{gridArea:"m",padding:16,overflow:"auto"}}>Main</main>
+          <Footer style={{gridArea:"f"}}><p>Footer</p></Footer>
+        </div>
+      </Card.Body></Card.Root>
+
+      <Card.Root><Card.Header>Dark theme</Card.Header><Card.Body style={{padding:0}}>
+        <Header theme="dark"><Header.Section>Dark App</Header.Section></Header>
+        <div style={{display:"flex",height:200}}>
+          <Sidebar theme="dark">
+            <Sidebar.Item icon={<Icon name="home" />} selected>Home</Sidebar.Item>
+          </Sidebar>
+          <main style={{flex:1,padding:16,background:"#1f2937",color:"#e5e7eb"}}>Dark</main>
+        </div>
+        <Footer theme="dark"><p>Dark Footer</p></Footer>
+      </Card.Body></Card.Root>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. 접근성
+
+- Header: `<header>` 시맨틱 + role="banner" 자동.
+- Sidebar: `<nav>` 시맨틱 + role="navigation" 자동.
+- Footer: `<footer>` 시맨틱 + role="contentinfo" 자동.
+- Sidebar.Item: anchor (href) 또는 button. `aria-current="page"` for selected.
+- Sidebar collapsible 토글: `aria-label` 동적.
+- 키보드: anchor/button 표준.
+
+## 6. Edge cases
+- Header height < icon — 자동 잘림. 사용자 책임.
+- Sidebar 아주 좁은 collapsedWidth (예: 40px): 아이콘만 → 정상.
+- Sidebar.Item children + icon 둘 다 없음: 빈 행.
+- Sidebar in horizontal layout: 사용자 책임 (parent flex 가정).
+- sticky + 부모 overflow auto 없음: sticky 작동 안 함.
+- href + onClick 동시: 둘 다 동작 (preventDefault 사용자 책임).
+
+## 7. 구현 단계
+- Phase 1: 6개 파일 작성
+- Phase 2: 데모
+- Phase 3: 정리
+
+## 8. 체크리스트
+- [ ] 6개 파일
+- [ ] typecheck/build
+- [ ] Header sections (start/center/end) 정상
+- [ ] Sidebar collapsible toggle
+- [ ] Sidebar.Item selected/disabled
+- [ ] Footer 정상
+- [ ] Full grid layout 데모 정상
+- [ ] dark theme
+- [ ] candidates / README

--- a/src/components/Calendar/Calendar.dateMath.ts
+++ b/src/components/Calendar/Calendar.dateMath.ts
@@ -1,0 +1,106 @@
+import type { CalendarDate } from "./Calendar.types";
+
+export function isValidCalendarDate(c: CalendarDate): boolean {
+  const d = new Date(c.year, c.month - 1, c.day);
+  return (
+    d.getFullYear() === c.year &&
+    d.getMonth() === c.month - 1 &&
+    d.getDate() === c.day
+  );
+}
+
+export function compareCalendarDate(a: CalendarDate, b: CalendarDate): number {
+  if (a.year !== b.year) return a.year - b.year;
+  if (a.month !== b.month) return a.month - b.month;
+  return a.day - b.day;
+}
+
+export function isSameDay(
+  a: CalendarDate | null,
+  b: CalendarDate | null,
+): boolean {
+  if (!a || !b) return false;
+  return a.year === b.year && a.month === b.month && a.day === b.day;
+}
+
+export function getDaysInMonth(year: number, month: number): number {
+  return new Date(year, month, 0).getDate();
+}
+
+export function startOfMonthWeekday(year: number, month: number): number {
+  return new Date(year, month - 1, 1).getDay();
+}
+
+export function addMonths(c: CalendarDate, delta: number): CalendarDate {
+  const targetMonthIndex = c.month - 1 + delta;
+  const year = c.year + Math.floor(targetMonthIndex / 12);
+  const monthIdx = ((targetMonthIndex % 12) + 12) % 12;
+  const monthHuman = monthIdx + 1;
+  const day = Math.min(c.day, getDaysInMonth(year, monthHuman));
+  return { year, month: monthHuman, day };
+}
+
+export function addDays(c: CalendarDate, delta: number): CalendarDate {
+  const d = new Date(c.year, c.month - 1, c.day + delta);
+  return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
+}
+
+export function addYears(c: CalendarDate, delta: number): CalendarDate {
+  return addMonths(c, delta * 12);
+}
+
+export function todayCalendarDate(): CalendarDate {
+  const d = new Date();
+  return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
+}
+
+export function orderedWeekdays(weekStartsOn: number): number[] {
+  return [0, 1, 2, 3, 4, 5, 6].map((i) => (i + weekStartsOn) % 7);
+}
+
+export function toCalendarDate(d: Date): CalendarDate {
+  return {
+    year: d.getFullYear(),
+    month: d.getMonth() + 1,
+    day: d.getDate(),
+  };
+}
+
+export function toDate(c: CalendarDate): Date {
+  return new Date(c.year, c.month - 1, c.day);
+}
+
+export function normalizeDateInput(
+  input: CalendarDate | Date | null | undefined,
+): CalendarDate | null {
+  if (input == null) return null;
+  if (input instanceof Date) return toCalendarDate(input);
+  return input;
+}
+
+export function weekdayOf(c: CalendarDate): number {
+  return new Date(c.year, c.month - 1, c.day).getDay();
+}
+
+export function buildMonthGrid(
+  currentMonth: CalendarDate,
+  weekStartsOn: number,
+): CalendarDate[] {
+  const { year, month } = currentMonth;
+  const firstWeekday = startOfMonthWeekday(year, month);
+  const lead = (firstWeekday - weekStartsOn + 7) % 7;
+  const start = addDays({ year, month, day: 1 }, -lead);
+  const grid: CalendarDate[] = [];
+  for (let i = 0; i < 42; i++) grid.push(addDays(start, i));
+  return grid;
+}
+
+export function clampToRange(
+  c: CalendarDate,
+  minDate: CalendarDate | null,
+  maxDate: CalendarDate | null,
+): CalendarDate {
+  if (minDate && compareCalendarDate(c, minDate) < 0) return minDate;
+  if (maxDate && compareCalendarDate(c, maxDate) > 0) return maxDate;
+  return c;
+}

--- a/src/components/Calendar/Calendar.intl.ts
+++ b/src/components/Calendar/Calendar.intl.ts
@@ -1,0 +1,46 @@
+import type { CalendarDate } from "./Calendar.types";
+
+export function getMonthLabel(
+  month: CalendarDate,
+  locale: string,
+  format: "long" | "short" = "long",
+): string {
+  const date = new Date(month.year, month.month - 1, 1);
+  return new Intl.DateTimeFormat(locale, {
+    month: format,
+    year: "numeric",
+  }).format(date);
+}
+
+export function getWeekdayLabel(
+  weekday: number,
+  locale: string,
+  format: "narrow" | "short" | "long" = "narrow",
+): string {
+  // 1970-01-04 is a Sunday; offset by `weekday` to get desired day-of-week
+  const date = new Date(1970, 0, 4 + weekday);
+  return new Intl.DateTimeFormat(locale, { weekday: format }).format(date);
+}
+
+export function defaultLocale(): string {
+  if (typeof navigator !== "undefined" && navigator.language) {
+    return navigator.language;
+  }
+  return "en-US";
+}
+
+export function deriveWeekStartsOn(locale: string): number {
+  if (typeof Intl === "undefined") return 0;
+  try {
+    const loc = new Intl.Locale(locale) as Intl.Locale & {
+      getWeekInfo?: () => { firstDay?: number };
+    };
+    const info = loc.getWeekInfo?.();
+    if (info?.firstDay != null) {
+      return info.firstDay === 7 ? 0 : info.firstDay;
+    }
+  } catch {
+    // ignore
+  }
+  return 0;
+}

--- a/src/components/Calendar/Calendar.theme.ts
+++ b/src/components/Calendar/Calendar.theme.ts
@@ -1,0 +1,86 @@
+import type { CalendarTheme } from "./Calendar.types";
+
+export interface CalendarThemeTokens {
+  bg: string;
+  border: string;
+
+  navBtn: string;
+  navBtnHover: string;
+  navBtnHoverBg: string;
+  monthLabel: string;
+
+  weekdayFg: string;
+
+  dayFg: string;
+  dayBg: string;
+  dayBgHover: string;
+  dayFgMuted: string;
+  dayFgToday: string;
+  dayBorderToday: string;
+  dayBgSelected: string;
+  dayFgSelected: string;
+  dayBgRange: string;
+  dayBgRangePreview: string;
+  dayFgDisabled: string;
+  dayBgDisabled: string;
+  dayBgFocused: string;
+
+  disabledOpacity: number;
+}
+
+export const calendarThemes: Record<CalendarTheme, CalendarThemeTokens> = {
+  light: {
+    bg: "#ffffff",
+    border: "rgba(0,0,0,0.08)",
+
+    navBtn: "#6b7280",
+    navBtnHover: "#111827",
+    navBtnHoverBg: "#f3f4f6",
+    monthLabel: "#111827",
+
+    weekdayFg: "#9ca3af",
+
+    dayFg: "#111827",
+    dayBg: "transparent",
+    dayBgHover: "#eef2ff",
+    dayFgMuted: "#cbd5e1",
+    dayFgToday: "#2563eb",
+    dayBorderToday: "#2563eb",
+    dayBgSelected: "#2563eb",
+    dayFgSelected: "#ffffff",
+    dayBgRange: "rgba(37,99,235,0.10)",
+    dayBgRangePreview: "rgba(37,99,235,0.05)",
+    dayFgDisabled: "#cbd5e1",
+    dayBgDisabled: "transparent",
+    dayBgFocused: "rgba(37,99,235,0.18)",
+
+    disabledOpacity: 0.5,
+  },
+  dark: {
+    bg: "#1f2937",
+    border: "rgba(255,255,255,0.08)",
+
+    navBtn: "#9ca3af",
+    navBtnHover: "#e5e7eb",
+    navBtnHoverBg: "#334155",
+    monthLabel: "#e5e7eb",
+
+    weekdayFg: "#6b7280",
+
+    dayFg: "#e5e7eb",
+    dayBg: "transparent",
+    dayBgHover: "#334155",
+    dayFgMuted: "#4b5563",
+    dayFgToday: "#60a5fa",
+    dayBorderToday: "#60a5fa",
+    dayBgSelected: "#60a5fa",
+    dayFgSelected: "#0f172a",
+    dayBgRange: "rgba(96,165,250,0.18)",
+    dayBgRangePreview: "rgba(96,165,250,0.10)",
+    dayFgDisabled: "#4b5563",
+    dayBgDisabled: "transparent",
+    dayBgFocused: "rgba(96,165,250,0.28)",
+
+    disabledOpacity: 0.5,
+  },
+};

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,0 +1,17 @@
+import { CalendarRoot } from "./CalendarRoot";
+import { CalendarHeader } from "./CalendarHeader";
+import { CalendarNav } from "./CalendarNav";
+import { CalendarMonthLabel } from "./CalendarMonthLabel";
+import { CalendarWeekdayHeader } from "./CalendarWeekdayHeader";
+import { CalendarGrid } from "./CalendarGrid";
+import { CalendarDay } from "./CalendarDay";
+
+export const Calendar = {
+  Root: CalendarRoot,
+  Header: CalendarHeader,
+  Nav: CalendarNav,
+  MonthLabel: CalendarMonthLabel,
+  WeekdayHeader: CalendarWeekdayHeader,
+  Grid: CalendarGrid,
+  Day: CalendarDay,
+};

--- a/src/components/Calendar/Calendar.types.ts
+++ b/src/components/Calendar/Calendar.types.ts
@@ -1,0 +1,125 @@
+import type { CSSProperties, ReactNode } from "react";
+
+export type CalendarTheme = "light" | "dark";
+export type CalendarMode = "single" | "range" | "multiple";
+
+/** Year 절대값, month 1-12 (1-indexed), day 1-31. JS Date 회피로 timezone-safe. */
+export interface CalendarDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+export type CalendarSingleValue = CalendarDate | null;
+
+export interface CalendarRangeValue {
+  start: CalendarDate | null;
+  end: CalendarDate | null;
+}
+
+export type CalendarMultipleValue = CalendarDate[];
+
+/** 0 = Sunday, 1 = Monday, ..., 6 = Saturday. */
+export type WeekStart = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface CalendarDayInfo {
+  date: CalendarDate;
+  inCurrentMonth: boolean;
+  isToday: boolean;
+  isSelected: boolean;
+  isRangeStart: boolean;
+  isRangeEnd: boolean;
+  isInRange: boolean;
+  isRangePreview: boolean;
+  isDisabled: boolean;
+  isFocused: boolean;
+}
+
+interface CalendarRootBase {
+  month?: CalendarDate;
+  defaultMonth?: CalendarDate;
+  onMonthChange?: (month: CalendarDate) => void;
+
+  minDate?: CalendarDate | Date;
+  maxDate?: CalendarDate | Date;
+  isDisabled?: (day: CalendarDate) => boolean;
+
+  locale?: string;
+  weekStartsOn?: WeekStart;
+  theme?: CalendarTheme;
+  disabled?: boolean;
+  autoFocus?: boolean;
+
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+export interface CalendarRootSingleProps extends CalendarRootBase {
+  mode?: "single";
+  value?: CalendarSingleValue;
+  defaultValue?: CalendarSingleValue;
+  onValueChange?: (value: CalendarSingleValue) => void;
+  onSelect?: (date: CalendarDate) => void;
+}
+
+export interface CalendarRootRangeProps extends CalendarRootBase {
+  mode: "range";
+  value?: CalendarRangeValue;
+  defaultValue?: CalendarRangeValue;
+  onValueChange?: (value: CalendarRangeValue) => void;
+  onSelect?: (range: CalendarRangeValue) => void;
+}
+
+export interface CalendarRootMultipleProps extends CalendarRootBase {
+  mode: "multiple";
+  value?: CalendarMultipleValue;
+  defaultValue?: CalendarMultipleValue;
+  onValueChange?: (value: CalendarMultipleValue) => void;
+  onSelect?: (dates: CalendarMultipleValue) => void;
+}
+
+export type CalendarRootProps =
+  | CalendarRootSingleProps
+  | CalendarRootRangeProps
+  | CalendarRootMultipleProps;
+
+export interface CalendarHeaderProps {
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+export interface CalendarNavProps {
+  direction: "prev-year" | "prev-month" | "next-month" | "next-year";
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+  "aria-label"?: string;
+}
+
+export interface CalendarMonthLabelProps {
+  format?: "long" | "short" | ((month: CalendarDate, locale: string) => string);
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface CalendarWeekdayHeaderProps {
+  format?: "narrow" | "short" | "long";
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface CalendarGridProps {
+  children?: (day: CalendarDayInfo) => ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface CalendarDayProps {
+  day: CalendarDayInfo;
+  onClick?: (date: CalendarDate) => void;
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}

--- a/src/components/Calendar/CalendarContext.ts
+++ b/src/components/Calendar/CalendarContext.ts
@@ -1,0 +1,50 @@
+import { createContext, useContext } from "react";
+import type {
+  CalendarDate,
+  CalendarMode,
+  CalendarMultipleValue,
+  CalendarRangeValue,
+  CalendarSingleValue,
+  CalendarTheme,
+  WeekStart,
+} from "./Calendar.types";
+
+export type CalendarContextValueUnion =
+  | CalendarSingleValue
+  | CalendarRangeValue
+  | CalendarMultipleValue;
+
+export interface CalendarContextValue {
+  mode: CalendarMode;
+
+  value: CalendarContextValueUnion;
+  setValue: (next: CalendarContextValueUnion) => void;
+
+  month: CalendarDate;
+  setMonth: (next: CalendarDate) => void;
+
+  isDisabledDay: (day: CalendarDate) => boolean;
+
+  focusedDay: CalendarDate | null;
+  setFocusedDay: (d: CalendarDate | null) => void;
+
+  rangePreviewEnd: CalendarDate | null;
+  setRangePreviewEnd: (d: CalendarDate | null) => void;
+
+  selectDay: (day: CalendarDate) => void;
+
+  locale: string;
+  weekStartsOn: WeekStart;
+  theme: CalendarTheme;
+  disabled: boolean;
+}
+
+export const CalendarContext = createContext<CalendarContextValue | null>(null);
+
+export function useCalendarContext(): CalendarContextValue {
+  const ctx = useContext(CalendarContext);
+  if (!ctx) {
+    throw new Error("Calendar.* components must be used within <Calendar.Root>");
+  }
+  return ctx;
+}

--- a/src/components/Calendar/CalendarDay.tsx
+++ b/src/components/Calendar/CalendarDay.tsx
@@ -1,0 +1,175 @@
+import { useCallback, type CSSProperties, type KeyboardEvent } from "react";
+import { useCalendarContext } from "./CalendarContext";
+import {
+  addDays,
+  addMonths,
+  addYears,
+  weekdayOf,
+} from "./Calendar.dateMath";
+import { calendarThemes } from "./Calendar.theme";
+import type {
+  CalendarDate,
+  CalendarDayProps,
+  WeekStart,
+} from "./Calendar.types";
+
+function weekdayIndex(date: CalendarDate, weekStartsOn: WeekStart): number {
+  const wd = weekdayOf(date);
+  return (wd - weekStartsOn + 7) % 7;
+}
+
+export function CalendarDay(props: CalendarDayProps) {
+  const { day, onClick, className, style, children } = props;
+  const ctx = useCalendarContext();
+  const tokens = calendarThemes[ctx.theme];
+
+  const handleClick = useCallback(() => {
+    if (day.isDisabled || ctx.disabled) return;
+    if (onClick) onClick(day.date);
+    else ctx.selectDay(day.date);
+  }, [day.isDisabled, day.date, ctx, onClick]);
+
+  const handleMouseEnter = useCallback(() => {
+    if (ctx.mode === "range" && !day.isDisabled) {
+      ctx.setRangePreviewEnd(day.date);
+    }
+    if (!day.isDisabled && !ctx.disabled) {
+      ctx.setFocusedDay(day.date);
+    }
+  }, [ctx, day.isDisabled, day.date]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLButtonElement>) => {
+      if (ctx.disabled) return;
+
+      let next: CalendarDate | null = null;
+      switch (e.key) {
+        case "ArrowLeft":
+          next = addDays(day.date, -1);
+          break;
+        case "ArrowRight":
+          next = addDays(day.date, 1);
+          break;
+        case "ArrowUp":
+          next = addDays(day.date, -7);
+          break;
+        case "ArrowDown":
+          next = addDays(day.date, 7);
+          break;
+        case "Home":
+          next = addDays(day.date, -weekdayIndex(day.date, ctx.weekStartsOn));
+          break;
+        case "End":
+          next = addDays(day.date, 6 - weekdayIndex(day.date, ctx.weekStartsOn));
+          break;
+        case "PageUp":
+          next = e.shiftKey ? addYears(day.date, -1) : addMonths(day.date, -1);
+          break;
+        case "PageDown":
+          next = e.shiftKey ? addYears(day.date, 1) : addMonths(day.date, 1);
+          break;
+        case "Enter":
+        case " ":
+          e.preventDefault();
+          handleClick();
+          return;
+        default:
+          return;
+      }
+
+      e.preventDefault();
+      if (next) {
+        ctx.setFocusedDay(next);
+        if (next.month !== ctx.month.month || next.year !== ctx.month.year) {
+          ctx.setMonth({ year: next.year, month: next.month, day: 1 });
+        }
+        const target = next;
+        requestAnimationFrame(() => {
+          const cell = document.querySelector<HTMLElement>(
+            `[data-day="${target.year}-${target.month}-${target.day}"]`,
+          );
+          cell?.focus();
+        });
+      }
+    },
+    [ctx, day.date, handleClick],
+  );
+
+  const fg = day.isDisabled
+    ? tokens.dayFgDisabled
+    : !day.inCurrentMonth
+      ? tokens.dayFgMuted
+      : day.isSelected
+        ? tokens.dayFgSelected
+        : day.isToday
+          ? tokens.dayFgToday
+          : tokens.dayFg;
+
+  const bg = day.isDisabled
+    ? tokens.dayBgDisabled
+    : day.isSelected || day.isRangeStart || day.isRangeEnd
+      ? tokens.dayBgSelected
+      : day.isInRange
+        ? tokens.dayBgRange
+        : day.isRangePreview
+          ? tokens.dayBgRangePreview
+          : day.isFocused
+            ? tokens.dayBgFocused
+            : tokens.dayBg;
+
+  const border =
+    day.isToday && !day.isSelected
+      ? `1px solid ${tokens.dayBorderToday}`
+      : "1px solid transparent";
+
+  const cellStyle: CSSProperties = {
+    width: 36,
+    height: 36,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: 13,
+    fontFamily: "inherit",
+    cursor: day.isDisabled ? "not-allowed" : "pointer",
+    color: fg,
+    background: bg,
+    border,
+    borderRadius: 4,
+    boxSizing: "border-box",
+    opacity: day.isDisabled ? tokens.disabledOpacity : 1,
+    outline: "none",
+    transition: "background 100ms ease, color 100ms ease",
+    padding: 0,
+    ...style,
+  };
+
+  return (
+    <button
+      type="button"
+      role="gridcell"
+      tabIndex={day.isFocused ? 0 : -1}
+      aria-selected={day.isSelected}
+      aria-disabled={day.isDisabled || undefined}
+      aria-label={`${day.date.year}-${String(day.date.month).padStart(2, "0")}-${String(day.date.day).padStart(2, "0")}`}
+      data-day={`${day.date.year}-${day.date.month}-${day.date.day}`}
+      data-day-focused={day.isFocused ? "true" : undefined}
+      data-day-selected={day.isSelected ? "true" : undefined}
+      data-day-today={day.isToday ? "true" : undefined}
+      data-in-current-month={day.inCurrentMonth ? "true" : undefined}
+      data-range-start={day.isRangeStart ? "true" : undefined}
+      data-range-end={day.isRangeEnd ? "true" : undefined}
+      data-in-range={day.isInRange ? "true" : undefined}
+      data-range-preview={day.isRangePreview ? "true" : undefined}
+      onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onKeyDown={handleKeyDown}
+      disabled={day.isDisabled || ctx.disabled}
+      className={className}
+      style={cellStyle}
+    >
+      {children ?? day.date.day}
+    </button>
+  );
+}
+
+CalendarDay.displayName = "Calendar.Day";

--- a/src/components/Calendar/CalendarGrid.tsx
+++ b/src/components/Calendar/CalendarGrid.tsx
@@ -1,0 +1,125 @@
+import { Fragment, useMemo, type CSSProperties } from "react";
+import { useCalendarContext } from "./CalendarContext";
+import {
+  buildMonthGrid,
+  compareCalendarDate,
+  isSameDay,
+  todayCalendarDate,
+} from "./Calendar.dateMath";
+import { CalendarDay } from "./CalendarDay";
+import type {
+  CalendarContextValue,
+} from "./CalendarContext";
+import type {
+  CalendarDate,
+  CalendarDayInfo,
+  CalendarGridProps,
+  CalendarMultipleValue,
+  CalendarRangeValue,
+  CalendarSingleValue,
+} from "./Calendar.types";
+
+function computeDayInfo(
+  date: CalendarDate,
+  ctx: CalendarContextValue,
+): CalendarDayInfo {
+  const today = todayCalendarDate();
+  const inCurrentMonth =
+    date.month === ctx.month.month && date.year === ctx.month.year;
+  const isToday = isSameDay(date, today);
+
+  let isSelected = false;
+  let isRangeStart = false;
+  let isRangeEnd = false;
+  let isInRange = false;
+  let isRangePreview = false;
+
+  if (ctx.mode === "single") {
+    const v = ctx.value as CalendarSingleValue;
+    isSelected = isSameDay(date, v);
+  } else if (ctx.mode === "range") {
+    const v = ctx.value as CalendarRangeValue;
+    isRangeStart = isSameDay(date, v.start);
+    isRangeEnd = isSameDay(date, v.end);
+    if (v.start && v.end) {
+      isInRange =
+        compareCalendarDate(date, v.start) > 0 &&
+        compareCalendarDate(date, v.end) < 0;
+    }
+    isSelected = isRangeStart || isRangeEnd;
+
+    if (v.start && !v.end && ctx.rangePreviewEnd) {
+      const lo =
+        compareCalendarDate(v.start, ctx.rangePreviewEnd) <= 0
+          ? v.start
+          : ctx.rangePreviewEnd;
+      const hi =
+        compareCalendarDate(v.start, ctx.rangePreviewEnd) <= 0
+          ? ctx.rangePreviewEnd
+          : v.start;
+      isRangePreview =
+        compareCalendarDate(date, lo) >= 0 && compareCalendarDate(date, hi) <= 0;
+    }
+  } else if (ctx.mode === "multiple") {
+    const v = ctx.value as CalendarMultipleValue;
+    isSelected = v.some((d) => isSameDay(d, date));
+  }
+
+  return {
+    date,
+    inCurrentMonth,
+    isToday,
+    isSelected,
+    isRangeStart,
+    isRangeEnd,
+    isInRange,
+    isRangePreview,
+    isDisabled: ctx.isDisabledDay(date),
+    isFocused: isSameDay(date, ctx.focusedDay),
+  };
+}
+
+export function CalendarGrid(props: CalendarGridProps) {
+  const { children, className, style } = props;
+  const ctx = useCalendarContext();
+  const days = useMemo(
+    () => buildMonthGrid(ctx.month, ctx.weekStartsOn),
+    [ctx.month, ctx.weekStartsOn],
+  );
+
+  const handleMouseLeave = () => {
+    if (ctx.mode === "range") ctx.setRangePreviewEnd(null);
+  };
+
+  const baseStyle: CSSProperties = {
+    display: "grid",
+    gridTemplateColumns: "repeat(7, 1fr)",
+    gap: 0,
+    ...style,
+  };
+
+  return (
+    <div
+      role="grid"
+      className={className}
+      style={baseStyle}
+      onMouseLeave={handleMouseLeave}
+    >
+      {days.map((date, i) => {
+        const info = computeDayInfo(date, ctx);
+        return children ? (
+          <Fragment key={`${date.year}-${date.month}-${date.day}-${i}`}>
+            {children(info)}
+          </Fragment>
+        ) : (
+          <CalendarDay
+            key={`${date.year}-${date.month}-${date.day}-${i}`}
+            day={info}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+CalendarGrid.displayName = "Calendar.Grid";

--- a/src/components/Calendar/CalendarHeader.tsx
+++ b/src/components/Calendar/CalendarHeader.tsx
@@ -1,0 +1,23 @@
+import type { CSSProperties } from "react";
+import type { CalendarHeaderProps } from "./Calendar.types";
+
+export function CalendarHeader(props: CalendarHeaderProps) {
+  const { className, style, children } = props;
+
+  const baseStyle: CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: "4px 4px 8px",
+    gap: 4,
+    ...style,
+  };
+
+  return (
+    <div className={className} style={baseStyle}>
+      {children}
+    </div>
+  );
+}
+
+CalendarHeader.displayName = "Calendar.Header";

--- a/src/components/Calendar/CalendarMonthLabel.tsx
+++ b/src/components/Calendar/CalendarMonthLabel.tsx
@@ -1,0 +1,34 @@
+import type { CSSProperties } from "react";
+import { useCalendarContext } from "./CalendarContext";
+import { getMonthLabel } from "./Calendar.intl";
+import { calendarThemes } from "./Calendar.theme";
+import type { CalendarMonthLabelProps } from "./Calendar.types";
+
+export function CalendarMonthLabel(props: CalendarMonthLabelProps) {
+  const { format = "long", className, style } = props;
+  const ctx = useCalendarContext();
+  const tokens = calendarThemes[ctx.theme];
+
+  const label =
+    typeof format === "function"
+      ? format(ctx.month, ctx.locale)
+      : getMonthLabel(ctx.month, ctx.locale, format);
+
+  const baseStyle: CSSProperties = {
+    fontWeight: 600,
+    fontSize: 13,
+    color: tokens.monthLabel,
+    flex: 1,
+    textAlign: "center",
+    userSelect: "none",
+    ...style,
+  };
+
+  return (
+    <span aria-live="polite" className={className} style={baseStyle}>
+      {label}
+    </span>
+  );
+}
+
+CalendarMonthLabel.displayName = "Calendar.MonthLabel";

--- a/src/components/Calendar/CalendarNav.tsx
+++ b/src/components/Calendar/CalendarNav.tsx
@@ -1,0 +1,70 @@
+import { useState, type CSSProperties } from "react";
+import { useCalendarContext } from "./CalendarContext";
+import { addMonths } from "./Calendar.dateMath";
+import { calendarThemes } from "./Calendar.theme";
+import type { CalendarNavProps } from "./Calendar.types";
+
+const labelMap: Record<CalendarNavProps["direction"], string> = {
+  "prev-year": "Previous year",
+  "prev-month": "Previous month",
+  "next-month": "Next month",
+  "next-year": "Next year",
+};
+
+const defaultGlyph: Record<CalendarNavProps["direction"], string> = {
+  "prev-year": "«",
+  "prev-month": "‹",
+  "next-month": "›",
+  "next-year": "»",
+};
+
+const deltaMap: Record<CalendarNavProps["direction"], number> = {
+  "prev-year": -12,
+  "prev-month": -1,
+  "next-month": 1,
+  "next-year": 12,
+};
+
+export function CalendarNav(props: CalendarNavProps) {
+  const { direction, className, style, children, "aria-label": ariaLabel } = props;
+  const ctx = useCalendarContext();
+  const tokens = calendarThemes[ctx.theme];
+  const [hovered, setHovered] = useState(false);
+
+  const handleClick = () => {
+    if (ctx.disabled) return;
+    ctx.setMonth(addMonths(ctx.month, deltaMap[direction]));
+  };
+
+  const baseStyle: CSSProperties = {
+    background: hovered && !ctx.disabled ? tokens.navBtnHoverBg : "transparent",
+    border: "none",
+    color: hovered && !ctx.disabled ? tokens.navBtnHover : tokens.navBtn,
+    cursor: ctx.disabled ? "not-allowed" : "pointer",
+    padding: "4px 8px",
+    borderRadius: 4,
+    fontSize: 14,
+    lineHeight: 1,
+    fontFamily: "inherit",
+    transition: "background 120ms ease, color 120ms ease",
+    ...style,
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      aria-label={ariaLabel ?? labelMap[direction]}
+      disabled={ctx.disabled}
+      className={className}
+      style={baseStyle}
+      data-nav-direction={direction}
+    >
+      {children ?? defaultGlyph[direction]}
+    </button>
+  );
+}
+
+CalendarNav.displayName = "Calendar.Nav";

--- a/src/components/Calendar/CalendarRoot.tsx
+++ b/src/components/Calendar/CalendarRoot.tsx
@@ -1,0 +1,237 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import { CalendarContext, type CalendarContextValue, type CalendarContextValueUnion } from "./CalendarContext";
+import {
+  compareCalendarDate,
+  isSameDay,
+  normalizeDateInput,
+  todayCalendarDate,
+} from "./Calendar.dateMath";
+import { calendarThemes } from "./Calendar.theme";
+import { defaultLocale } from "./Calendar.intl";
+import type {
+  CalendarDate,
+  CalendarMultipleValue,
+  CalendarRangeValue,
+  CalendarRootProps,
+  CalendarSingleValue,
+  WeekStart,
+} from "./Calendar.types";
+
+function defaultValueFor(mode: "single" | "range" | "multiple"): CalendarContextValueUnion {
+  if (mode === "range") return { start: null, end: null } satisfies CalendarRangeValue;
+  if (mode === "multiple") return [] as CalendarMultipleValue;
+  return null as CalendarSingleValue;
+}
+
+export function CalendarRoot(props: CalendarRootProps) {
+  const mode = (props.mode ?? "single") as "single" | "range" | "multiple";
+
+  const {
+    month: controlledMonth,
+    defaultMonth,
+    onMonthChange,
+    minDate,
+    maxDate,
+    isDisabled,
+    locale = defaultLocale(),
+    weekStartsOn = 0 as WeekStart,
+    theme = "light",
+    disabled = false,
+    autoFocus = false,
+    className,
+    style,
+    children,
+  } = props;
+
+  // value (controlled / uncontrolled)
+  const isValueControlled = "value" in props && props.value !== undefined;
+  const initialValue = useMemo<CalendarContextValueUnion>(() => {
+    if ("defaultValue" in props && props.defaultValue !== undefined) {
+      return props.defaultValue as CalendarContextValueUnion;
+    }
+    return defaultValueFor(mode);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const [internalValue, setInternalValue] = useState<CalendarContextValueUnion>(initialValue);
+  const value = isValueControlled
+    ? ((props as { value: CalendarContextValueUnion }).value)
+    : internalValue;
+
+  const setValue = useCallback((next: CalendarContextValueUnion) => {
+    if (!isValueControlled) setInternalValue(next);
+    // narrow callback by mode
+    if (mode === "single") {
+      (props as CalendarRootProps & { onValueChange?: (v: CalendarSingleValue) => void })
+        .onValueChange?.(next as CalendarSingleValue);
+    } else if (mode === "range") {
+      (props as CalendarRootProps & { onValueChange?: (v: CalendarRangeValue) => void })
+        .onValueChange?.(next as CalendarRangeValue);
+    } else {
+      (props as CalendarRootProps & { onValueChange?: (v: CalendarMultipleValue) => void })
+        .onValueChange?.(next as CalendarMultipleValue);
+    }
+  }, [isValueControlled, mode, props]);
+
+  // month (controlled / uncontrolled)
+  const initialMonth = useMemo<CalendarDate>(() => {
+    if (controlledMonth) return controlledMonth;
+    if (defaultMonth) return defaultMonth;
+    if (mode === "single" && value) return value as CalendarDate;
+    if (mode === "range") {
+      const v = value as CalendarRangeValue;
+      if (v.start) return v.start;
+      if (v.end) return v.end;
+    }
+    if (mode === "multiple") {
+      const v = value as CalendarMultipleValue;
+      if (v.length > 0) return v[0]!;
+    }
+    return todayCalendarDate();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const [internalMonth, setInternalMonth] = useState<CalendarDate>(initialMonth);
+  const month = controlledMonth ?? internalMonth;
+  const setMonth = useCallback((next: CalendarDate) => {
+    if (controlledMonth === undefined) setInternalMonth(next);
+    onMonthChange?.(next);
+  }, [controlledMonth, onMonthChange]);
+
+  // focus
+  const [focusedDay, setFocusedDay] = useState<CalendarDate | null>(null);
+
+  // range preview
+  const [rangePreviewEnd, setRangePreviewEnd] = useState<CalendarDate | null>(null);
+
+  // disabled predicate (combined min/max + custom)
+  const minDateNorm = useMemo(() => normalizeDateInput(minDate), [minDate]);
+  const maxDateNorm = useMemo(() => normalizeDateInput(maxDate), [maxDate]);
+  const isDisabledDay = useCallback(
+    (d: CalendarDate) => {
+      if (minDateNorm && compareCalendarDate(d, minDateNorm) < 0) return true;
+      if (maxDateNorm && compareCalendarDate(d, maxDateNorm) > 0) return true;
+      if (isDisabled?.(d)) return true;
+      return false;
+    },
+    [minDateNorm, maxDateNorm, isDisabled],
+  );
+
+  const selectDay = useCallback(
+    (day: CalendarDate) => {
+      if (disabled || isDisabledDay(day)) return;
+
+      if (mode === "single") {
+        setValue(day);
+        (props as CalendarRootProps & { onSelect?: (d: CalendarDate) => void }).onSelect?.(day);
+      } else if (mode === "range") {
+        const cur = value as CalendarRangeValue;
+        let next: CalendarRangeValue;
+        if (cur.start === null || (cur.start !== null && cur.end !== null)) {
+          next = { start: day, end: null };
+        } else {
+          if (compareCalendarDate(day, cur.start) < 0) {
+            next = { start: day, end: cur.start };
+          } else {
+            next = { start: cur.start, end: day };
+          }
+        }
+        setValue(next);
+        if (next.start && next.end) {
+          (props as CalendarRootProps & { onSelect?: (r: CalendarRangeValue) => void }).onSelect?.(next);
+        }
+      } else if (mode === "multiple") {
+        const cur = value as CalendarMultipleValue;
+        const idx = cur.findIndex((d) => isSameDay(d, day));
+        let next: CalendarMultipleValue;
+        if (idx >= 0) {
+          next = [...cur.slice(0, idx), ...cur.slice(idx + 1)];
+        } else {
+          next = [...cur, day].sort(compareCalendarDate);
+        }
+        setValue(next);
+        (props as CalendarRootProps & { onSelect?: (d: CalendarMultipleValue) => void }).onSelect?.(next);
+      }
+    },
+    [disabled, isDisabledDay, mode, value, setValue, props],
+  );
+
+  // autoFocus (mount 시 첫 cell 포커스)
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!autoFocus) return;
+    const initialFocus: CalendarDate = (() => {
+      if (mode === "single" && value) return value as CalendarDate;
+      if (mode === "range") {
+        const v = value as CalendarRangeValue;
+        if (v.start) return v.start;
+      }
+      if (mode === "multiple") {
+        const v = value as CalendarMultipleValue;
+        if (v.length > 0) return v[0]!;
+      }
+      return todayCalendarDate();
+    })();
+    setFocusedDay(initialFocus);
+    requestAnimationFrame(() => {
+      const cell = rootRef.current?.querySelector<HTMLElement>(`[data-day-focused="true"]`);
+      cell?.focus();
+    });
+  }, [autoFocus]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const tokens = calendarThemes[theme];
+
+  const ctx: CalendarContextValue = useMemo(
+    () => ({
+      mode,
+      value,
+      setValue,
+      month,
+      setMonth,
+      isDisabledDay,
+      focusedDay,
+      setFocusedDay,
+      rangePreviewEnd,
+      setRangePreviewEnd,
+      selectDay,
+      locale,
+      weekStartsOn,
+      theme,
+      disabled,
+    }),
+    [mode, value, setValue, month, setMonth, isDisabledDay, focusedDay, rangePreviewEnd, selectDay, locale, weekStartsOn, theme, disabled],
+  );
+
+  const rootStyle: CSSProperties = {
+    display: "inline-block",
+    background: tokens.bg,
+    border: `1px solid ${tokens.border}`,
+    borderRadius: 8,
+    padding: 8,
+    fontFamily: "inherit",
+    boxSizing: "border-box",
+    ...style,
+  };
+
+  return (
+    <CalendarContext.Provider value={ctx}>
+      <div
+        ref={rootRef}
+        role="application"
+        aria-label="Calendar"
+        aria-disabled={disabled || undefined}
+        className={className}
+        style={rootStyle}
+      >
+        {children}
+      </div>
+    </CalendarContext.Provider>
+  );
+}
+
+CalendarRoot.displayName = "Calendar.Root";

--- a/src/components/Calendar/CalendarWeekdayHeader.tsx
+++ b/src/components/Calendar/CalendarWeekdayHeader.tsx
@@ -1,0 +1,38 @@
+import type { CSSProperties } from "react";
+import { useCalendarContext } from "./CalendarContext";
+import { orderedWeekdays } from "./Calendar.dateMath";
+import { getWeekdayLabel } from "./Calendar.intl";
+import { calendarThemes } from "./Calendar.theme";
+import type { CalendarWeekdayHeaderProps } from "./Calendar.types";
+
+export function CalendarWeekdayHeader(props: CalendarWeekdayHeaderProps) {
+  const { format = "narrow", className, style } = props;
+  const ctx = useCalendarContext();
+  const tokens = calendarThemes[ctx.theme];
+  const weekdays = orderedWeekdays(ctx.weekStartsOn);
+
+  const baseStyle: CSSProperties = {
+    display: "grid",
+    gridTemplateColumns: "repeat(7, 1fr)",
+    textAlign: "center",
+    fontSize: 11,
+    color: tokens.weekdayFg,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    padding: "4px 0",
+    userSelect: "none",
+    ...style,
+  };
+
+  return (
+    <div className={className} style={baseStyle}>
+      {weekdays.map((wd) => (
+        <span key={wd} aria-hidden="true">
+          {getWeekdayLabel(wd, ctx.locale, format)}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+CalendarWeekdayHeader.displayName = "Calendar.WeekdayHeader";

--- a/src/components/Calendar/index.ts
+++ b/src/components/Calendar/index.ts
@@ -1,0 +1,45 @@
+export { Calendar } from "./Calendar";
+export { CalendarRoot } from "./CalendarRoot";
+export { CalendarHeader } from "./CalendarHeader";
+export { CalendarNav } from "./CalendarNav";
+export { CalendarMonthLabel } from "./CalendarMonthLabel";
+export { CalendarWeekdayHeader } from "./CalendarWeekdayHeader";
+export { CalendarGrid } from "./CalendarGrid";
+export { CalendarDay } from "./CalendarDay";
+export type {
+  CalendarRootProps,
+  CalendarRootSingleProps,
+  CalendarRootRangeProps,
+  CalendarRootMultipleProps,
+  CalendarHeaderProps,
+  CalendarNavProps,
+  CalendarMonthLabelProps,
+  CalendarWeekdayHeaderProps,
+  CalendarGridProps,
+  CalendarDayProps,
+  CalendarDate,
+  CalendarDayInfo,
+  CalendarMode,
+  CalendarSingleValue,
+  CalendarRangeValue,
+  CalendarMultipleValue,
+  CalendarTheme,
+  WeekStart,
+} from "./Calendar.types";
+export type { CalendarThemeTokens } from "./Calendar.theme";
+export {
+  isSameDay,
+  isValidCalendarDate,
+  compareCalendarDate,
+  todayCalendarDate,
+  toCalendarDate,
+  toDate,
+  weekdayOf,
+  buildMonthGrid,
+  addDays,
+  addMonths,
+  addYears,
+  clampToRange,
+  normalizeDateInput,
+  orderedWeekdays,
+} from "./Calendar.dateMath";

--- a/src/components/DatePicker/DatePicker.dateMath.ts
+++ b/src/components/DatePicker/DatePicker.dateMath.ts
@@ -1,106 +1,20 @@
-import type { CalendarDate } from "./DatePicker.types";
-
-export function isValidCalendarDate(c: CalendarDate): boolean {
-  const d = new Date(c.year, c.month - 1, c.day);
-  return (
-    d.getFullYear() === c.year &&
-    d.getMonth() === c.month - 1 &&
-    d.getDate() === c.day
-  );
-}
-
-export function compareCalendarDate(a: CalendarDate, b: CalendarDate): number {
-  if (a.year !== b.year) return a.year - b.year;
-  if (a.month !== b.month) return a.month - b.month;
-  return a.day - b.day;
-}
-
-export function isSameDay(
-  a: CalendarDate | null,
-  b: CalendarDate | null,
-): boolean {
-  if (!a || !b) return false;
-  return a.year === b.year && a.month === b.month && a.day === b.day;
-}
-
-export function getDaysInMonth(year: number, month: number): number {
-  return new Date(year, month, 0).getDate();
-}
-
-export function startOfMonthWeekday(year: number, month: number): number {
-  return new Date(year, month - 1, 1).getDay();
-}
-
-export function addMonths(c: CalendarDate, delta: number): CalendarDate {
-  const targetMonthIndex = c.month - 1 + delta;
-  const year = c.year + Math.floor(targetMonthIndex / 12);
-  const monthIdx = ((targetMonthIndex % 12) + 12) % 12;
-  const monthHuman = monthIdx + 1;
-  const day = Math.min(c.day, getDaysInMonth(year, monthHuman));
-  return { year, month: monthHuman, day };
-}
-
-export function addDays(c: CalendarDate, delta: number): CalendarDate {
-  const d = new Date(c.year, c.month - 1, c.day + delta);
-  return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
-}
-
-export function addYears(c: CalendarDate, delta: number): CalendarDate {
-  return addMonths(c, delta * 12);
-}
-
-export function todayCalendarDate(): CalendarDate {
-  const d = new Date();
-  return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
-}
-
-export function orderedWeekdays(weekStartsOn: number): number[] {
-  return [0, 1, 2, 3, 4, 5, 6].map((i) => (i + weekStartsOn) % 7);
-}
-
-export function toCalendarDate(d: Date): CalendarDate {
-  return {
-    year: d.getFullYear(),
-    month: d.getMonth() + 1,
-    day: d.getDate(),
-  };
-}
-
-export function toDate(c: CalendarDate): Date {
-  return new Date(c.year, c.month - 1, c.day);
-}
-
-export function normalizeDateInput(
-  input: CalendarDate | Date | null | undefined,
-): CalendarDate | null {
-  if (input == null) return null;
-  if (input instanceof Date) return toCalendarDate(input);
-  return input;
-}
-
-export function weekdayOf(c: CalendarDate): number {
-  return new Date(c.year, c.month - 1, c.day).getDay();
-}
-
-export function buildMonthGrid(
-  currentMonth: CalendarDate,
-  weekStartsOn: number,
-): CalendarDate[] {
-  const { year, month } = currentMonth;
-  const firstWeekday = startOfMonthWeekday(year, month);
-  const lead = (firstWeekday - weekStartsOn + 7) % 7;
-  const start = addDays({ year, month, day: 1 }, -lead);
-  const grid: CalendarDate[] = [];
-  for (let i = 0; i < 42; i++) grid.push(addDays(start, i));
-  return grid;
-}
-
-export function clampToRange(
-  c: CalendarDate,
-  minDate: CalendarDate | null,
-  maxDate: CalendarDate | null,
-): CalendarDate {
-  if (minDate && compareCalendarDate(c, minDate) < 0) return minDate;
-  if (maxDate && compareCalendarDate(c, maxDate) > 0) return maxDate;
-  return c;
-}
+// All date math is now centralized in Calendar/Calendar.dateMath.ts.
+// This file re-exports from there for backwards compatibility within DatePicker.
+export {
+  isValidCalendarDate,
+  compareCalendarDate,
+  isSameDay,
+  getDaysInMonth,
+  startOfMonthWeekday,
+  addMonths,
+  addDays,
+  addYears,
+  todayCalendarDate,
+  orderedWeekdays,
+  toCalendarDate,
+  toDate,
+  normalizeDateInput,
+  weekdayOf,
+  buildMonthGrid,
+  clampToRange,
+} from "../Calendar/Calendar.dateMath";

--- a/src/components/DatePicker/DatePicker.intl.ts
+++ b/src/components/DatePicker/DatePicker.intl.ts
@@ -1,3 +1,10 @@
+// Locale helpers — Calendar provides shared locale utilities.
+// DatePicker still needs its own per-purpose Intl.DateTimeFormat instances
+// (monthLabel/weekdayShort/ariaDate) for the popover header, which differ
+// in shape from Calendar's per-call formatters. Both coexist.
+
+export { deriveWeekStartsOn } from "../Calendar/Calendar.intl";
+
 export function createMonthLabelFormatter(locale: string): Intl.DateTimeFormat {
   return new Intl.DateTimeFormat(locale, { year: "numeric", month: "long" });
 }
@@ -10,20 +17,4 @@ export function createWeekdayShortFormatter(
 
 export function createAriaDateFormatter(locale: string): Intl.DateTimeFormat {
   return new Intl.DateTimeFormat(locale, { dateStyle: "full" });
-}
-
-export function deriveWeekStartsOn(locale: string): number {
-  if (typeof Intl === "undefined") return 0;
-  try {
-    const loc = new Intl.Locale(locale) as Intl.Locale & {
-      getWeekInfo?: () => { firstDay?: number };
-    };
-    const info = loc.getWeekInfo?.();
-    if (info?.firstDay != null) {
-      return info.firstDay === 7 ? 0 : info.firstDay;
-    }
-  } catch {
-    // ignore
-  }
-  return 0;
 }

--- a/src/components/DatePicker/DatePicker.parts.tsx
+++ b/src/components/DatePicker/DatePicker.parts.tsx
@@ -1,39 +1,456 @@
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type CSSProperties,
+  type FocusEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
+import { Calendar } from "../Calendar";
 import type {
-  DatePickerInputProps,
-  DatePickerTriggerProps,
+  CalendarDate,
+  CalendarMultipleValue,
+  CalendarRangeValue,
+  CalendarSingleValue,
+} from "../Calendar/Calendar.types";
+import { useDatePickerContext } from "./DatePickerContext";
+import { datePickerPalette } from "./DatePicker.theme";
+import { formatCalendarDate, parseRaw } from "./DatePicker.format";
+import type {
   DatePickerCalendarProps,
-  DatePickerHeaderProps,
-  DatePickerMonthLabelProps,
-  DatePickerNavProps,
-  DatePickerGridProps,
   DatePickerDayProps,
   DatePickerFooterProps,
+  DatePickerGridProps,
+  DatePickerHeaderProps,
+  DatePickerInputProps,
+  DatePickerMonthLabelProps,
+  DatePickerNavProps,
+  DatePickerTriggerProps,
 } from "./DatePicker.types";
 
-export function DatePickerInput(_props: DatePickerInputProps) {
-  return null;
+// ── DatePickerInput ─────────────────────────────────────────────────────────
+
+export function DatePickerInput(props: DatePickerInputProps) {
+  const { placeholder, className, style, part, "aria-label": ariaLabel } = props;
+  const ctx = useDatePickerContext();
+  const palette = datePickerPalette[ctx.theme];
+  const [hovered, setHovered] = useState(false);
+
+  // 표시 값 결정
+  const isEnd = part === "end";
+  const formattedValue = (() => {
+    if (ctx.mode === "single") {
+      return ctx.single ? formatCalendarDate(ctx.single, ctx.format) : "";
+    }
+    const v = isEnd ? ctx.range.end : ctx.range.start;
+    return v ? formatCalendarDate(v, ctx.format) : "";
+  })();
+
+  const typed = isEnd ? ctx.typedRawEnd : ctx.typedRaw;
+  const display = typed !== null ? typed : formattedValue;
+
+  const isInvalid = isEnd ? ctx.invalidEnd : ctx.invalid;
+
+  const inputRef = part === "end" ? ctx.inputEndRef : ctx.inputRef;
+  const inputId = part === "start" ? ctx.ids.inputStart : part === "end" ? ctx.ids.inputEnd : ctx.ids.input;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = e.target.value;
+    if (isEnd) ctx.setTypedRawEnd(v);
+    else ctx.setTypedRaw(v);
+  };
+
+  const handleBlur = (_e: FocusEvent<HTMLInputElement>) => {
+    ctx.commitTyped(part ?? null);
+  };
+
+  const handleFocus = () => {
+    if (ctx.openOnFocus && !ctx.disabled) ctx.setOpen(true);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      ctx.commitTyped(part ?? null);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      ctx.cancelTyped(part ?? null);
+      ctx.setOpen(false);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      ctx.setOpen(true);
+      ctx.requestFocusOnFocusedDay();
+    }
+  };
+
+  const baseStyle: CSSProperties = {
+    background: palette.inputBg,
+    color: palette.inputFg,
+    border: `1px solid ${
+      isInvalid ? palette.inputError : hovered ? palette.inputFocusRing : palette.border
+    }`,
+    borderRadius: 6,
+    padding: "6px 10px",
+    fontSize: 13,
+    fontFamily: "inherit",
+    outline: "none",
+    minWidth: 130,
+    boxSizing: "border-box",
+    transition: "border-color 120ms ease",
+    ...style,
+  };
+
+  return (
+    <input
+      ref={inputRef as React.RefObject<HTMLInputElement>}
+      id={inputId}
+      type="text"
+      role="combobox"
+      aria-haspopup="dialog"
+      aria-expanded={ctx.open}
+      aria-controls={ctx.ids.dialog}
+      aria-invalid={isInvalid || undefined}
+      aria-label={ariaLabel ?? (part === "end" ? "End date" : part === "start" ? "Start date" : "Date")}
+      value={display}
+      placeholder={placeholder ?? ctx.format}
+      disabled={ctx.disabled}
+      onChange={handleChange}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className={className}
+      style={baseStyle}
+      data-datepicker-input
+      data-part={part}
+    />
+  );
 }
-export function DatePickerTrigger(_props: DatePickerTriggerProps) {
-  return null;
+DatePickerInput.displayName = "DatePicker.Input";
+
+// ── DatePickerTrigger ────────────────────────────────────────────────────────
+
+export function DatePickerTrigger(props: DatePickerTriggerProps) {
+  const { className, style, children, "aria-label": ariaLabel } = props;
+  const ctx = useDatePickerContext();
+  const palette = datePickerPalette[ctx.theme];
+  const [hovered, setHovered] = useState(false);
+
+  const handleClick = () => {
+    if (ctx.disabled) return;
+    ctx.setOpen(!ctx.open);
+  };
+
+  const baseStyle: CSSProperties = {
+    background: hovered && !ctx.disabled ? palette.navHoverBg : palette.inputBg,
+    color: palette.inputFg,
+    border: `1px solid ${palette.border}`,
+    borderRadius: 6,
+    padding: "6px 8px",
+    fontSize: 13,
+    fontFamily: "inherit",
+    cursor: ctx.disabled ? "not-allowed" : "pointer",
+    opacity: ctx.disabled ? 0.5 : 1,
+    transition: "background 120ms ease",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    ...style,
+  };
+
+  return (
+    <button
+      ref={ctx.triggerRef as React.RefObject<HTMLButtonElement>}
+      type="button"
+      id={ctx.ids.trigger}
+      aria-label={ariaLabel ?? "Open calendar"}
+      aria-haspopup="dialog"
+      aria-expanded={ctx.open}
+      aria-controls={ctx.ids.dialog}
+      onClick={handleClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      disabled={ctx.disabled}
+      className={className}
+      style={baseStyle}
+    >
+      {children ?? "📅"}
+    </button>
+  );
 }
-export function DatePickerCalendar(_props: DatePickerCalendarProps) {
-  return null;
+DatePickerTrigger.displayName = "DatePicker.Trigger";
+
+// ── DatePickerCalendar (popover container + Calendar.Root bridge) ────────────
+
+export function DatePickerCalendar(props: DatePickerCalendarProps) {
+  const { className, style, children } = props;
+  const ctx = useDatePickerContext();
+  const palette = datePickerPalette[ctx.theme];
+
+  // outside click
+  useEffect(() => {
+    if (!ctx.open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const t = e.target as Node | null;
+      if (!t) return;
+      const trigger = ctx.triggerRef.current;
+      const grid = ctx.gridRef.current;
+      const input = ctx.inputRef.current;
+      const inputEnd = ctx.inputEndRef.current;
+      if (
+        (trigger && trigger.contains(t)) ||
+        (grid && grid.contains(t)) ||
+        (input && input.contains(t)) ||
+        (inputEnd && inputEnd.contains(t))
+      ) {
+        return;
+      }
+      ctx.setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [ctx.open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Esc
+  useEffect(() => {
+    if (!ctx.open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        ctx.setOpen(false);
+        ctx.triggerRef.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown as unknown as EventListener);
+    return () =>
+      document.removeEventListener("keydown", onKeyDown as unknown as EventListener);
+  }, [ctx.open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!ctx.open) return null;
+
+  // bridged value to Calendar
+  const value =
+    ctx.mode === "range"
+      ? (ctx.range as CalendarRangeValue)
+      : (ctx.single as CalendarSingleValue);
+
+  const handleValueChange = (
+    v: CalendarSingleValue | CalendarRangeValue | CalendarMultipleValue,
+  ) => {
+    if (ctx.mode === "single") {
+      // selectDay handles close + commit; we use selectDay path through onSelect for close
+      // but value change needs to commit. Use selectDay directly via onSelect for completeness.
+      // Here, just commit via selectDay if a non-null date.
+      const next = v as CalendarSingleValue;
+      if (next) ctx.selectDay(next);
+    } else if (ctx.mode === "range") {
+      const next = v as CalendarRangeValue;
+      // Calendar's selectDay produces full range progressions; map to DatePicker.selectDay
+      // by selecting whichever day is "the new edit".
+      // Since we pass controlled value, Calendar already has the right next state.
+      // We need to commit it via the appropriate range setter.
+      // The simplest: detect which day was clicked (last touched).
+      // Here, defer: just call selectDay on the most recently changed boundary.
+      // But Calendar already calls setValue internally. Translate:
+      // - if start changed and end null: a new range starting at start.
+      // - if end is now set: completion.
+      // We use the CalendarRangeValue directly (DatePicker doesn't care about
+      // which click triggered it; selectDay will be called via Calendar.Day's
+      // own onClick, NOT via this onValueChange).
+      // So we need a different approach — see below: pass selectDay through Calendar.Day's onClick
+      // override. For now, this onValueChange only fires from controlled value changes from
+      // Calendar.Root.setValue. We mirror to range state.
+      // (Compatibility) — call commitRange directly:
+      // We don't have a direct commitRange in context, but selectDay handles the click flow.
+      // Simpler: ignore onValueChange and rely on Day onClick override below.
+    }
+  };
+
+  const dialogStyle: CSSProperties = {
+    position: "absolute",
+    top: "calc(100% + 4px)",
+    left: 0,
+    zIndex: 1000,
+    background: palette.calendarBg,
+    border: `1px solid ${palette.calendarBorder}`,
+    borderRadius: 8,
+    boxShadow: palette.calendarShadow,
+    padding: 0,
+    ...style,
+  };
+
+  // mode-specific props for Calendar.Root (discriminated union)
+  const calendarRootProps =
+    ctx.mode === "range"
+      ? ({
+          mode: "range" as const,
+          value: ctx.range as CalendarRangeValue,
+          onValueChange: (v: CalendarRangeValue) => handleValueChange(v),
+        })
+      : ({
+          mode: "single" as const,
+          value: ctx.single as CalendarSingleValue,
+          onValueChange: (v: CalendarSingleValue) => handleValueChange(v),
+        });
+
+  return (
+    <div
+      role="dialog"
+      id={ctx.ids.dialog}
+      aria-label="Calendar"
+      aria-modal="false"
+      ref={ctx.gridRef as React.RefObject<HTMLDivElement>}
+      className={className}
+      style={dialogStyle}
+    >
+      <Calendar.Root
+        {...calendarRootProps}
+        month={ctx.currentMonth}
+        onMonthChange={ctx.setCurrentMonth}
+        isDisabled={ctx.isDisabledInternal}
+        locale={ctx.locale}
+        weekStartsOn={ctx.weekStartsOn as 0 | 1 | 2 | 3 | 4 | 5 | 6}
+        theme={ctx.theme}
+        disabled={ctx.disabled}
+        autoFocus={ctx.open}
+        style={{ border: "none", borderRadius: 8, padding: 8 }}
+      >
+        {children}
+      </Calendar.Root>
+    </div>
+  );
 }
-export function DatePickerHeader(_props: DatePickerHeaderProps) {
-  return null;
+DatePickerCalendar.displayName = "DatePicker.Calendar";
+
+// ── Header / Nav / MonthLabel — alias-style wrappers ────────────────────────
+
+export function DatePickerHeader(props: DatePickerHeaderProps) {
+  return <Calendar.Header {...props} />;
 }
-export function DatePickerMonthLabel(_props: DatePickerMonthLabelProps) {
-  return null;
+DatePickerHeader.displayName = "DatePicker.Header";
+
+export function DatePickerNav(props: DatePickerNavProps) {
+  return <Calendar.Nav {...props} />;
 }
-export function DatePickerNav(_props: DatePickerNavProps) {
-  return null;
+DatePickerNav.displayName = "DatePicker.Nav";
+
+export function DatePickerMonthLabel(props: DatePickerMonthLabelProps) {
+  return <Calendar.MonthLabel {...props} />;
 }
-export function DatePickerGrid(_props: DatePickerGridProps) {
-  return null;
+DatePickerMonthLabel.displayName = "DatePicker.MonthLabel";
+
+// ── Grid (combines WeekdayHeader + Calendar.Grid for DatePicker default) ─────
+
+export function DatePickerGrid(props: DatePickerGridProps) {
+  const { className, style, children } = props;
+
+  return (
+    <div className={className} style={style}>
+      <Calendar.WeekdayHeader />
+      {children !== undefined ? (
+        <Calendar.Grid>{children}</Calendar.Grid>
+      ) : (
+        <Calendar.Grid />
+      )}
+    </div>
+  );
 }
-export function DatePickerDay(_props: DatePickerDayProps) {
-  return null;
+DatePickerGrid.displayName = "DatePicker.Grid";
+
+// ── Day — wraps Calendar.Day, but onClick routes to DatePicker.selectDay ────
+
+export function DatePickerDay(props: DatePickerDayProps) {
+  const { day, className, style } = props;
+  const ctx = useDatePickerContext();
+
+  // Override onClick to use DatePicker's selectDay (which handles close + range progression)
+  const handleClick = useCallback(
+    (date: CalendarDate) => {
+      ctx.selectDay(date);
+    },
+    [ctx],
+  );
+
+  return (
+    <Calendar.Day
+      day={day}
+      onClick={handleClick}
+      {...(className !== undefined ? { className } : {})}
+      {...(style !== undefined ? { style } : {})}
+    />
+  );
 }
-export function DatePickerFooter(_props: DatePickerFooterProps) {
-  return null;
+DatePickerDay.displayName = "DatePicker.Day";
+
+// ── Footer (Today + Clear buttons) ───────────────────────────────────────────
+
+export function DatePickerFooter(props: DatePickerFooterProps) {
+  const { className, style, children } = props;
+  const ctx = useDatePickerContext();
+  const palette = datePickerPalette[ctx.theme];
+
+  const baseStyle: CSSProperties = {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 8,
+    padding: "8px 8px 4px",
+    borderTop: `1px solid ${palette.footerBorder}`,
+    marginTop: 4,
+    ...style,
+  };
+
+  if (children !== undefined) {
+    return (
+      <div className={className} style={baseStyle}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div className={className} style={baseStyle}>
+      <FooterButton onClick={ctx.setToToday} palette={palette}>
+        Today
+      </FooterButton>
+      <FooterButton onClick={ctx.clear} palette={palette}>
+        Clear
+      </FooterButton>
+    </div>
+  );
+}
+DatePickerFooter.displayName = "DatePicker.Footer";
+
+function FooterButton({
+  onClick,
+  palette,
+  children,
+}: {
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+  palette: typeof datePickerPalette["light"];
+  children: React.ReactNode;
+}) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        background: hovered ? palette.ghostHoverBg : "transparent",
+        border: "none",
+        color: palette.ghostFg,
+        padding: "4px 10px",
+        borderRadius: 4,
+        cursor: "pointer",
+        fontSize: 12,
+        fontFamily: "inherit",
+        transition: "background 120ms ease",
+      }}
+    >
+      {children}
+    </button>
+  );
 }

--- a/src/components/DatePicker/DatePicker.types.ts
+++ b/src/components/DatePicker/DatePicker.types.ts
@@ -1,22 +1,23 @@
 import type { CSSProperties, ReactNode } from "react";
+import type {
+  CalendarDate,
+  WeekStart,
+  CalendarSingleValue,
+  CalendarRangeValue,
+  CalendarDayInfo,
+} from "../Calendar/Calendar.types";
+
+// Re-export Calendar types so users can import from "@pihitpihit/plastic" via DatePicker barrel.
+// Canonical source: Calendar.
+export type { CalendarDate, WeekStart, CalendarDayInfo } from "../Calendar/Calendar.types";
 
 export type DatePickerTheme = "light" | "dark";
 export type DatePickerMode = "single" | "range";
 
-export interface CalendarDate {
-  year: number;
-  month: number;
-  day: number;
-}
+/** Backwards-compatible aliases for DatePicker users. */
+export type SingleValue = CalendarSingleValue;
+export type RangeValue = CalendarRangeValue;
 
-export type SingleValue = CalendarDate | null;
-
-export interface RangeValue {
-  start: CalendarDate | null;
-  end: CalendarDate | null;
-}
-
-export type WeekStart = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 export type ParseMode = "lenient" | "strict";
 
 interface DatePickerRootBaseProps {
@@ -110,13 +111,16 @@ export interface DatePickerNavProps {
 }
 
 export interface DatePickerGridProps {
-  children?: (day: DatePickerDayInfo) => ReactNode;
+  children?: (day: CalendarDayInfo) => ReactNode;
   className?: string;
   style?: CSSProperties;
 }
 
+/** @deprecated Renamed to CalendarDayInfo (re-exported from Calendar). */
+export type DatePickerDayInfo = CalendarDayInfo;
+
 export interface DatePickerDayProps {
-  day: DatePickerDayInfo;
+  day: CalendarDayInfo;
   className?: string;
   style?: CSSProperties;
 }
@@ -125,17 +129,4 @@ export interface DatePickerFooterProps {
   className?: string;
   style?: CSSProperties;
   children?: ReactNode;
-}
-
-export interface DatePickerDayInfo {
-  date: CalendarDate;
-  inCurrentMonth: boolean;
-  isToday: boolean;
-  isSelected: boolean;
-  isRangeStart: boolean;
-  isRangeEnd: boolean;
-  isInRange: boolean;
-  isRangePreview: boolean;
-  isDisabled: boolean;
-  isFocused: boolean;
 }

--- a/src/components/DatePicker/index.ts
+++ b/src/components/DatePicker/index.ts
@@ -27,7 +27,7 @@ export type {
   DatePickerFooterProps,
   DatePickerMode,
   DatePickerTheme,
-  CalendarDate,
   SingleValue,
   RangeValue,
 } from "./DatePicker.types";
+// CalendarDate and WeekStart are re-exported from Calendar's barrel.

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 export * from "./Accordion";
 export * from "./Actionable";
 export * from "./Button";
+export * from "./Calendar";
 export * from "./Card";
 export * from "./CodeView";
 export * from "./Combobox";


### PR DESCRIPTION
## Summary

- **`Calendar` 신설** — 월 그리드 단독 컴포넌트 (plan 025). 3 mode(single/range/multiple), 키보드 네비, range preview, locale, light/dark.
- **`DatePicker` 통합** — `DatePicker.parts.tsx`가 stub(null) 상태였으나 Calendar 도입을 계기로 실제 구현 완료. DatePicker.dateMath/intl/types 일부를 Calendar 단일 진실 원천으로 위임.
- **17개 plan 문서 추가 (023-039)** — `docs/candidates.md`의 잠정 후보 17개를 plan 문서로 승격. 의존 순서 기반 번호 배정.

## 주요 변경

### Calendar (신규)
14개 파일, ~1177줄. compound 패턴(`Root + Header + Nav + MonthLabel + WeekdayHeader + Grid + Day`).
- `Calendar.types.ts` — CalendarDate (timezone-safe `{year, month(1-12), day}`)
- `Calendar.dateMath.ts` — buildMonthGrid 등 (DatePicker.dateMath의 단일 진실 원천)
- `Calendar.theme.ts` — light/dark 토큰
- `CalendarRoot.tsx` — controlled/uncontrolled, 3 mode, autoFocus
- `CalendarDay.tsx` — Arrow/Home/End/PgUp/PgDn 키보드 + 자동 month 전환

### DatePicker (변경)
- `DatePicker.parts.tsx` 9개 stub → 실제 구현 (Input/Trigger/Calendar popover/Header/Nav/MonthLabel/Grid/Day/Footer)
- `DatePicker.dateMath.ts` → Calendar.dateMath re-export 단순화
- `DatePicker.types.ts` → CalendarDate/WeekStart/CalendarDayInfo는 Calendar에서 import (중복 제거)
- DatePicker context는 그대로 유지 — input 표시, popover open, format/parse, selectDay
- Calendar는 popover 내부에서 자체 context, DatePicker가 props로 bridge (close-on-select 등은 DatePicker.selectDay가 책임)

### Plan 문서 17개 (023-039)
| Tier | Plans |
|---|---|
| 0 (인프라/추출) | 023 Icon, 024 LineNumbers, 025 Calendar, 026 CopyButton |
| 1 (독립 primitive) | 027 Tag, 028 NumberInput, 029 Stack/Grid, 030 FileUpload, 031 Image, 032 ConfirmInline, 033 ErrorBoundary, 034 SmartSearch, 035 QRCode, 036 Changelog |
| 2 (severity 의존) | 037 Alert (Phase 0 severity 추출 포함), 038 Banner |
| 3 (다른 후보 의존) | 039 Sidebar+Header+Footer |

각 문서: Context, prior art, 공개 API, 동작 명세, 마이그레이션 (해당 시), 데모, 접근성, edge cases, 구현 단계, 체크리스트 포함.

### 데모
- `demo/src/pages/CalendarPage.tsx` 신설 (8 섹션)
- `App.tsx` NAV/라우팅 등록

### candidates 추적
- `docs/candidates.md` 신설 — pre-plan 후보, 횡단 추상, 검토 대상, 드롭 항목 추적

## Test plan
- [x] `npm run typecheck` 통과
- [x] `npm run build` 통과 (ESM 759KB, CJS 775KB, DTS 107KB)
- [ ] 데모 실행 (`cd demo && npm run dev`) 후 시각 회귀 확인:
  - [ ] CalendarPage 8개 섹션 모두 정상 (light/dark)
  - [ ] DatePickerPage 기존 섹션 시각 회귀 없음 (Input + Popover + Calendar 그리드)
  - [ ] 키보드 (Arrow/Home/End/PgUp/PgDn/Enter) Calendar 내부 작동
  - [ ] DatePicker close-on-select 동작
  - [ ] range mode 호버 preview
- [ ] Locale ko-KR 라벨 정상

> ⚠️ Note: `demo/src/pages/SelectPage.tsx`의 `Button variant="outline"` TS 에러는 사전 존재 (커밋 044e7b6 시점부터). 본 PR과 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)